### PR TITLE
Add reasoning_content parsing for OpenAI-compatible models

### DIFF
--- a/serdes-ai-models/src/openai/types.rs
+++ b/serdes-ai-models/src/openai/types.rs
@@ -477,6 +477,9 @@ pub struct ResponseMessage {
     pub tool_calls: Option<Vec<ResponseToolCall>>,
     /// Refusal (for content filter).
     pub refusal: Option<String>,
+    /// Reasoning/thinking content (for models like GLM-4 that support chain-of-thought).
+    /// This is returned by some OpenAI-compatible providers when the model does reasoning.
+    pub reasoning_content: Option<String>,
 }
 
 /// Response tool call.
@@ -571,6 +574,8 @@ pub struct ChunkDelta {
     pub tool_calls: Option<Vec<ChunkToolCall>>,
     /// Refusal.
     pub refusal: Option<String>,
+    /// Reasoning/thinking content delta (for models like GLM-4).
+    pub reasoning_content: Option<String>,
 }
 
 /// Chunk tool call.


### PR DESCRIPTION
This PR adds support for parsing `reasoning_content` field in OpenAI-compatible API responses.

## Changes

- Add `reasoning_content` field to `ResponseMessage` (non-streaming)
- Add `reasoning_content` field to `ChunkDelta` (streaming)
- Parse `reasoning_content` and emit `ThinkingPart`/`ThinkingPartDelta` events
- Supports models like GLM-4 that return thinking in `reasoning_content`

## Files Changed

- `serdes-ai-models/src/openai/chat.rs`
- `serdes-ai-models/src/openai/stream.rs`
- `serdes-ai-models/src/openai/types.rs`

## Testing

- Builds successfully with `cargo build --all-features`
- All tests pass