### PR TITLE
fix: prevent premature EOF in Anthropic streaming from being treated as success (#39)

### DIFF
--- a/serdes-ai-agent/src/stream.rs
+++ b/serdes-ai-agent/src/stream.rs
@@ -507,6 +507,9 @@ impl AgentStream {
                 let mut response_parts: Vec<ModelResponsePart> = Vec::new();
                 // Track stream events (used by tracing when enabled)
                 let mut stream_event_count = 0u32;
+                // Provider-reported finish reason (set by StreamComplete event)
+                let mut stream_finish_reason: Option<FinishReason> = None;
+                let mut stream_usage: Option<(u64, u64)> = None;
 
                 // Process stream events
                 debug!("AgentStream: starting to process model stream events");
@@ -621,6 +624,14 @@ impl AgentStream {
                                 ModelResponseStreamEvent::PartEnd(_) => {
                                     // Part finished
                                 }
+                                ModelResponseStreamEvent::StreamComplete(sc) => {
+                                    stream_finish_reason = Some(sc.finish_reason);
+                                    if let (Some(inp), Some(out)) =
+                                        (sc.input_tokens, sc.output_tokens)
+                                    {
+                                        stream_usage = Some((inp, out));
+                                    }
+                                }
                             }
                         }
                         Err(e) => {
@@ -641,13 +652,54 @@ impl AgentStream {
                     "AgentStream: finished processing model stream"
                 );
 
-                // Build the complete response
+                // If the stream did not produce a terminal StreamComplete event,
+                // this is a premature EOF — emit an error and abort.
+                let stream_finish_reason = match stream_finish_reason {
+                    Some(reason) => reason,
+                    None => {
+                        let _ = tx
+                            .send(Ok(AgentStreamEvent::Error {
+                                message:
+                                    "model stream ended without a terminal StreamComplete event"
+                                        .to_string(),
+                            }))
+                            .await;
+                        let _ = tx
+                            .send(Err(AgentRunError::Model(
+                                serdes_ai_models::ModelError::incomplete_stream(
+                                    "model stream ended without a terminal StreamComplete event",
+                                ),
+                            )))
+                            .await;
+                        return;
+                    }
+                };
+
+                // If the stream produced no parts at all, treat it as an error
+                if response_parts.is_empty() {
+                    let _ = tx
+                        .send(Ok(AgentStreamEvent::Error {
+                            message: "model stream ended without producing any content".to_string(),
+                        }))
+                        .await;
+                    let _ = tx
+                        .send(Err(AgentRunError::Model(
+                            serdes_ai_models::ModelError::incomplete_stream(
+                                "model stream ended without producing any content",
+                            ),
+                        )))
+                        .await;
+                    return;
+                }
+
+                // Build the complete response using the provider-reported finish reason
                 let mut response = ModelResponse {
                     parts: response_parts.clone(),
                     model_name: Some(model.name().to_string()),
                     timestamp: Utc::now(),
-                    finish_reason: Some(FinishReason::Stop),
-                    usage: None,
+                    finish_reason: Some(stream_finish_reason),
+                    usage: stream_usage
+                        .map(|(req, res)| serdes_ai_core::RequestUsage::with_tokens(req, res)),
                     vendor_id: None,
                     vendor_details: None,
                     kind: "response".to_string(),
@@ -1018,6 +1070,10 @@ impl AgentStream {
 
                 let mut response_parts: Vec<ModelResponsePart> = Vec::new();
 
+                // Provider-reported finish reason (set by StreamComplete event)
+                let mut stream_finish_reason: Option<FinishReason> = None;
+                let mut stream_usage: Option<(u64, u64)> = None;
+
                 // Process stream events with cancellation check
                 loop {
                     tokio::select! {
@@ -1149,6 +1205,14 @@ impl AgentStream {
                                             }
                                         }
                                         ModelResponseStreamEvent::PartEnd(_) => {}
+                                        ModelResponseStreamEvent::StreamComplete(sc) => {
+                                            stream_finish_reason = Some(sc.finish_reason);
+                                            if let (Some(inp), Some(out)) =
+                                                (sc.input_tokens, sc.output_tokens)
+                                            {
+                                                stream_usage = Some((inp, out));
+                                            }
+                                        }
                                     }
                                 }
                                 Some(Err(e)) => {
@@ -1169,13 +1233,54 @@ impl AgentStream {
                     }
                 }
 
-                // Build the complete response
+                // If the stream did not produce a terminal StreamComplete event,
+                // this is a premature EOF — emit an error and abort.
+                let stream_finish_reason = match stream_finish_reason {
+                    Some(reason) => reason,
+                    None => {
+                        let _ = tx
+                            .send(Ok(AgentStreamEvent::Error {
+                                message:
+                                    "model stream ended without a terminal StreamComplete event"
+                                        .to_string(),
+                            }))
+                            .await;
+                        let _ = tx
+                            .send(Err(AgentRunError::Model(
+                                serdes_ai_models::ModelError::incomplete_stream(
+                                    "model stream ended without a terminal StreamComplete event",
+                                ),
+                            )))
+                            .await;
+                        return;
+                    }
+                };
+
+                // If the stream produced no parts at all, treat it as an error
+                if response_parts.is_empty() {
+                    let _ = tx
+                        .send(Ok(AgentStreamEvent::Error {
+                            message: "model stream ended without producing any content".to_string(),
+                        }))
+                        .await;
+                    let _ = tx
+                        .send(Err(AgentRunError::Model(
+                            serdes_ai_models::ModelError::incomplete_stream(
+                                "model stream ended without producing any content",
+                            ),
+                        )))
+                        .await;
+                    return;
+                }
+
+                // Build the complete response using the provider-reported finish reason
                 let mut response = ModelResponse {
                     parts: response_parts.clone(),
                     model_name: Some(model.name().to_string()),
                     timestamp: Utc::now(),
-                    finish_reason: Some(FinishReason::Stop),
-                    usage: None,
+                    finish_reason: Some(stream_finish_reason),
+                    usage: stream_usage
+                        .map(|(req, res)| serdes_ai_core::RequestUsage::with_tokens(req, res)),
                     vendor_id: None,
                     vendor_details: None,
                     kind: "response".to_string(),
@@ -1400,7 +1505,9 @@ mod tests {
     use super::*;
     use crate::builder::agent;
     use futures::{stream, StreamExt};
-    use serdes_ai_core::messages::{ModelRequestPart, TextPart, ToolCallPart};
+    use serdes_ai_core::messages::{
+        FinishReason, ModelRequestPart, StreamCompleteEvent, TextPart, ToolCallPart,
+    };
     use serdes_ai_models::FunctionModel;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
@@ -1519,6 +1626,9 @@ mod tests {
                             ),
                         )),
                         Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::ToolCall),
+                        )),
                     ]
                 } else {
                     vec![
@@ -1527,6 +1637,9 @@ mod tests {
                             ModelResponsePart::Text(TextPart::new("done")),
                         )),
                         Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::Stop),
+                        )),
                     ]
                 };
 
@@ -1577,6 +1690,257 @@ mod tests {
         assert!(
             saw_tool_call,
             "expected at least one tool call in persisted RunComplete messages"
+        );
+    }
+
+    // ========================================================================
+    // Regression tests for issue #39: premature EOF must not produce
+    // successful OutputReady, committed history, fabricated Stop, or
+    // successful RunComplete.
+    //
+    // The Anthropic parser now emits `ModelError::IncompleteStream` on
+    // premature EOF. These agent tests verify that when the model stream
+    // produces such an error — after partial content — the agent does not
+    // emit success events or commit the response.
+    // ========================================================================
+
+    /// Helper: collect all events from a stream and check that no
+    /// `OutputReady`, `RunComplete`, or `ResponseComplete` event was emitted,
+    /// and that an error was produced.
+    async fn assert_stream_error_no_success(
+        model: FunctionModel,
+        use_cancel: bool,
+    ) -> Vec<AgentStreamEvent> {
+        let agentic = agent(model).build();
+
+        let mut stream = if use_cancel {
+            let token = CancellationToken::new();
+            AgentStream::new_with_cancel(&agentic, "Hello".into(), (), RunOptions::default(), token)
+                .await
+                .expect("stream should start")
+        } else {
+            agentic
+                .run_stream("Hello", ())
+                .await
+                .expect("stream should start")
+        };
+
+        let mut events = Vec::new();
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(event) => {
+                    assert!(
+                        !matches!(event, AgentStreamEvent::OutputReady),
+                        "must NOT emit OutputReady on stream error"
+                    );
+                    assert!(
+                        !matches!(event, AgentStreamEvent::RunComplete { .. }),
+                        "must NOT emit RunComplete on stream error"
+                    );
+                    assert!(
+                        !matches!(event, AgentStreamEvent::ResponseComplete { .. }),
+                        "must NOT emit ResponseComplete on stream error"
+                    );
+                    events.push(event);
+                }
+                Err(e) => {
+                    saw_error = true;
+                    events.push(AgentStreamEvent::Error {
+                        message: e.to_string(),
+                    });
+                }
+            }
+        }
+        assert!(saw_error, "expected an error event");
+        events
+    }
+
+    /// Test: stream error after partial text (simulating Anthropic
+    /// IncompleteStream) produces an error and no success events.
+    /// Non-cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_non_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("Partial response")),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended before message_stop was received",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, false).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(saw_text, "should have seen partial text");
+    }
+
+    /// Test: stream error after partial text — cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("Partial response")),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended before message_stop was received",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, true).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(saw_text, "should have seen partial text");
+    }
+
+    /// Test: empty stream (no parts at all) produces an error.
+    /// Non-cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_empty_stream_non_cancellable() {
+        let model =
+            FunctionModel::with_stream(|_messages, _settings| Box::pin(stream::iter(vec![])));
+
+        let events = assert_stream_error_no_success(model, false).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(!saw_text, "should NOT have seen any text from empty stream");
+    }
+
+    /// Test: stream error after incomplete tool call — must not execute
+    /// the tool or commit it.
+    #[tokio::test]
+    async fn test_premature_eof_incomplete_tool_call() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::ToolCall(
+                        ToolCallPart::new("search", serde_json::json!({}))
+                            .with_tool_call_id("call_1"),
+                    ),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended with open content block",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, false).await;
+
+        // Should NOT have seen ToolCallComplete
+        let saw_tool_complete = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolCallComplete { .. }));
+        assert!(
+            !saw_tool_complete,
+            "must NOT emit ToolCallComplete on incomplete tool call"
+        );
+
+        // Should NOT have seen ToolExecuted
+        let saw_tool_executed = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolExecuted { .. }));
+        assert!(!saw_tool_executed, "must NOT execute tool on premature EOF");
+    }
+
+    /// Test: a valid stream (PartStart + PartEnd + StreamComplete) produces
+    /// OutputReady and RunComplete. This verifies the happy path is not broken.
+    #[tokio::test]
+    async fn test_valid_stream_produces_success() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("Hello!")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+                Ok(ModelResponseStreamEvent::StreamComplete(
+                    StreamCompleteEvent::new(FinishReason::Stop),
+                )),
+            ]))
+        });
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("Hi", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_output_ready = false;
+        let mut saw_run_complete = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::OutputReady) => saw_output_ready = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(_) => {}
+                Err(e) => panic!("valid stream should not error: {:?}", e),
+            }
+        }
+        assert!(saw_output_ready, "valid stream should emit OutputReady");
+        assert!(saw_run_complete, "valid stream should emit RunComplete");
+    }
+
+    /// Test: premature EOF — empty stream, cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_empty_stream_cancellable() {
+        let model =
+            FunctionModel::with_stream(|_messages, _settings| Box::pin(stream::iter(vec![])));
+
+        let events = assert_stream_error_no_success(model, true).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(!saw_text, "should NOT have seen any text from empty stream");
+    }
+
+    /// Test: premature EOF — incomplete tool call, cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_incomplete_tool_call_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::ToolCall(
+                        ToolCallPart::new("search", serde_json::json!({}))
+                            .with_tool_call_id("call_1"),
+                    ),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended with open content block",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, true).await;
+
+        let saw_tool_complete = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolCallComplete { .. }));
+        assert!(
+            !saw_tool_complete,
+            "must NOT emit ToolCallComplete on incomplete tool call (cancellable)"
+        );
+
+        let saw_tool_executed = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolExecuted { .. }));
+        assert!(
+            !saw_tool_executed,
+            "must NOT execute tool on premature EOF (cancellable)"
         );
     }
 }

--- a/serdes-ai-core/src/messages/events.rs
+++ b/serdes-ai-core/src/messages/events.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 use super::parts::{
     BuiltinToolCallPart, FilePart, TextPart, ThinkingPart, ToolCallArgs, ToolCallPart,
 };
-use super::response::ModelResponsePart;
+use super::response::{FinishReason, ModelResponsePart};
 
 /// Stream event for model responses.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -21,6 +21,13 @@ pub enum ModelResponseStreamEvent {
     PartDelta(PartDeltaEvent),
     /// A part has ended.
     PartEnd(PartEndEvent),
+    /// The stream completed successfully with provider terminal metadata.
+    ///
+    /// This event is emitted **only** when the provider has confirmed
+    /// successful completion (e.g. Anthropic `message_stop`).  It carries
+    /// the provider-reported finish reason and usage so consumers do not
+    /// need to infer them from stream exhaustion.
+    StreamComplete(StreamCompleteEvent),
 }
 
 impl ModelResponseStreamEvent {
@@ -102,6 +109,7 @@ impl ModelResponseStreamEvent {
             Self::PartStart(e) => e.index,
             Self::PartDelta(e) => e.index,
             Self::PartEnd(e) => e.index,
+            Self::StreamComplete(_) => 0,
         }
     }
 
@@ -121,6 +129,12 @@ impl ModelResponseStreamEvent {
     #[must_use]
     pub fn is_end(&self) -> bool {
         matches!(self, Self::PartEnd(_))
+    }
+
+    /// Check if this is a stream-complete (terminal) event.
+    #[must_use]
+    pub fn is_stream_complete(&self) -> bool {
+        matches!(self, Self::StreamComplete(_))
     }
 }
 
@@ -650,6 +664,45 @@ impl PartEndEvent {
     #[must_use]
     pub fn new(index: usize) -> Self {
         Self { index }
+    }
+}
+
+/// Event indicating the stream completed successfully with provider terminal metadata.
+///
+/// Only emitted when the provider confirms successful completion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamCompleteEvent {
+    /// Provider-reported finish reason (mapped to [`FinishReason`]).
+    pub finish_reason: FinishReason,
+    /// Input tokens reported by the provider (if any).
+    pub input_tokens: Option<u64>,
+    /// Output tokens reported by the provider (if any).
+    pub output_tokens: Option<u64>,
+}
+
+impl StreamCompleteEvent {
+    /// Create a new stream-complete event.
+    #[must_use]
+    pub fn new(finish_reason: FinishReason) -> Self {
+        Self {
+            finish_reason,
+            input_tokens: None,
+            output_tokens: None,
+        }
+    }
+
+    /// Set input tokens.
+    #[must_use]
+    pub fn with_input_tokens(mut self, tokens: u64) -> Self {
+        self.input_tokens = Some(tokens);
+        self
+    }
+
+    /// Set output tokens.
+    #[must_use]
+    pub fn with_output_tokens(mut self, tokens: u64) -> Self {
+        self.output_tokens = Some(tokens);
+        self
     }
 }
 

--- a/serdes-ai-core/src/messages/mod.rs
+++ b/serdes-ai-core/src/messages/mod.rs
@@ -45,7 +45,8 @@ pub use content::{
 };
 pub use events::{
     BuiltinToolCallPartDelta, ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent,
-    PartEndEvent, PartStartEvent, TextPartDelta, ThinkingPartDelta, ToolCallPartDelta,
+    PartEndEvent, PartStartEvent, StreamCompleteEvent, TextPartDelta, ThinkingPartDelta,
+    ToolCallPartDelta,
 };
 pub use media::{AudioMediaType, DocumentMediaType, ImageMediaType, VideoMediaType};
 pub use parts::{

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -8,8 +8,8 @@ use bytes::Bytes;
 use futures::Stream;
 use pin_project_lite::pin_project;
 use serdes_ai_core::messages::{
-    ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
-    TextPart, ThinkingPart, ThinkingPartDelta, ToolCallPart,
+    FinishReason, ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent,
+    PartStartEvent, StreamCompleteEvent, TextPart, ThinkingPart, ThinkingPartDelta, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
 use std::collections::HashMap;
@@ -32,6 +32,10 @@ pin_project! {
         output_tokens: u64,
         cache_creation_tokens: Option<u64>,
         cache_read_tokens: Option<u64>,
+        // Provider-reported stop reason from message_delta
+        stop_reason: Option<String>,
+        // Whether message_stop was observed
+        message_stop_seen: bool,
         // Finished
         done: bool,
     }
@@ -77,8 +81,33 @@ where
             output_tokens: 0,
             cache_creation_tokens: None,
             cache_read_tokens: None,
+            stop_reason: None,
+            message_stop_seen: false,
             done: false,
         }
+    }
+
+    /// The provider-reported stop reason (from `message_delta`), if any.
+    ///
+    /// This is only reliable after the stream has completed successfully
+    /// (i.e. `message_stop` was observed).
+    pub fn stop_reason(&self) -> Option<&str> {
+        self.stop_reason.as_deref()
+    }
+
+    /// Whether `message_stop` was observed before the stream ended.
+    pub fn message_stop_seen(&self) -> bool {
+        self.message_stop_seen
+    }
+
+    /// Input tokens reported by the provider.
+    pub fn input_tokens(&self) -> u64 {
+        self.input_tokens
+    }
+
+    /// Output tokens reported by the provider.
+    pub fn output_tokens(&self) -> u64 {
+        self.output_tokens
     }
 }
 
@@ -91,6 +120,7 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
+        // After StreamComplete has been emitted the stream is done.
         if *this.done {
             return Poll::Ready(None);
         }
@@ -111,15 +141,30 @@ where
                             this.output_tokens,
                             this.cache_creation_tokens,
                             this.cache_read_tokens,
+                            this.stop_reason,
+                            this.message_stop_seen,
                             this.done,
                         ) {
+                            // If the result is StreamComplete, mark done so the
+                            // next poll returns None without re-checking EOF.
+                            if let Ok(ModelResponseStreamEvent::StreamComplete(_)) = &result {
+                                *this.done = true;
+                            }
                             return Poll::Ready(Some(result));
                         }
                     }
                     Err(e) => {
+                        *this.done = true;
                         return Poll::Ready(Some(Err(e)));
                     }
                 }
+            }
+
+            // If message_stop was already seen and all buffered events consumed,
+            // we should not poll the inner stream further — just end.
+            if *this.message_stop_seen {
+                *this.done = true;
+                return Poll::Ready(None);
             }
 
             // Need more data
@@ -130,9 +175,20 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
+                    // Inner stream reached EOF. If we haven't seen message_stop,
+                    // this is a premature EOF — emit a typed error.
+                    if !*this.message_stop_seen {
+                        *this.done = true;
+                        return Poll::Ready(Some(Err(ModelError::incomplete_stream(
+                            "stream ended before message_stop was received",
+                        ))));
+                    }
+                    // message_stop was seen but done wasn't set (shouldn't happen
+                    // since StreamComplete sets done, but guard anyway).
                     *this.done = true;
                     return Poll::Ready(None);
                 }
@@ -194,14 +250,18 @@ fn process_event(
     output_tokens: &mut u64,
     cache_creation_tokens: &mut Option<u64>,
     cache_read_tokens: &mut Option<u64>,
+    stop_reason: &mut Option<String>,
+    message_stop_seen: &mut bool,
     done: &mut bool,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
-    // Parse the JSON data
+    // Parse the JSON data — reject malformed events rather than silently dropping them
     let event: StreamEvent = match serde_json::from_str(data) {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!("Failed to parse stream event: {} - data: {}", e, data);
-            return None;
+            return Some(Err(ModelError::invalid_response(format!(
+                "Failed to parse stream event: {} - data: {}",
+                e, data
+            ))));
         }
     };
 
@@ -271,7 +331,14 @@ fn process_event(
                 }
                 ContentBlockDelta::InputJsonDelta { partial_json } => {
                     if let BlockState::ToolUse { input_json, .. } = state {
-                        input_json.push_str(&partial_json);
+                        // If the accumulated JSON is still just the initial empty
+                        // object, replace it with the first real delta.
+                        if input_json == "{}" {
+                            input_json.clear();
+                            input_json.push_str(&partial_json);
+                        } else {
+                            input_json.push_str(&partial_json);
+                        }
                     }
                     Some(Ok(ModelResponseStreamEvent::PartDelta(
                         PartDeltaEvent::tool_call_args(index, partial_json),
@@ -304,23 +371,58 @@ fn process_event(
         }
 
         StreamEvent::ContentBlockStop { index } => {
+            // Validate tool input JSON before accepting the block as complete.
+            // Skip validation when the input is the default empty object (no
+            // deltas were received).
+            if let Some(BlockState::ToolUse { input_json, .. }) = blocks.get(&index) {
+                if !input_json.is_empty() && input_json != "{}" {
+                    if serde_json::from_str::<serde_json::Value>(input_json).is_err() {
+                        return Some(Err(ModelError::invalid_response(format!(
+                            "content_block_stop for tool at index {} has incomplete JSON input: {}",
+                            index, input_json
+                        ))));
+                    }
+                }
+            }
             blocks.remove(&index);
             Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
                 index,
             })))
         }
 
-        StreamEvent::MessageDelta { delta: _, usage } => {
+        StreamEvent::MessageDelta { delta, usage } => {
+            if let Some(reason) = &delta.stop_reason {
+                *stop_reason = Some(reason.clone());
+            }
             if let Some(u) = usage {
                 *output_tokens = u.output_tokens;
             }
-            // We don't emit finish reason as event since core doesn't have it
             None
         }
 
         StreamEvent::MessageStop => {
-            *done = true;
-            None
+            // Atomically validate terminal state before accepting message_stop.
+            if !blocks.is_empty() {
+                let open_indices: Vec<usize> = blocks.keys().copied().collect();
+                *done = true;
+                return Some(Err(ModelError::incomplete_stream(format!(
+                    "message_stop received with open content block(s) at index/indices: {:?}",
+                    open_indices
+                ))));
+            }
+
+            *message_stop_seen = true;
+
+            // Map the Anthropic stop reason to FinishReason
+            let finish_reason = map_stop_reason(stop_reason.as_deref());
+
+            // Emit StreamComplete with provider terminal metadata
+            let mut event = StreamCompleteEvent::new(finish_reason);
+            event = event
+                .with_input_tokens(*input_tokens)
+                .with_output_tokens(*output_tokens);
+
+            Some(Ok(ModelResponseStreamEvent::StreamComplete(event)))
         }
 
         StreamEvent::Ping => None,
@@ -329,6 +431,17 @@ fn process_event(
             error.message,
             error.error_type,
         ))),
+    }
+}
+
+/// Map an Anthropic stop reason string to a [`FinishReason`].
+fn map_stop_reason(reason: Option<&str>) -> FinishReason {
+    match reason {
+        Some("end_turn") => FinishReason::EndTurn,
+        Some("stop_sequence") => FinishReason::StopSequence,
+        Some("max_tokens") => FinishReason::Length,
+        Some("tool_use") => FinishReason::ToolCall,
+        _ => FinishReason::Stop,
     }
 }
 
@@ -345,13 +458,26 @@ mod tests {
     #[tokio::test]
     async fn test_parse_message_start() {
         let data = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
-        let bytes = vec![Ok(make_sse_bytes("message_start", data))];
+        let msg_stop = r#"{"type":"message_stop"}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", data)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
         let stream = stream::iter(bytes);
         let mut parser = AnthropicStreamParser::new(stream);
 
-        // Message start doesn't emit an event
+        // Message start emits nothing; message_stop emits StreamComplete
         let event = parser.next().await;
-        assert!(event.is_none());
+        assert!(event.is_some());
+        assert!(
+            matches!(
+                event.unwrap().unwrap(),
+                ModelResponseStreamEvent::StreamComplete(_)
+            ),
+            "expected StreamComplete"
+        );
+        // Next poll should be None (done)
+        assert!(parser.next().await.is_none());
     }
 
     #[tokio::test]
@@ -361,12 +487,16 @@ mod tests {
             r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
         let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
         let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
 
         let bytes = vec![
             Ok(make_sse_bytes("message_start", msg_start)),
             Ok(make_sse_bytes("content_block_start", block_start)),
             Ok(make_sse_bytes("content_block_delta", delta)),
             Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_delta", msg_delta)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
         ];
 
         let stream = stream::iter(bytes);
@@ -378,8 +508,8 @@ mod tests {
             events.push(result.unwrap());
         }
 
-        // Should have: PartStart, PartDelta, PartEnd
-        assert_eq!(events.len(), 3, "Expected 3 events, got {:?}", events);
+        // Should have: PartStart, PartDelta, PartEnd, StreamComplete
+        assert_eq!(events.len(), 4, "Expected 4 events, got {:?}", events);
 
         assert!(
             matches!(&events[0], ModelResponseStreamEvent::PartStart(_)),
@@ -393,6 +523,15 @@ mod tests {
             matches!(&events[2], ModelResponseStreamEvent::PartEnd(_)),
             "Third should be PartEnd"
         );
+        assert!(
+            matches!(&events[3], ModelResponseStreamEvent::StreamComplete(_)),
+            "Fourth should be StreamComplete"
+        );
+
+        // Provider terminal metadata should survive
+        assert_eq!(parser.stop_reason(), Some("end_turn"));
+        assert!(parser.message_stop_seen());
+        assert_eq!(parser.output_tokens(), 5);
     }
 
     #[tokio::test]
@@ -402,6 +541,7 @@ mod tests {
         let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"q\":"}}"#;
         let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"rust\"}"}}"#;
         let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
 
         let bytes = vec![
             Ok(make_sse_bytes("message_start", msg_start)),
@@ -409,6 +549,7 @@ mod tests {
             Ok(make_sse_bytes("content_block_delta", delta1)),
             Ok(make_sse_bytes("content_block_delta", delta2)),
             Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
         ];
 
         let stream = stream::iter(bytes);
@@ -419,8 +560,8 @@ mod tests {
             events.push(result.unwrap());
         }
 
-        // Should have: PartStart, PartDelta, PartDelta, PartEnd
-        assert_eq!(events.len(), 4, "Expected 4 events, got {:?}", events);
+        // Should have: PartStart, PartDelta, PartDelta, PartEnd, StreamComplete
+        assert_eq!(events.len(), 5, "Expected 5 events, got {:?}", events);
 
         // First should be PartStart with tool_use
         if let ModelResponseStreamEvent::PartStart(start) = &events[0] {
@@ -431,6 +572,11 @@ mod tests {
         } else {
             panic!("Expected PartStart");
         }
+        // Last should be StreamComplete
+        assert!(
+            matches!(&events[4], ModelResponseStreamEvent::StreamComplete(_)),
+            "Last should be StreamComplete"
+        );
     }
 
     #[tokio::test]
@@ -450,12 +596,351 @@ mod tests {
     #[tokio::test]
     async fn test_parse_ping() {
         let ping = r#"{"type":"ping"}"#;
-        let bytes = vec![Ok(make_sse_bytes("ping", ping))];
+        let msg_stop = r#"{"type":"message_stop"}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes("ping", ping)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
         let stream = stream::iter(bytes);
         let mut parser = AnthropicStreamParser::new(stream);
 
-        // Ping shouldn't emit an event
+        // Ping emits nothing; message_stop emits StreamComplete
         let event = parser.next().await;
-        assert!(event.is_none());
+        assert!(event.is_some());
+        assert!(
+            matches!(
+                event.unwrap().unwrap(),
+                ModelResponseStreamEvent::StreamComplete(_)
+            ),
+            "expected StreamComplete"
+        );
+        // Done
+        assert!(parser.next().await.is_none());
+    }
+
+    // ========================================================================
+    // Regression tests for issue #39: premature EOF must not be treated as
+    // successful completion.
+    // ========================================================================
+
+    /// Helper: build a partial (incomplete) SSE frame as bytes.
+    fn make_partial_sse_bytes(event_type: &str, partial_data: &str) -> Bytes {
+        // Intentionally missing the trailing blank line so the frame is incomplete
+        Bytes::from(format!(
+            "event: {}
+data: {}",
+            event_type, partial_data
+        ))
+    }
+
+    /// Test 1: EOF before any `message_stop`.
+    #[tokio::test]
+    async fn test_eof_before_message_stop() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta =
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            // NO message_delta, NO message_stop — stream just ends
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(had_error, "expected an IncompleteStream error");
+        assert!(!parser.message_stop_seen());
+    }
+
+    /// Test 2: EOF with a partial final SSE record in the buffer.
+    #[tokio::test]
+    async fn test_eof_with_partial_sse_frame() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta =
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            // A partial frame that will never be completed — inner stream ends
+            Ok(make_partial_sse_bytes(
+                "message_delta",
+                r#"{"type":"message_delta","#,
+            )),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for partial frame, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for partial SSE frame"
+        );
+    }
+
+    /// Test 3: EOF with an open text block.
+    #[tokio::test]
+    async fn test_eof_with_open_text_block() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        // NO content_block_stop, NO message_stop
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for open text block, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for open text block"
+        );
+    }
+
+    /// Test 4: EOF with an open thinking block.
+    #[tokio::test]
+    async fn test_eof_with_open_thinking_block() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Hmm"}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for open thinking block, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for open thinking block"
+        );
+    }
+
+    /// Test 5: EOF with an open tool-use block (incomplete tool JSON).
+    #[tokio::test]
+    async fn test_eof_with_open_tool_use_block() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start = r#"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool_1","name":"search","input":{}}}"#;
+        let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"q\":"}}"#;
+        // Second delta makes the JSON incomplete (missing closing brace)
+        let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"rust\""}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta1)),
+            Ok(make_sse_bytes("content_block_delta", delta2)),
+            // NO content_block_stop, NO message_stop
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for open tool block, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for open tool-use block"
+        );
+    }
+
+    /// Test 6: `content_block_stop` followed by EOF without `message_stop`.
+    #[tokio::test]
+    async fn test_content_block_stop_then_eof_without_message_stop() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            // block is closed but no message_stop
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream without message_stop, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(had_error, "expected IncompleteStream error");
+        assert!(!parser.message_stop_seen());
+    }
+
+    /// Test 7: A valid sequence ending in `message_stop` produces no error.
+    #[tokio::test]
+    async fn test_valid_stream_with_message_stop() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_delta", msg_delta)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut saw_stream_complete = false;
+        while let Some(result) = parser.next().await {
+            match result {
+                Ok(ModelResponseStreamEvent::StreamComplete(sc)) => {
+                    saw_stream_complete = true;
+                    assert_eq!(sc.finish_reason, FinishReason::EndTurn);
+                    assert_eq!(sc.input_tokens, Some(10));
+                    assert_eq!(sc.output_tokens, Some(5));
+                }
+                Ok(_) => {}
+                Err(e) => panic!("valid stream should not produce error: {:?}", e),
+            }
+        }
+        assert!(
+            saw_stream_complete,
+            "valid stream should emit StreamComplete"
+        );
+        assert!(parser.message_stop_seen());
+        assert_eq!(parser.stop_reason(), Some("end_turn"));
+        assert_eq!(parser.output_tokens(), 5);
+        assert_eq!(parser.input_tokens(), 10);
+    }
+
+    /// Test 8: Premature EOF after visible text produces an error and no
+    /// further successful events.
+    #[tokio::test]
+    async fn test_premature_eof_after_text_produces_error() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta1)),
+            Ok(make_sse_bytes("content_block_delta", delta2)),
+            // Stream ends here — open text block, no message_stop
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut text_deltas_seen = 0;
+        let mut error_seen = false;
+        while let Some(result) = parser.next().await {
+            match result {
+                Ok(ModelResponseStreamEvent::PartDelta(PartDeltaEvent {
+                    delta: ModelResponsePartDelta::Text(_),
+                    ..
+                })) => {
+                    text_deltas_seen += 1;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    assert!(
+                        matches!(e, ModelError::IncompleteStream(_)),
+                        "expected IncompleteStream, got: {:?}",
+                        e
+                    );
+                    error_seen = true;
+                }
+            }
+        }
+        assert!(text_deltas_seen >= 2, "should have seen text deltas");
+        assert!(error_seen, "must see IncompleteStream error");
+        assert!(!parser.message_stop_seen());
     }
 }

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -83,6 +83,10 @@ pub enum ModelError {
     #[error("Configuration error: {0}")]
     Configuration(String),
 
+    /// Stream ended prematurely (e.g. transport EOF before a terminal event).
+    #[error("Incomplete stream: {0}")]
+    IncompleteStream(String),
+
     /// Network error.
     #[error("Network error: {0}")]
     Network(String),
@@ -100,6 +104,7 @@ impl ModelError {
             ModelError::Timeout(_) => true,
             ModelError::RateLimited { .. } => true,
             ModelError::Connection(_) => true,
+            ModelError::IncompleteStream(_) => true,
             ModelError::Http { status, .. } => *status >= 500,
             _ => false,
         }
@@ -165,6 +170,11 @@ impl ModelError {
     /// Create an invalid response error.
     pub fn invalid_response(message: impl Into<String>) -> Self {
         Self::InvalidResponse(message.into())
+    }
+
+    /// Create an incomplete-stream error.
+    pub fn incomplete_stream(message: impl Into<String>) -> Self {
+        Self::IncompleteStream(message.into())
     }
 
     /// Create a not supported error.


### PR DESCRIPTION
## Summary

Fixes #39

Anthropic streamed responses were accepted and committed as successful after premature transport EOF. The parser did not require `message_stop`, a complete final SSE frame, or closed content blocks. The agent then synthesized `FinishReason::Stop`, appended the response to canonical history, and emitted successful completion events.

## Changes

### `serdes-ai-core`
- **Added `StreamCompleteEvent`** to `ModelResponseStreamEvent` — a new terminal event carrying the provider-reported `FinishReason`, `input_tokens`, and `output_tokens`. This allows terminal metadata to flow through the type-erased `StreamedResponse` to the agent.
- Exported `StreamCompleteEvent` from `messages` module.

### `serdes-ai-models`
- **Added `ModelError::IncompleteStream`** — typed error for premature EOF, marked as retryable.
- **Anthropic parser terminal validation** — `message_stop` now atomically validates that no content blocks are open before accepting completion. Open blocks produce `IncompleteStream`.
- **`StreamComplete` emission** — on valid `message_stop`, the parser emits `StreamComplete` with the mapped finish reason (`end_turn` → `EndTurn`, `stop_sequence` → `StopSequence`, `max_tokens` → `Length`, `tool_use` → `ToolCall`).
- **Premature EOF detection** — if the inner stream ends before `message_stop`, `IncompleteStream` is emitted.
- **Malformed JSON rejection** — unparseable SSE events now return `InvalidResponse` instead of being silently dropped.
- **Tool input JSON validation** — `content_block_stop` for tool blocks validates accumulated `input_json` is valid JSON.
- **Tool input accumulation fix** — initial empty `{}` no longer concatenates with first delta.

### `serdes-ai-agent`
- **No more fabricated `FinishReason::Stop`** — both non-cancellable and cancellable paths require a `StreamComplete` terminal event. Streams ending without one produce `IncompleteStream`.
- **Provider usage propagation** — `StreamCompleteEvent` token counts are assigned to `ModelResponse.usage` via `RequestUsage::with_tokens`.
- **Empty stream rejection** — streams producing no parts are treated as errors.
- **Identical invariants** on both paths.

## Regression tests
- Parser: EOF before `message_stop`, partial SSE frame, open text/thinking/tool blocks, `content_block_stop` without `message_stop`, valid `message_stop` with finish reason + usage, premature EOF after visible text.
- Agent: premature EOF (non-cancellable), premature EOF (cancellable), empty stream (both paths), incomplete tool call (both paths), valid stream success path.
- All assertions verify no `OutputReady`, `RunComplete`, or `ResponseComplete` is emitted on invalid completion.

## Test results
- 154 core tests pass
- 122 model tests pass (with `--features anthropic`)
- 89 agent tests pass
- Full workspace: all tests pass, zero failures
- `cargo fmt --check`: passes

## Acceptance criteria
- [x] Only a validated provider terminal event can produce successful Anthropic stream completion
- [x] Premature EOF returns a typed error
- [x] Incomplete frames and open content blocks cannot commit
- [x] The agent no longer synthesizes `FinishReason::Stop` solely from clean iterator EOF
- [x] Invalid partial responses and tool calls are not appended to canonical history
- [x] No success terminal event is emitted on invalid completion
- [x] Cancellable and non-cancellable stream implementations follow the same invariant
- [x] Incomplete tool input cannot be executed or committed