### PR TITLE
Fix Anthropic transient error classification

### DIFF
--- a/serdes-ai-models/src/anthropic/error.rs
+++ b/serdes-ai-models/src/anthropic/error.rs
@@ -1,0 +1,98 @@
+//! Anthropic provider error classification.
+
+use crate::error::{ModelError, ProviderErrorKind};
+use std::time::Duration;
+
+/// Convert an Anthropic provider error into the canonical model error form.
+pub(super) fn map_anthropic_error(
+    code: impl Into<String>,
+    message: impl Into<String>,
+    retry_after: Option<Duration>,
+    http_status: Option<u16>,
+) -> ModelError {
+    let code = code.into();
+    let kind = match code.as_str() {
+        "rate_limit_error" => ProviderErrorKind::RateLimited,
+        "overloaded_error" => ProviderErrorKind::Overloaded,
+        "api_error" => ProviderErrorKind::Server,
+        "authentication_error" => ProviderErrorKind::Authentication,
+        "invalid_request_error" => ProviderErrorKind::InvalidRequest,
+        "not_found_error" => ProviderErrorKind::NotFound,
+        "permission_error" => ProviderErrorKind::PermissionDenied,
+        "billing_error" => ProviderErrorKind::Billing,
+        "request_too_large" => ProviderErrorKind::RequestTooLarge,
+        _ if http_status == Some(429) => ProviderErrorKind::RateLimited,
+        _ if http_status.is_some_and(|status| status >= 500) => ProviderErrorKind::Server,
+        _ => ProviderErrorKind::Other,
+    };
+
+    ModelError::provider("anthropic", code, message, kind, retry_after)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_retryable_errors() {
+        let rate_limit = map_anthropic_error(
+            "rate_limit_error",
+            "slow down",
+            Some(Duration::from_secs(12)),
+            Some(429),
+        );
+        assert!(rate_limit.is_rate_limited());
+        assert!(rate_limit.is_retryable());
+        assert_eq!(rate_limit.retry_after(), Some(Duration::from_secs(12)));
+
+        let overloaded = map_anthropic_error("overloaded_error", "try again", None, Some(529));
+        assert!(overloaded.is_transient());
+        assert!(overloaded.is_retryable());
+    }
+
+    #[test]
+    fn classifies_permanent_errors() {
+        for code in ["authentication_error", "invalid_request_error"] {
+            let error = map_anthropic_error(code, "permanent", None, Some(400));
+            assert!(!error.is_retryable(), "{code} must not be retryable");
+        }
+    }
+
+    #[test]
+    fn preserves_provider_metadata() {
+        let error = map_anthropic_error("overloaded_error", "capacity exhausted", None, None);
+
+        match error {
+            ModelError::Provider {
+                provider,
+                code,
+                message,
+                kind,
+                retry_after,
+            } => {
+                assert_eq!(provider, "anthropic");
+                assert_eq!(code, "overloaded_error");
+                assert_eq!(message, "capacity exhausted");
+                assert_eq!(kind, ProviderErrorKind::Overloaded);
+                assert_eq!(retry_after, None);
+            }
+            other => panic!("expected provider error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transport_does_not_change_known_provider_semantics() {
+        for code in [
+            "rate_limit_error",
+            "overloaded_error",
+            "authentication_error",
+            "invalid_request_error",
+        ] {
+            let http = map_anthropic_error(code, "message", None, Some(500));
+            let sse = map_anthropic_error(code, "message", None, None);
+            assert_eq!(http.is_retryable(), sse.is_retryable(), "{code}");
+            assert_eq!(http.is_rate_limited(), sse.is_rate_limited(), "{code}");
+            assert_eq!(http.is_transient(), sse.is_transient(), "{code}");
+        }
+    }
+}

--- a/serdes-ai-models/src/anthropic/mod.rs
+++ b/serdes-ai-models/src/anthropic/mod.rs
@@ -32,6 +32,7 @@
 //! let response = model.request(&messages, &settings, &params).await?;
 //! ```
 
+mod error;
 pub mod model;
 pub mod stream;
 pub mod types;

--- a/serdes-ai-models/src/anthropic/model.rs
+++ b/serdes-ai-models/src/anthropic/model.rs
@@ -1,5 +1,6 @@
 //! Anthropic Claude model implementation.
 
+use super::error::map_anthropic_error;
 use super::stream::AnthropicStreamParser;
 use super::types::*;
 use crate::error::ModelError;
@@ -551,32 +552,19 @@ impl AnthropicModel {
 
     /// Handle API error response.
     fn handle_error_response(&self, status: u16, body: &str, headers: &HeaderMap) -> ModelError {
+        let retry_after = Self::parse_retry_after(headers);
+
         if let Ok(err) = serde_json::from_str::<AnthropicError>(body) {
-            let code = err.error.error_type.clone();
-
-            match status {
-                401 => return ModelError::auth(err.error.message),
-                429 => return ModelError::rate_limited(Self::parse_retry_after(headers)),
-                404 => return ModelError::NotFound(err.error.message),
-                400 => {
-                    if code == "invalid_request_error" {
-                        return ModelError::Api {
-                            message: err.error.message,
-                            code: Some(code),
-                        };
-                    }
-                }
-                _ => {}
-            }
-
-            return ModelError::Api {
-                message: err.error.message,
-                code: Some(code),
-            };
+            return map_anthropic_error(
+                err.error.error_type,
+                err.error.message,
+                retry_after,
+                Some(status),
+            );
         }
 
         if status == 429 {
-            return ModelError::rate_limited(Self::parse_retry_after(headers));
+            return ModelError::rate_limited(retry_after);
         }
 
         ModelError::http(status, body)
@@ -687,6 +675,35 @@ impl Model for AnthropicModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_handle_error_response_uses_provider_semantics() {
+        let model = AnthropicModel::new("claude-3-5-sonnet-20241022", "key");
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", "7".parse().unwrap());
+
+        let rate_limit = model.handle_error_response(
+            429,
+            r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#,
+            &headers,
+        );
+        assert!(rate_limit.is_rate_limited());
+        assert_eq!(rate_limit.retry_after(), Some(Duration::from_secs(7)));
+
+        let overloaded = model.handle_error_response(
+            529,
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"busy"}}"#,
+            &HeaderMap::new(),
+        );
+        assert!(overloaded.is_transient());
+
+        let auth = model.handle_error_response(
+            401,
+            r#"{"type":"error","error":{"type":"authentication_error","message":"bad key"}}"#,
+            &HeaderMap::new(),
+        );
+        assert!(!auth.is_retryable());
+    }
 
     #[test]
     fn test_anthropic_model_new() {

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides streaming support for Anthropic's Messages API.
 
+use super::error::map_anthropic_error;
 use super::types::{ContentBlockDelta, ContentBlockStart, StreamEvent};
 use crate::error::ModelError;
 use bytes::Bytes;
@@ -325,9 +326,11 @@ fn process_event(
 
         StreamEvent::Ping => None,
 
-        StreamEvent::Error { error } => Some(Err(ModelError::api_with_code(
-            error.message,
+        StreamEvent::Error { error } => Some(Err(map_anthropic_error(
             error.error_type,
+            error.message,
+            None,
+            None,
         ))),
     }
 }
@@ -433,18 +436,48 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_parse_error() {
+    async fn parse_stream_error(code: &str, message: &str) -> ModelError {
         let error =
-            r#"{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}"#;
-        let bytes = vec![Ok(make_sse_bytes("error", error))];
-        let stream = stream::iter(bytes);
+            format!(r#"{{"type":"error","error":{{"type":"{code}","message":"{message}"}}}}"#);
+        let stream = stream::iter(vec![Ok(make_sse_bytes("error", &error))]);
         let mut parser = AnthropicStreamParser::new(stream);
+        parser.next().await.unwrap().unwrap_err()
+    }
 
-        let event = parser.next().await.unwrap();
-        assert!(event.is_err());
-        let err = event.unwrap_err();
-        assert!(err.to_string().contains("Rate limited"));
+    #[tokio::test]
+    async fn test_parse_rate_limit_error() {
+        let err = parse_stream_error("rate_limit_error", "Rate limited").await;
+
+        assert!(err.is_rate_limited());
+        assert!(err.is_retryable());
+        match err {
+            ModelError::Provider {
+                code,
+                message,
+                kind,
+                ..
+            } => {
+                assert_eq!(code, "rate_limit_error");
+                assert_eq!(message, "Rate limited");
+                assert_eq!(kind, crate::ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected provider error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_overloaded_error() {
+        let err = parse_stream_error("overloaded_error", "Overloaded").await;
+        assert!(err.is_transient());
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn test_parse_permanent_errors() {
+        for code in ["authentication_error", "invalid_request_error"] {
+            let err = parse_stream_error(code, "Permanent").await;
+            assert!(!err.is_retryable(), "{code} must not be retryable");
+        }
     }
 
     #[tokio::test]

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -4,6 +4,31 @@ use std::collections::HashMap;
 use std::time::Duration;
 use thiserror::Error;
 
+/// Semantic classification for a provider-reported API error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderErrorKind {
+    /// The provider rate-limited the request.
+    RateLimited,
+    /// The provider is temporarily overloaded.
+    Overloaded,
+    /// The provider reported a transient server failure.
+    Server,
+    /// Authentication failed.
+    Authentication,
+    /// The request was invalid.
+    InvalidRequest,
+    /// The requested resource was not found.
+    NotFound,
+    /// The caller lacks permission for the request.
+    PermissionDenied,
+    /// The account cannot make the request for billing reasons.
+    Billing,
+    /// The request exceeded the provider's size limit.
+    RequestTooLarge,
+    /// An unclassified provider error.
+    Other,
+}
+
 /// Model-related errors.
 #[derive(Debug, Error)]
 pub enum ModelError {
@@ -25,6 +50,21 @@ pub enum ModelError {
         message: String,
         /// Error code.
         code: Option<String>,
+    },
+
+    /// Structured error reported by a model provider.
+    #[error("{provider} API error ({code}): {message}")]
+    Provider {
+        /// Provider name.
+        provider: String,
+        /// Provider-specific error type or code.
+        code: String,
+        /// Provider-supplied error message.
+        message: String,
+        /// Semantic classification used by retry and fallback policies.
+        kind: ProviderErrorKind,
+        /// Suggested retry delay, when supplied by the provider.
+        retry_after: Option<Duration>,
     },
 
     /// Request timeout.
@@ -96,11 +136,34 @@ impl ModelError {
     /// Check if this error is retryable.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
+        self.is_rate_limited() || self.is_transient()
+    }
+
+    /// Check if this error represents rate limiting.
+    #[must_use]
+    pub fn is_rate_limited(&self) -> bool {
+        matches!(self, ModelError::RateLimited { .. })
+            || matches!(
+                self,
+                ModelError::Provider {
+                    kind: ProviderErrorKind::RateLimited,
+                    ..
+                }
+            )
+    }
+
+    /// Check if this error is transient, excluding rate limits.
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
         match self {
-            ModelError::Timeout(_) => true,
-            ModelError::RateLimited { .. } => true,
-            ModelError::Connection(_) => true,
+            ModelError::Timeout(_) | ModelError::Connection(_) | ModelError::Network(_) => true,
             ModelError::Http { status, .. } => *status >= 500,
+            ModelError::Provider { kind, .. } => {
+                matches!(
+                    kind,
+                    ProviderErrorKind::Overloaded | ProviderErrorKind::Server
+                )
+            }
             _ => false,
         }
     }
@@ -110,6 +173,7 @@ impl ModelError {
     pub fn retry_after(&self) -> Option<Duration> {
         match self {
             ModelError::RateLimited { retry_after } => *retry_after,
+            ModelError::Provider { retry_after, .. } => *retry_after,
             _ => None,
         }
     }
@@ -133,6 +197,23 @@ impl ModelError {
     /// Create a rate limited error.
     pub fn rate_limited(retry_after: Option<Duration>) -> Self {
         Self::RateLimited { retry_after }
+    }
+
+    /// Create a structured provider error.
+    pub fn provider(
+        provider: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+        kind: ProviderErrorKind,
+        retry_after: Option<Duration>,
+    ) -> Self {
+        Self::Provider {
+            provider: provider.into(),
+            code: code.into(),
+            message: message.into(),
+            kind,
+            retry_after,
+        }
     }
 
     /// Create an HTTP error.

--- a/serdes-ai-models/src/fallback.rs
+++ b/serdes-ai-models/src/fallback.rs
@@ -44,12 +44,8 @@ impl RetryOn {
     pub fn should_retry(&self, error: &ModelError) -> bool {
         match self {
             RetryOn::AnyError => true,
-            RetryOn::RateLimits => matches!(error, ModelError::RateLimited { .. }),
-            RetryOn::Transient => match error {
-                ModelError::Timeout(_) | ModelError::Connection(_) | ModelError::Network(_) => true,
-                ModelError::Http { status, .. } => *status >= 500,
-                _ => false,
-            },
+            RetryOn::RateLimits => error.is_rate_limited(),
+            RetryOn::Transient => error.is_transient(),
         }
     }
 }
@@ -300,6 +296,7 @@ impl Model for FallbackModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ProviderErrorKind;
     use crate::mock::MockModel;
     use serdes_ai_core::messages::TextPart;
     use serdes_ai_core::{FinishReason, ModelResponsePart};
@@ -360,6 +357,19 @@ mod tests {
                 ModelError::Timeout(d) => Err(ModelError::Timeout(*d)),
                 ModelError::Connection(msg) => Err(ModelError::Connection(msg.clone())),
                 ModelError::Authentication(msg) => Err(ModelError::Authentication(msg.clone())),
+                ModelError::Provider {
+                    provider,
+                    code,
+                    message,
+                    kind,
+                    retry_after,
+                } => Err(ModelError::Provider {
+                    provider: provider.clone(),
+                    code: code.clone(),
+                    message: message.clone(),
+                    kind: *kind,
+                    retry_after: *retry_after,
+                }),
                 ModelError::Http {
                     status,
                     body,
@@ -462,6 +472,14 @@ mod tests {
         assert!(RetryOn::RateLimits.should_retry(&ModelError::rate_limited(None)));
         assert!(!RetryOn::RateLimits.should_retry(&ModelError::api("test")));
         assert!(!RetryOn::RateLimits.should_retry(&ModelError::Timeout(Duration::from_secs(30))));
+        let provider_rate_limit = ModelError::provider(
+            "anthropic",
+            "rate_limit_error",
+            "slow down",
+            ProviderErrorKind::RateLimited,
+            None,
+        );
+        assert!(RetryOn::RateLimits.should_retry(&provider_rate_limit));
 
         // Transient retries on timeout, connection, network, and 5xx errors
         assert!(RetryOn::Transient.should_retry(&ModelError::Timeout(Duration::from_secs(30))));
@@ -471,6 +489,14 @@ mod tests {
         assert!(RetryOn::Transient.should_retry(&ModelError::http(502, "Bad gateway")));
         assert!(!RetryOn::Transient.should_retry(&ModelError::http(400, "Bad request")));
         assert!(!RetryOn::Transient.should_retry(&ModelError::api("test")));
+        let provider_overload = ModelError::provider(
+            "anthropic",
+            "overloaded_error",
+            "busy",
+            ProviderErrorKind::Overloaded,
+            None,
+        );
+        assert!(RetryOn::Transient.should_retry(&provider_overload));
         assert!(!RetryOn::Transient.should_retry(&ModelError::rate_limited(None)));
     }
 
@@ -771,6 +797,64 @@ mod tests {
         } else {
             panic!("Expected text response");
         }
+    }
+
+    #[tokio::test]
+    async fn test_fallback_rate_limit_policy_accepts_provider_classification() {
+        let primary = FailingMockModel::new(
+            "primary",
+            ModelError::provider(
+                "anthropic",
+                "rate_limit_error",
+                "slow down",
+                ProviderErrorKind::RateLimited,
+                Some(Duration::from_secs(3)),
+            ),
+        );
+        let backup = SucceedingMockModel::new("backup", "ok");
+        let backup_calls = backup.call_count.clone();
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::RateLimits);
+
+        let result = fallback
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fallback_transient_policy_accepts_provider_overload() {
+        let primary = FailingMockModel::new(
+            "primary",
+            ModelError::provider(
+                "anthropic",
+                "overloaded_error",
+                "busy",
+                ProviderErrorKind::Overloaded,
+                None,
+            ),
+        );
+        let backup = SucceedingMockModel::new("backup", "ok");
+        let backup_calls = backup.call_count.clone();
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let result = fallback
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/serdes-ai-models/src/lib.rs
+++ b/serdes-ai-models/src/lib.rs
@@ -162,7 +162,7 @@ pub use antigravity::AntigravityModel;
 pub mod mock;
 
 // Re-exports
-pub use error::{ModelError, ModelResult};
+pub use error::{ModelError, ModelResult, ProviderErrorKind};
 pub use fallback::{FallbackModel, RetryOn};
 pub use mock::{FunctionModel, MockModel, TestModel};
 pub use model::{


### PR DESCRIPTION
## Summary
- add one authoritative Anthropic provider-error classifier shared by HTTP responses and in-band SSE errors
- preserve provider code, message, semantic kind, and Retry-After metadata
- classify rate limits and overload/server failures as retryable while keeping permanent errors non-retryable
- make fallback policies consume the same canonical rate-limit/transient helpers

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p serdes-ai-models --features anthropic --lib` (123 passed)
- `cargo test --workspace --lib`
- `cargo clippy -p serdes-ai-models --features anthropic --all-targets -- -D warnings`
- OCR: 7 files reviewed, 0 comments

Fixes #41