### PR TITLE
Close streaming integrity and resilience gaps (#39-#46)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,6 +3,8 @@
 [build]
 # Use all available CPU cores
 jobs = -1
+# Keep large all-feature workspace builds from retaining duplicate incremental artifacts.
+incremental = false
 
 [target.x86_64-unknown-linux-gnu]
 rustflags = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,6 +3129,7 @@ dependencies = [
  "serdes-ai-core",
  "serdes-ai-output",
  "serdes-ai-retries",
+ "serdes-ai-streaming",
  "serdes-ai-tools",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,6 +3128,7 @@ dependencies = [
  "serde_json",
  "serdes-ai-core",
  "serdes-ai-output",
+ "serdes-ai-retries",
  "serdes-ai-tools",
  "thiserror 1.0.69",
  "tokio",

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SerdesAI 🦀
 
-> **A complete Rust port of pydantic-ai for building production-ready AI agents**
+> **A type-safe Rust AI agent framework inspired by pydantic-ai**
 
 [![Crates.io](https://img.shields.io/crates/v/serdes-ai.svg)](https://crates.io/crates/serdes-ai)
 [![Documentation](https://docs.rs/serdes-ai/badge.svg)](https://docs.rs/serdes-ai)
 [![CI](https://github.com/janfeddersen-wq/serdesAI/workflows/CI/badge.svg)](https://github.com/janfeddersen-wq/serdesAI/actions)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-SerdesAI is a comprehensive, type-safe Rust framework for building AI agents that interact with large language models. It is a complete port of [pydantic-ai](https://github.com/pydantic/pydantic-ai) to pure Rust, providing ergonomic async APIs with compile-time safety guarantees.
+SerdesAI is a type-safe Rust framework for building AI agents that interact with large language models. It follows many architectural ideas from [pydantic-ai](https://github.com/pydantic/pydantic-ai), while parity work remains ongoing and Rust-specific APIs may differ. Evaluate the capabilities and provider paths you need before production deployment.
 
 ## ✨ Features
 
@@ -322,19 +322,28 @@ serdes-ai = { version = "0.1", features = ["full"] }
 - [Examples](./examples/)
 - [Migration from pydantic-ai](./docs/migration.md)
 
-## ⚖️ Comparison with pydantic-ai
+## ⚖️ Capability and parity status
 
-| Feature       | pydantic-ai            | serdes-ai        |
-| ------------- | ---------------------- | ---------------- |
-| Language      | Python                 | Rust             |
-| Type Safety   | Runtime (Pydantic)     | Compile-time     |
-| Async Runtime | asyncio                | tokio            |
-| Validation    | Pydantic v2            | serde + custom   |
-| Performance   | Good                   | Excellent        |
-| Memory Safety | Garbage Collected      | Ownership system |
-| Binary Size   | Large (Python runtime) | Minimal          |
-| Startup Time  | Slow                   | Instant          |
-| Thread Safety | GIL limitations        | Fully concurrent |
+The current audit baseline is pydantic-ai at the SerdesAI upstream revision
+`be5774b5c618a71fe899ac5b8c6a5e958ea42a5d` (2026-07-13). This is a capability
+comparison, not a claim of API or behavioral parity.
+
+| Capability | SerdesAI status | Notes |
+| --- | --- | --- |
+| Typed agents and dependencies | Implemented | Rust generics and serde-based output validation |
+| Model providers | Implemented, provider-specific | Verify the selected model/profile capability flags |
+| Tool calling and structured output | Implemented | Provider behavior and schema support vary |
+| Streaming terminal integrity | Implemented for the audited Anthropic path | Requires provider terminal metadata; premature EOF is an error |
+| Same-model smart retries | Implemented, opt-in | `RetryingModel` / `with_retries`; total deadline and `Retry-After` supported |
+| Cross-model streaming fallback | Implemented with a strict boundary | May switch before the first event only; every event, including metadata, locks the attempt |
+| Shared SSE framing | Implemented and used by Anthropic | Strict UTF-8, bounded buffering, incomplete-EOF rejection |
+| Graphs, MCP, embeddings, evaluations | Implemented as separate crates | APIs are Rust-native and are not asserted to match every pydantic-ai feature |
+| Full pydantic-ai API/behavior parity | Ongoing | No unconditional full-port or production-readiness claim |
+
+Retries and fallback are separate. Retries repeat the same model and are enabled
+explicitly. Fallback selects another model. For streaming fallback, an acquisition
+failure or retryable error before the first event can select a backup. Once any
+event escapes, later errors propagate without replaying or concatenating output.
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,29 @@ let graph = Graph::new()
 let result = graph.run(WorkflowState::default(), ()).await?;
 ```
 
+## 🔄 Model Retries
+
+Same-model retries are explicit and provider-neutral:
+
+```rust,ignore
+use serdes_ai::prelude::*;
+use std::time::Duration;
+
+let model = OpenAIChatModel::from_env("gpt-4o")?.with_retries(
+    RetryPolicy::for_model_requests()
+        .max_attempts(3)
+        .total_timeout(Some(Duration::from_secs(30))),
+);
+let agent = AgentBuilder::new(model).build();
+```
+
+Retries honor classified rate limits, transient server failures, connection
+errors, timeouts, and `Retry-After`. Authentication and invalid requests are not
+retried. Dropping the request future cancels backoff. Streaming retries stop at
+the first caller-visible event, so partial responses are never replayed. Use
+`RetryPolicy::disabled()` for one explicit attempt. Same-model retry is separate
+from `FallbackModel`, which selects another model.
+
 ## 📦 Crates
 
 SerdesAI is organized as a workspace of focused crates:

--- a/README.md
+++ b/README.md
@@ -324,9 +324,12 @@ serdes-ai = { version = "0.1", features = ["full"] }
 
 ## ⚖️ Capability and parity status
 
-The current audit baseline is pydantic-ai at the SerdesAI upstream revision
-`be5774b5c618a71fe899ac5b8c6a5e958ea42a5d` (2026-07-13). This is a capability
-comparison, not a claim of API or behavioral parity.
+The comparison target for this capability matrix is pydantic-ai v2.9.1
+(`bf9a2435de41aaf269fc6bc72fe641f2fa0465c6`, released 2026-07-13). The
+SerdesAI implementation was audited from upstream revision
+`be5774b5c618a71fe899ac5b8c6a5e958ea42a5d`. This matrix records SerdesAI's
+status for the listed capabilities; it is not an exhaustive claim of API or
+behavioral parity.
 
 | Capability | SerdesAI status | Notes |
 | --- | --- | --- |

--- a/serdes-ai-a2a/src/storage.rs
+++ b/serdes-ai-a2a/src/storage.rs
@@ -135,7 +135,7 @@ impl Storage for InMemoryStorage {
         let mut all_tasks: Vec<Task> = tasks.values().cloned().collect();
 
         // Sort by created_at descending (newest first)
-        all_tasks.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        all_tasks.sort_by_key(|task| std::cmp::Reverse(task.created_at));
 
         if let Some(limit) = limit {
             all_tasks.truncate(limit);

--- a/serdes-ai-agent/src/builder.rs
+++ b/serdes-ai-agent/src/builder.rs
@@ -100,6 +100,8 @@ pub struct ModelConfig {
     pub base_url: Option<String>,
     /// Optional request timeout
     pub timeout: Option<Duration>,
+    /// Optional same-model retry policy. Retries are disabled when omitted.
+    pub retry_policy: Option<serdes_ai_models::RetryPolicy>,
 }
 
 impl ModelConfig {
@@ -119,6 +121,7 @@ impl ModelConfig {
             api_key: None,
             base_url: None,
             timeout: None,
+            retry_policy: None,
         }
     }
 
@@ -140,6 +143,20 @@ impl ModelConfig {
     #[must_use]
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = Some(timeout);
+        self
+    }
+
+    /// Enable same-model retries with the supplied policy.
+    #[must_use]
+    pub fn with_retries(mut self, policy: serdes_ai_models::RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Explicitly disable same-model retries.
+    #[must_use]
+    pub fn without_retries(mut self) -> Self {
+        self.retry_policy = None;
         self
     }
 
@@ -172,18 +189,17 @@ impl ModelConfig {
     /// - `ollama` - Local Ollama models
     /// - `google` - Google/Gemini models
     pub fn build_model(&self) -> Result<Arc<dyn Model>, ModelError> {
-        // If no custom config, use infer_model which handles feature flags
-        if self.api_key.is_none() && self.base_url.is_none() && self.timeout.is_none() {
-            return serdes_ai_models::infer_model(&self.spec);
-        }
+        let model = if self.api_key.is_none() && self.base_url.is_none() && self.timeout.is_none() {
+            serdes_ai_models::infer_model(&self.spec)?
+        } else {
+            let (provider, model_name) = self.parse_spec();
+            self.build_model_with_config(provider, model_name)?
+        };
 
-        // Custom config requires building the model directly
-        let (provider, model_name) = self.parse_spec();
-
-        // We need to build the model with custom settings
-        // This requires the concrete model types which are behind feature flags
-        // in serdes-ai-models. We use a helper function pattern.
-        self.build_model_with_config(provider, model_name)
+        Ok(match self.retry_policy.clone() {
+            Some(policy) => Arc::new(serdes_ai_models::RetryingModel::from_arc(model, policy)),
+            None => model,
+        })
     }
 
     fn build_model_with_config(
@@ -362,6 +378,15 @@ where
     #[must_use]
     pub fn model_settings(mut self, settings: ModelSettings) -> Self {
         self.model_settings = settings;
+        self
+    }
+
+    /// Enable same-model retries for this agent's model.
+    #[must_use]
+    pub fn model_retries(mut self, policy: serdes_ai_models::RetryPolicy) -> Self {
+        self.model = Arc::new(serdes_ai_models::RetryingModel::from_arc(
+            self.model, policy,
+        ));
         self
     }
 

--- a/serdes-ai-agent/src/errors.rs
+++ b/serdes-ai-agent/src/errors.rs
@@ -2,6 +2,7 @@
 //!
 //! This module defines all errors that can occur during agent execution.
 
+use serdes_ai_core::{ClassifyModelFailure, ModelFailure};
 use serdes_ai_models::ModelError;
 use serdes_ai_tools::ToolError;
 use thiserror::Error;
@@ -93,13 +94,22 @@ impl AgentRunError {
     /// Check if this error is retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
-            Self::Model(e) => e.is_retryable(),
+            Self::Model(e) => e.model_failure().is_retryable(),
             Self::Tool(e) => e.is_retryable(),
             Self::UsageLimitExceeded(_) => false,
             Self::Cancelled => false,
             Self::Timeout { .. } => false,
             Self::MaxRetriesExceeded { .. } => false,
             _ => true,
+        }
+    }
+
+    /// Return canonical model-call failure metadata when this error came from a model.
+    #[must_use]
+    pub fn model_failure(&self) -> Option<ModelFailure> {
+        match self {
+            Self::Model(error) => Some(error.model_failure()),
+            _ => None,
         }
     }
 }

--- a/serdes-ai-agent/src/stream.rs
+++ b/serdes-ai-agent/src/stream.rs
@@ -552,14 +552,12 @@ impl AgentStream {
                                                 }
                                             }
                                         }
-                                        ModelResponsePart::Thinking(t) => {
-                                            if !t.content.is_empty() {
-                                                let _ = tx
-                                                    .send(Ok(AgentStreamEvent::ThinkingDelta {
-                                                        text: t.content.clone(),
-                                                    }))
-                                                    .await;
-                                            }
+                                        ModelResponsePart::Thinking(t) if !t.content.is_empty() => {
+                                            let _ = tx
+                                                .send(Ok(AgentStreamEvent::ThinkingDelta {
+                                                    text: t.content.clone(),
+                                                }))
+                                                .await;
                                         }
                                         _ => {}
                                     }
@@ -1135,15 +1133,15 @@ impl AgentStream {
                                                         }
                                                     }
                                                 }
-                                                ModelResponsePart::Thinking(t) => {
-                                                    if !t.content.is_empty() {
-                                                        accumulated_thinking.push_str(&t.content);
-                                                        let _ = tx
-                                                            .send(Ok(AgentStreamEvent::ThinkingDelta {
-                                                                text: t.content.clone(),
-                                                            }))
-                                                            .await;
-                                                    }
+                                                ModelResponsePart::Thinking(t)
+                                                    if !t.content.is_empty() =>
+                                                {
+                                                    accumulated_thinking.push_str(&t.content);
+                                                    let _ = tx
+                                                        .send(Ok(AgentStreamEvent::ThinkingDelta {
+                                                            text: t.content.clone(),
+                                                        }))
+                                                        .await;
                                                 }
                                                 _ => {}
                                             }

--- a/serdes-ai-agent/src/stream.rs
+++ b/serdes-ai-agent/src/stream.rs
@@ -10,10 +10,10 @@ use crate::run::{CompressionStrategy, RunOptions};
 use chrono::Utc;
 use futures::{Stream, StreamExt};
 use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, ToolCallArgs, ToolReturnPart, UserContent,
+    ModelResponseStreamEvent, StreamCompleteEvent, ToolCallArgs, ToolReturnPart, UserContent,
 };
 use serdes_ai_core::{
-    FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart,
+    FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, RequestUsage,
 };
 use serdes_ai_models::ModelRequestParameters;
 use std::pin::Pin;
@@ -148,6 +148,31 @@ fn canonicalize_tool_call_args_in_response(response: &mut ModelResponse) {
             tc.args = ToolCallArgs::Json(repaired);
         }
     }
+}
+
+fn usage_from_stream_complete(event: &StreamCompleteEvent) -> Option<RequestUsage> {
+    if event.input_tokens.is_none()
+        && event.output_tokens.is_none()
+        && event.cache_creation_tokens.is_none()
+        && event.cache_read_tokens.is_none()
+    {
+        return None;
+    }
+
+    let mut usage = RequestUsage::new();
+    if let Some(tokens) = event.input_tokens {
+        usage = usage.request_tokens(tokens);
+    }
+    if let Some(tokens) = event.output_tokens {
+        usage = usage.response_tokens(tokens);
+    }
+    if let Some(tokens) = event.cache_creation_tokens {
+        usage = usage.cache_creation_tokens(tokens);
+    }
+    if let Some(tokens) = event.cache_read_tokens {
+        usage = usage.cache_read_tokens(tokens);
+    }
+    Some(usage)
 }
 
 impl AgentStream {
@@ -509,7 +534,7 @@ impl AgentStream {
                 let mut stream_event_count = 0u32;
                 // Provider-reported finish reason (set by StreamComplete event)
                 let mut stream_finish_reason: Option<FinishReason> = None;
-                let mut stream_usage: Option<(u64, u64)> = None;
+                let mut stream_usage: Option<RequestUsage> = None;
 
                 // Process stream events
                 debug!("AgentStream: starting to process model stream events");
@@ -624,11 +649,7 @@ impl AgentStream {
                                 }
                                 ModelResponseStreamEvent::StreamComplete(sc) => {
                                     stream_finish_reason = Some(sc.finish_reason);
-                                    if let (Some(inp), Some(out)) =
-                                        (sc.input_tokens, sc.output_tokens)
-                                    {
-                                        stream_usage = Some((inp, out));
-                                    }
+                                    stream_usage = usage_from_stream_complete(&sc);
                                 }
                             }
                         }
@@ -696,8 +717,7 @@ impl AgentStream {
                     model_name: Some(model.name().to_string()),
                     timestamp: Utc::now(),
                     finish_reason: Some(stream_finish_reason),
-                    usage: stream_usage
-                        .map(|(req, res)| serdes_ai_core::RequestUsage::with_tokens(req, res)),
+                    usage: stream_usage,
                     vendor_id: None,
                     vendor_details: None,
                     kind: "response".to_string(),
@@ -1070,7 +1090,7 @@ impl AgentStream {
 
                 // Provider-reported finish reason (set by StreamComplete event)
                 let mut stream_finish_reason: Option<FinishReason> = None;
-                let mut stream_usage: Option<(u64, u64)> = None;
+                let mut stream_usage: Option<RequestUsage> = None;
 
                 // Process stream events with cancellation check
                 loop {
@@ -1205,11 +1225,7 @@ impl AgentStream {
                                         ModelResponseStreamEvent::PartEnd(_) => {}
                                         ModelResponseStreamEvent::StreamComplete(sc) => {
                                             stream_finish_reason = Some(sc.finish_reason);
-                                            if let (Some(inp), Some(out)) =
-                                                (sc.input_tokens, sc.output_tokens)
-                                            {
-                                                stream_usage = Some((inp, out));
-                                            }
+                                            stream_usage = usage_from_stream_complete(&sc);
                                         }
                                     }
                                 }
@@ -1277,8 +1293,7 @@ impl AgentStream {
                     model_name: Some(model.name().to_string()),
                     timestamp: Utc::now(),
                     finish_reason: Some(stream_finish_reason),
-                    usage: stream_usage
-                        .map(|(req, res)| serdes_ai_core::RequestUsage::with_tokens(req, res)),
+                    usage: stream_usage,
                     vendor_id: None,
                     vendor_details: None,
                     kind: "response".to_string(),
@@ -1584,6 +1599,23 @@ mod tests {
         } else {
             panic!("Expected Cancelled event");
         }
+    }
+
+    #[test]
+    fn test_stream_complete_usage_preserves_all_provider_token_fields() {
+        let event = StreamCompleteEvent::new(FinishReason::Stop)
+            .with_input_tokens(10)
+            .with_output_tokens(5)
+            .with_cache_creation_tokens(3)
+            .with_cache_read_tokens(7);
+
+        let usage = usage_from_stream_complete(&event).expect("usage should be present");
+
+        assert_eq!(usage.request_tokens, Some(10));
+        assert_eq!(usage.response_tokens, Some(5));
+        assert_eq!(usage.total_tokens, Some(15));
+        assert_eq!(usage.cache_creation_tokens, Some(3));
+        assert_eq!(usage.cache_read_tokens, Some(7));
     }
 
     #[test]

--- a/serdes-ai-agent/src/stream.rs
+++ b/serdes-ai-agent/src/stream.rs
@@ -507,6 +507,9 @@ impl AgentStream {
                 let mut response_parts: Vec<ModelResponsePart> = Vec::new();
                 // Track stream events (used by tracing when enabled)
                 let mut stream_event_count = 0u32;
+                // Provider-reported finish reason (set by StreamComplete event)
+                let mut stream_finish_reason: Option<FinishReason> = None;
+                let mut stream_usage: Option<(u64, u64)> = None;
 
                 // Process stream events
                 debug!("AgentStream: starting to process model stream events");
@@ -621,6 +624,14 @@ impl AgentStream {
                                 ModelResponseStreamEvent::PartEnd(_) => {
                                     // Part finished
                                 }
+                                ModelResponseStreamEvent::StreamComplete(sc) => {
+                                    stream_finish_reason = Some(sc.finish_reason);
+                                    if let (Some(inp), Some(out)) =
+                                        (sc.input_tokens, sc.output_tokens)
+                                    {
+                                        stream_usage = Some((inp, out));
+                                    }
+                                }
                             }
                         }
                         Err(e) => {
@@ -641,13 +652,54 @@ impl AgentStream {
                     "AgentStream: finished processing model stream"
                 );
 
-                // Build the complete response
+                // If the stream did not produce a terminal StreamComplete event,
+                // this is a premature EOF — emit an error and abort.
+                let stream_finish_reason = match stream_finish_reason {
+                    Some(reason) => reason,
+                    None => {
+                        let _ = tx
+                            .send(Ok(AgentStreamEvent::Error {
+                                message:
+                                    "model stream ended without a terminal StreamComplete event"
+                                        .to_string(),
+                            }))
+                            .await;
+                        let _ = tx
+                            .send(Err(AgentRunError::Model(
+                                serdes_ai_models::ModelError::incomplete_stream(
+                                    "model stream ended without a terminal StreamComplete event",
+                                ),
+                            )))
+                            .await;
+                        return;
+                    }
+                };
+
+                // If the stream produced no parts at all, treat it as an error
+                if response_parts.is_empty() {
+                    let _ = tx
+                        .send(Ok(AgentStreamEvent::Error {
+                            message: "model stream ended without producing any content".to_string(),
+                        }))
+                        .await;
+                    let _ = tx
+                        .send(Err(AgentRunError::Model(
+                            serdes_ai_models::ModelError::incomplete_stream(
+                                "model stream ended without producing any content",
+                            ),
+                        )))
+                        .await;
+                    return;
+                }
+
+                // Build the complete response using the provider-reported finish reason
                 let mut response = ModelResponse {
                     parts: response_parts.clone(),
                     model_name: Some(model.name().to_string()),
                     timestamp: Utc::now(),
-                    finish_reason: Some(FinishReason::Stop),
-                    usage: None,
+                    finish_reason: Some(stream_finish_reason),
+                    usage: stream_usage
+                        .map(|(req, res)| serdes_ai_core::RequestUsage::with_tokens(req, res)),
                     vendor_id: None,
                     vendor_details: None,
                     kind: "response".to_string(),
@@ -1018,6 +1070,10 @@ impl AgentStream {
 
                 let mut response_parts: Vec<ModelResponsePart> = Vec::new();
 
+                // Provider-reported finish reason (set by StreamComplete event)
+                let mut stream_finish_reason: Option<FinishReason> = None;
+                let mut stream_usage: Option<(u64, u64)> = None;
+
                 // Process stream events with cancellation check
                 loop {
                     tokio::select! {
@@ -1149,6 +1205,14 @@ impl AgentStream {
                                             }
                                         }
                                         ModelResponseStreamEvent::PartEnd(_) => {}
+                                        ModelResponseStreamEvent::StreamComplete(sc) => {
+                                            stream_finish_reason = Some(sc.finish_reason);
+                                            if let (Some(inp), Some(out)) =
+                                                (sc.input_tokens, sc.output_tokens)
+                                            {
+                                                stream_usage = Some((inp, out));
+                                            }
+                                        }
                                     }
                                 }
                                 Some(Err(e)) => {
@@ -1169,13 +1233,54 @@ impl AgentStream {
                     }
                 }
 
-                // Build the complete response
+                // If the stream did not produce a terminal StreamComplete event,
+                // this is a premature EOF — emit an error and abort.
+                let stream_finish_reason = match stream_finish_reason {
+                    Some(reason) => reason,
+                    None => {
+                        let _ = tx
+                            .send(Ok(AgentStreamEvent::Error {
+                                message:
+                                    "model stream ended without a terminal StreamComplete event"
+                                        .to_string(),
+                            }))
+                            .await;
+                        let _ = tx
+                            .send(Err(AgentRunError::Model(
+                                serdes_ai_models::ModelError::incomplete_stream(
+                                    "model stream ended without a terminal StreamComplete event",
+                                ),
+                            )))
+                            .await;
+                        return;
+                    }
+                };
+
+                // If the stream produced no parts at all, treat it as an error
+                if response_parts.is_empty() {
+                    let _ = tx
+                        .send(Ok(AgentStreamEvent::Error {
+                            message: "model stream ended without producing any content".to_string(),
+                        }))
+                        .await;
+                    let _ = tx
+                        .send(Err(AgentRunError::Model(
+                            serdes_ai_models::ModelError::incomplete_stream(
+                                "model stream ended without producing any content",
+                            ),
+                        )))
+                        .await;
+                    return;
+                }
+
+                // Build the complete response using the provider-reported finish reason
                 let mut response = ModelResponse {
                     parts: response_parts.clone(),
                     model_name: Some(model.name().to_string()),
                     timestamp: Utc::now(),
-                    finish_reason: Some(FinishReason::Stop),
-                    usage: None,
+                    finish_reason: Some(stream_finish_reason),
+                    usage: stream_usage
+                        .map(|(req, res)| serdes_ai_core::RequestUsage::with_tokens(req, res)),
                     vendor_id: None,
                     vendor_details: None,
                     kind: "response".to_string(),
@@ -1400,7 +1505,9 @@ mod tests {
     use super::*;
     use crate::builder::agent;
     use futures::{stream, StreamExt};
-    use serdes_ai_core::messages::{ModelRequestPart, TextPart, ToolCallPart};
+    use serdes_ai_core::messages::{
+        FinishReason, ModelRequestPart, StreamCompleteEvent, TextPart, ToolCallPart,
+    };
     use serdes_ai_models::FunctionModel;
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
@@ -1519,6 +1626,9 @@ mod tests {
                             ),
                         )),
                         Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::ToolCall),
+                        )),
                     ]
                 } else {
                     vec![
@@ -1527,6 +1637,9 @@ mod tests {
                             ModelResponsePart::Text(TextPart::new("done")),
                         )),
                         Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::Stop),
+                        )),
                     ]
                 };
 
@@ -1577,6 +1690,257 @@ mod tests {
         assert!(
             saw_tool_call,
             "expected at least one tool call in persisted RunComplete messages"
+        );
+    }
+
+    // ========================================================================
+    // Regression tests for issue #39: premature EOF must not produce
+    // successful OutputReady, committed history, fabricated Stop, or
+    // successful RunComplete.
+    //
+    // The Anthropic parser now emits `ModelError::IncompleteStream` on
+    // premature EOF. These agent tests verify that when the model stream
+    // produces such an error — after partial content — the agent does not
+    // emit success events or commit the response.
+    // ========================================================================
+
+    /// Helper: collect all events from a stream and check that no
+    /// `OutputReady`, `RunComplete`, or `ResponseComplete` event was emitted,
+    /// and that an error was produced.
+    async fn assert_stream_error_no_success(
+        model: FunctionModel,
+        use_cancel: bool,
+    ) -> Vec<AgentStreamEvent> {
+        let agentic = agent(model).build();
+
+        let mut stream = if use_cancel {
+            let token = CancellationToken::new();
+            AgentStream::new_with_cancel(&agentic, "Hello".into(), (), RunOptions::default(), token)
+                .await
+                .expect("stream should start")
+        } else {
+            agentic
+                .run_stream("Hello", ())
+                .await
+                .expect("stream should start")
+        };
+
+        let mut events = Vec::new();
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(event) => {
+                    assert!(
+                        !matches!(event, AgentStreamEvent::OutputReady),
+                        "must NOT emit OutputReady on stream error"
+                    );
+                    assert!(
+                        !matches!(event, AgentStreamEvent::RunComplete { .. }),
+                        "must NOT emit RunComplete on stream error"
+                    );
+                    assert!(
+                        !matches!(event, AgentStreamEvent::ResponseComplete { .. }),
+                        "must NOT emit ResponseComplete on stream error"
+                    );
+                    events.push(event);
+                }
+                Err(e) => {
+                    saw_error = true;
+                    events.push(AgentStreamEvent::Error {
+                        message: e.to_string(),
+                    });
+                }
+            }
+        }
+        assert!(saw_error, "expected an error event");
+        events
+    }
+
+    /// Test: stream error after partial text (simulating Anthropic
+    /// IncompleteStream) produces an error and no success events.
+    /// Non-cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_non_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("Partial response")),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended before message_stop was received",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, false).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(saw_text, "should have seen partial text");
+    }
+
+    /// Test: stream error after partial text — cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("Partial response")),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended before message_stop was received",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, true).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(saw_text, "should have seen partial text");
+    }
+
+    /// Test: empty stream (no parts at all) produces an error.
+    /// Non-cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_empty_stream_non_cancellable() {
+        let model =
+            FunctionModel::with_stream(|_messages, _settings| Box::pin(stream::iter(vec![])));
+
+        let events = assert_stream_error_no_success(model, false).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(!saw_text, "should NOT have seen any text from empty stream");
+    }
+
+    /// Test: stream error after incomplete tool call — must not execute
+    /// the tool or commit it.
+    #[tokio::test]
+    async fn test_premature_eof_incomplete_tool_call() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::ToolCall(
+                        ToolCallPart::new("search", serde_json::json!({}))
+                            .with_tool_call_id("call_1"),
+                    ),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended with open content block",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, false).await;
+
+        // Should NOT have seen ToolCallComplete
+        let saw_tool_complete = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolCallComplete { .. }));
+        assert!(
+            !saw_tool_complete,
+            "must NOT emit ToolCallComplete on incomplete tool call"
+        );
+
+        // Should NOT have seen ToolExecuted
+        let saw_tool_executed = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolExecuted { .. }));
+        assert!(!saw_tool_executed, "must NOT execute tool on premature EOF");
+    }
+
+    /// Test: a valid stream (PartStart + PartEnd + StreamComplete) produces
+    /// OutputReady and RunComplete. This verifies the happy path is not broken.
+    #[tokio::test]
+    async fn test_valid_stream_produces_success() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("Hello!")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+                Ok(ModelResponseStreamEvent::StreamComplete(
+                    StreamCompleteEvent::new(FinishReason::Stop),
+                )),
+            ]))
+        });
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("Hi", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_output_ready = false;
+        let mut saw_run_complete = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::OutputReady) => saw_output_ready = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(_) => {}
+                Err(e) => panic!("valid stream should not error: {:?}", e),
+            }
+        }
+        assert!(saw_output_ready, "valid stream should emit OutputReady");
+        assert!(saw_run_complete, "valid stream should emit RunComplete");
+    }
+
+    /// Test: premature EOF — empty stream, cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_empty_stream_cancellable() {
+        let model =
+            FunctionModel::with_stream(|_messages, _settings| Box::pin(stream::iter(vec![])));
+
+        let events = assert_stream_error_no_success(model, true).await;
+
+        let saw_text = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::TextDelta { .. }));
+        assert!(!saw_text, "should NOT have seen any text from empty stream");
+    }
+
+    /// Test: premature EOF — incomplete tool call, cancellable path.
+    #[tokio::test]
+    async fn test_premature_eof_incomplete_tool_call_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::ToolCall(
+                        ToolCallPart::new("search", serde_json::json!({}))
+                            .with_tool_call_id("call_1"),
+                    ),
+                )),
+                Err(serdes_ai_models::ModelError::incomplete_stream(
+                    "stream ended with open content block",
+                )),
+            ]))
+        });
+
+        let events = assert_stream_error_no_success(model, true).await;
+
+        let saw_tool_complete = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolCallComplete { .. }));
+        assert!(
+            !saw_tool_complete,
+            "must NOT emit ToolCallComplete on incomplete tool call (cancellable)"
+        );
+
+        let saw_tool_executed = events
+            .iter()
+            .any(|e| matches!(e, AgentStreamEvent::ToolExecuted { .. }));
+        assert!(
+            !saw_tool_executed,
+            "must NOT execute tool on premature EOF (cancellable)"
         );
     }
 }

--- a/serdes-ai-core/src/errors.rs
+++ b/serdes-ai-core/src/errors.rs
@@ -7,6 +7,141 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt;
 use std::time::Duration;
+/// Authoritative semantic category for a model-call failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelFailureKind {
+    /// The provider rate-limited the request.
+    RateLimited,
+    /// The provider is temporarily overloaded.
+    Overloaded,
+    /// The provider reported a transient server failure.
+    Server,
+    /// The request timed out.
+    Timeout,
+    /// The connection failed before a complete response was received.
+    Connection,
+    /// A streamed response ended before provider-level completion.
+    IncompleteStream,
+    /// Authentication failed.
+    Authentication,
+    /// The request was invalid.
+    InvalidRequest,
+    /// The requested resource was not found.
+    NotFound,
+    /// The caller lacks permission.
+    PermissionDenied,
+    /// The account cannot make the request for billing reasons.
+    Billing,
+    /// The request exceeded the provider's size limit.
+    RequestTooLarge,
+    /// The provider returned malformed or invalid response data.
+    InvalidResponse,
+    /// The operation was cancelled.
+    Cancelled,
+    /// Model or provider configuration is invalid.
+    Configuration,
+    /// An otherwise unclassified model-call failure.
+    Other,
+}
+
+impl ModelFailureKind {
+    /// Whether this category is rate limiting.
+    #[must_use]
+    pub fn is_rate_limited(self) -> bool {
+        matches!(self, Self::RateLimited)
+    }
+
+    /// Whether this category is transient, excluding rate limiting.
+    #[must_use]
+    pub fn is_transient(self) -> bool {
+        matches!(
+            self,
+            Self::Overloaded
+                | Self::Server
+                | Self::Timeout
+                | Self::Connection
+                | Self::IncompleteStream
+        )
+    }
+
+    /// Whether a same-model retry is safe by default.
+    #[must_use]
+    pub fn is_retryable(self) -> bool {
+        self.is_rate_limited() || self.is_transient()
+    }
+}
+
+/// Normalized metadata shared by direct model calls, retries, fallback, and agents.
+///
+/// Provider adapters should retain their concrete error as the Rust error source
+/// where possible and expose this value for policy decisions and diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelFailure {
+    /// Semantic failure category.
+    pub kind: ModelFailureKind,
+    /// Human-readable failure message.
+    pub message: String,
+    /// HTTP status, when present.
+    pub status: Option<u16>,
+    /// Provider-specific error code or type.
+    pub provider_code: Option<String>,
+    /// Provider-requested minimum retry delay.
+    pub retry_after: Option<Duration>,
+    /// Provider identifier, when known.
+    pub provider: Option<String>,
+    /// Model identifier, when known.
+    pub model: Option<String>,
+    /// One-based attempt number, when known.
+    pub attempt: Option<u32>,
+    /// String representation of the original cause for serializable diagnostics.
+    pub cause: Option<String>,
+}
+
+impl ModelFailure {
+    /// Create normalized failure metadata.
+    #[must_use]
+    pub fn new(kind: ModelFailureKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            status: None,
+            provider_code: None,
+            retry_after: None,
+            provider: None,
+            model: None,
+            attempt: None,
+            cause: None,
+        }
+    }
+
+    /// Whether this failure is retryable by the canonical policy.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        self.kind.is_retryable()
+    }
+
+    /// Add provider, model, and attempt context without changing classification.
+    #[must_use]
+    pub fn with_context(
+        mut self,
+        provider: Option<String>,
+        model: Option<String>,
+        attempt: Option<u32>,
+    ) -> Self {
+        self.provider = provider;
+        self.model = model;
+        self.attempt = attempt;
+        self
+    }
+}
+
+/// A model-call error that can expose the canonical cross-crate classification.
+pub trait ClassifyModelFailure {
+    /// Return normalized model-call failure metadata.
+    fn model_failure(&self) -> ModelFailure;
+}
+
 use thiserror::Error;
 
 /// The main error type for serdes-ai operations.
@@ -215,10 +350,11 @@ impl ModelApiError {
     /// Set headers.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = headers;
-        // Parse retry-after if present
-        if let Some(retry_after) = self.headers.get("retry-after") {
-            self.retry_after = retry_after.parse().ok();
-        }
+        self.retry_after = self
+            .headers
+            .iter()
+            .find(|(name, _)| name.eq_ignore_ascii_case("retry-after"))
+            .and_then(|(_, value)| value.parse().ok());
         self
     }
 
@@ -586,6 +722,55 @@ impl CallDeferred {
     pub fn with_tool_call_id(mut self, id: impl Into<String>) -> Self {
         self.tool_call_id = Some(id.into());
         self
+    }
+}
+impl ClassifyModelFailure for ModelApiError {
+    fn model_failure(&self) -> ModelFailure {
+        let kind = match self.status_code {
+            429 => ModelFailureKind::RateLimited,
+            500..=599 => ModelFailureKind::Server,
+            400 => ModelFailureKind::InvalidRequest,
+            401 => ModelFailureKind::Authentication,
+            403 => ModelFailureKind::PermissionDenied,
+            404 => ModelFailureKind::NotFound,
+            _ => ModelFailureKind::Other,
+        };
+        let mut failure = ModelFailure::new(
+            kind,
+            self.message.clone().unwrap_or_else(|| self.body.clone()),
+        );
+        failure.status = Some(self.status_code);
+        failure.provider_code = self.error_code.clone();
+        failure.retry_after = self.retry_after.map(Duration::from_secs);
+        failure.cause = Some(self.to_string());
+        failure
+    }
+}
+
+impl ClassifyModelFailure for ModelHttpError {
+    fn model_failure(&self) -> ModelFailure {
+        let (kind, status) = match self.kind {
+            HttpErrorKind::Timeout => (ModelFailureKind::Timeout, None),
+            HttpErrorKind::Connection => (ModelFailureKind::Connection, None),
+            HttpErrorKind::Request => (ModelFailureKind::InvalidRequest, None),
+            HttpErrorKind::Response { status } => {
+                let kind = match status {
+                    Some(429) => ModelFailureKind::RateLimited,
+                    Some(500..=599) => ModelFailureKind::Server,
+                    Some(400) => ModelFailureKind::InvalidRequest,
+                    Some(401) => ModelFailureKind::Authentication,
+                    Some(403) => ModelFailureKind::PermissionDenied,
+                    Some(404) => ModelFailureKind::NotFound,
+                    _ => ModelFailureKind::Other,
+                };
+                (kind, status)
+            }
+        };
+        let mut failure = ModelFailure::new(kind, self.message.clone());
+        failure.status = status;
+        failure.retry_after = self.retry_after;
+        failure.cause = Some(self.to_string());
+        failure
     }
 }
 

--- a/serdes-ai-core/src/lib.rs
+++ b/serdes-ai-core/src/lib.rs
@@ -58,7 +58,7 @@ pub mod settings;
 pub mod usage;
 
 // Re-exports for convenience
-pub use errors::{Result, SerdesAiError};
+pub use errors::{ClassifyModelFailure, ModelFailure, ModelFailureKind, Result, SerdesAiError};
 pub use format::{format_as_xml, format_as_xml_with_options, XmlFormatError, XmlFormatOptions};
 pub use identifier::{now_utc, ConversationId, RunId, ToolCallId};
 pub use messages::{

--- a/serdes-ai-core/src/messages/events.rs
+++ b/serdes-ai-core/src/messages/events.rs
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 use super::parts::{
     BuiltinToolCallPart, FilePart, TextPart, ThinkingPart, ToolCallArgs, ToolCallPart,
 };
-use super::response::ModelResponsePart;
+use super::response::{FinishReason, ModelResponsePart};
 
 /// Stream event for model responses.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -21,6 +21,13 @@ pub enum ModelResponseStreamEvent {
     PartDelta(PartDeltaEvent),
     /// A part has ended.
     PartEnd(PartEndEvent),
+    /// The stream completed successfully with provider terminal metadata.
+    ///
+    /// This event is emitted **only** when the provider has confirmed
+    /// successful completion (e.g. Anthropic `message_stop`).  It carries
+    /// the provider-reported finish reason and usage so consumers do not
+    /// need to infer them from stream exhaustion.
+    StreamComplete(StreamCompleteEvent),
 }
 
 impl ModelResponseStreamEvent {
@@ -102,6 +109,7 @@ impl ModelResponseStreamEvent {
             Self::PartStart(e) => e.index,
             Self::PartDelta(e) => e.index,
             Self::PartEnd(e) => e.index,
+            Self::StreamComplete(_) => 0,
         }
     }
 
@@ -121,6 +129,12 @@ impl ModelResponseStreamEvent {
     #[must_use]
     pub fn is_end(&self) -> bool {
         matches!(self, Self::PartEnd(_))
+    }
+
+    /// Check if this is a stream-complete (terminal) event.
+    #[must_use]
+    pub fn is_stream_complete(&self) -> bool {
+        matches!(self, Self::StreamComplete(_))
     }
 }
 
@@ -650,6 +664,45 @@ impl PartEndEvent {
     #[must_use]
     pub fn new(index: usize) -> Self {
         Self { index }
+    }
+}
+
+/// Event indicating the stream completed successfully with provider terminal metadata.
+///
+/// Only emitted when the provider confirms successful completion.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StreamCompleteEvent {
+    /// Provider-reported finish reason (mapped to [`FinishReason`]).
+    pub finish_reason: FinishReason,
+    /// Input tokens reported by the provider (if any).
+    pub input_tokens: Option<u64>,
+    /// Output tokens reported by the provider (if any).
+    pub output_tokens: Option<u64>,
+}
+
+impl StreamCompleteEvent {
+    /// Create a new stream-complete event.
+    #[must_use]
+    pub fn new(finish_reason: FinishReason) -> Self {
+        Self {
+            finish_reason,
+            input_tokens: None,
+            output_tokens: None,
+        }
+    }
+
+    /// Set input tokens.
+    #[must_use]
+    pub fn with_input_tokens(mut self, tokens: u64) -> Self {
+        self.input_tokens = Some(tokens);
+        self
+    }
+
+    /// Set output tokens.
+    #[must_use]
+    pub fn with_output_tokens(mut self, tokens: u64) -> Self {
+        self.output_tokens = Some(tokens);
+        self
     }
 }
 

--- a/serdes-ai-core/src/messages/events.rs
+++ b/serdes-ai-core/src/messages/events.rs
@@ -678,6 +678,12 @@ pub struct StreamCompleteEvent {
     pub input_tokens: Option<u64>,
     /// Output tokens reported by the provider (if any).
     pub output_tokens: Option<u64>,
+    /// Tokens used to create cache entries (if reported).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_creation_tokens: Option<u64>,
+    /// Tokens read from cache (if reported).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_read_tokens: Option<u64>,
 }
 
 impl StreamCompleteEvent {
@@ -688,6 +694,8 @@ impl StreamCompleteEvent {
             finish_reason,
             input_tokens: None,
             output_tokens: None,
+            cache_creation_tokens: None,
+            cache_read_tokens: None,
         }
     }
 
@@ -702,6 +710,20 @@ impl StreamCompleteEvent {
     #[must_use]
     pub fn with_output_tokens(mut self, tokens: u64) -> Self {
         self.output_tokens = Some(tokens);
+        self
+    }
+
+    /// Set cache creation tokens.
+    #[must_use]
+    pub fn with_cache_creation_tokens(mut self, tokens: u64) -> Self {
+        self.cache_creation_tokens = Some(tokens);
+        self
+    }
+
+    /// Set cache read tokens.
+    #[must_use]
+    pub fn with_cache_read_tokens(mut self, tokens: u64) -> Self {
+        self.cache_read_tokens = Some(tokens);
         self
     }
 }

--- a/serdes-ai-core/src/messages/mod.rs
+++ b/serdes-ai-core/src/messages/mod.rs
@@ -45,7 +45,8 @@ pub use content::{
 };
 pub use events::{
     BuiltinToolCallPartDelta, ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent,
-    PartEndEvent, PartStartEvent, TextPartDelta, ThinkingPartDelta, ToolCallPartDelta,
+    PartEndEvent, PartStartEvent, StreamCompleteEvent, TextPartDelta, ThinkingPartDelta,
+    ToolCallPartDelta,
 };
 pub use media::{AudioMediaType, DocumentMediaType, ImageMediaType, VideoMediaType};
 pub use parts::{

--- a/serdes-ai-models/Cargo.toml
+++ b/serdes-ai-models/Cargo.toml
@@ -37,6 +37,7 @@ serdes-ai-core = { workspace = true }
 serdes-ai-tools = { workspace = true }
 serdes-ai-output = { workspace = true }
 serdes-ai-retries = { workspace = true }
+serdes-ai-streaming = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/serdes-ai-models/Cargo.toml
+++ b/serdes-ai-models/Cargo.toml
@@ -36,6 +36,7 @@ antigravity = ["dep:uuid"]
 serdes-ai-core = { workspace = true }
 serdes-ai-tools = { workspace = true }
 serdes-ai-output = { workspace = true }
+serdes-ai-retries = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/serdes-ai-models/README.md
+++ b/serdes-ai-models/README.md
@@ -26,12 +26,24 @@ serdes-ai-models = "0.1"
 
 ## Usage
 
-```rust
-use serdes_ai_models::{OpenAIChatModel, Model};
+```rust,ignore
+use serdes_ai_models::{Model, ModelRetryExt, OpenAIChatModel, RetryPolicy};
+use std::time::Duration;
 
-let model = OpenAIChatModel::from_env("gpt-4o")?;
-let response = model.chat(messages, options).await?;
+let model = OpenAIChatModel::from_env("gpt-4o")?.with_retries(
+    RetryPolicy::for_model_requests()
+        .max_attempts(3)
+        .total_timeout(Some(Duration::from_secs(30))),
+);
+
+let response = model.request(&messages, &settings, &params).await?;
 ```
+
+Retries are opt-in. `RetryPolicy::disabled()` performs exactly one attempt. The
+policy retries the same model; `FallbackModel` remains responsible for selecting
+a different model. Streaming requests may be retried only while acquiring the
+stream and before the first caller-visible event. Once an event is returned, later
+stream errors pass through without replaying or concatenating another response.
 
 ## Part of SerdesAI
 

--- a/serdes-ai-models/README.md
+++ b/serdes-ai-models/README.md
@@ -41,6 +41,27 @@ let response = model.request(&messages, &settings, &params).await?;
 
 Retries are opt-in. `RetryPolicy::disabled()` performs exactly one attempt. The
 policy retries the same model; `FallbackModel` remains responsible for selecting
+## Model failure contract
+
+`serdes_ai_core::ModelFailure` is the authoritative, serializable classification
+used by direct model calls, same-model retries, fallback selection, and agent
+wrappers. It preserves the semantic kind, HTTP status, provider code,
+`Retry-After`, and available provider/model/attempt context. `ModelError` remains
+the concrete source-bearing error and implements `ClassifyModelFailure`.
+
+Migration guidance:
+
+- Use `ClassifyModelFailure::model_failure()` instead of matching retryability in
+  each crate.
+- `ProviderErrorKind` remains a compatibility alias for `ModelFailureKind`.
+- Core `ModelApiError` and `ModelHttpError` convert into `ModelError` while
+  remaining the source of the converted error.
+- `serdes-ai-providers::ProviderError` is limited to provider discovery and
+  configuration; model-call failures use `ModelError`.
+- `serdes-ai-retries::RetryableError` remains limited to the legacy standalone
+  HTTP retry client. Tool, user, cancellation, and output-validation failures
+  retain their distinct semantics.
+
 a different model. Streaming requests may be retried only while acquiring the
 stream and before the first caller-visible event. Once an event is returned, later
 stream errors pass through without replaying or concatenating another response.

--- a/serdes-ai-models/README.md
+++ b/serdes-ai-models/README.md
@@ -41,6 +41,18 @@ let response = model.request(&messages, &settings, &params).await?;
 
 Retries are opt-in. `RetryPolicy::disabled()` performs exactly one attempt. The
 policy retries the same model; `FallbackModel` remains responsible for selecting
+## Streaming fallback boundary
+
+`FallbackModel` can select another model for acquisition errors or retryable
+errors yielded before the first stream event. It polls and buffers at most one
+event while selecting an attempt. Every event counts as caller-visible exposure,
+including terminal/provider metadata. Once an event is returned, later errors
+are propagated from that model and fallback never replays or concatenates
+another model's output. Dropping the initial request future closes the current
+stream and prevents another fallback attempt.
+
+Same-model retries remain a separate opt-in layer through `RetryingModel`.
+
 ## Model failure contract
 
 `serdes_ai_core::ModelFailure` is the authoritative, serializable classification

--- a/serdes-ai-models/src/anthropic/error.rs
+++ b/serdes-ai-models/src/anthropic/error.rs
@@ -1,0 +1,98 @@
+//! Anthropic provider error classification.
+
+use crate::error::{ModelError, ProviderErrorKind};
+use std::time::Duration;
+
+/// Convert an Anthropic provider error into the canonical model error form.
+pub(super) fn map_anthropic_error(
+    code: impl Into<String>,
+    message: impl Into<String>,
+    retry_after: Option<Duration>,
+    http_status: Option<u16>,
+) -> ModelError {
+    let code = code.into();
+    let kind = match code.as_str() {
+        "rate_limit_error" => ProviderErrorKind::RateLimited,
+        "overloaded_error" => ProviderErrorKind::Overloaded,
+        "api_error" => ProviderErrorKind::Server,
+        "authentication_error" => ProviderErrorKind::Authentication,
+        "invalid_request_error" => ProviderErrorKind::InvalidRequest,
+        "not_found_error" => ProviderErrorKind::NotFound,
+        "permission_error" => ProviderErrorKind::PermissionDenied,
+        "billing_error" => ProviderErrorKind::Billing,
+        "request_too_large" => ProviderErrorKind::RequestTooLarge,
+        _ if http_status == Some(429) => ProviderErrorKind::RateLimited,
+        _ if http_status.is_some_and(|status| status >= 500) => ProviderErrorKind::Server,
+        _ => ProviderErrorKind::Other,
+    };
+
+    ModelError::provider("anthropic", code, message, kind, retry_after)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_retryable_errors() {
+        let rate_limit = map_anthropic_error(
+            "rate_limit_error",
+            "slow down",
+            Some(Duration::from_secs(12)),
+            Some(429),
+        );
+        assert!(rate_limit.is_rate_limited());
+        assert!(rate_limit.is_retryable());
+        assert_eq!(rate_limit.retry_after(), Some(Duration::from_secs(12)));
+
+        let overloaded = map_anthropic_error("overloaded_error", "try again", None, Some(529));
+        assert!(overloaded.is_transient());
+        assert!(overloaded.is_retryable());
+    }
+
+    #[test]
+    fn classifies_permanent_errors() {
+        for code in ["authentication_error", "invalid_request_error"] {
+            let error = map_anthropic_error(code, "permanent", None, Some(400));
+            assert!(!error.is_retryable(), "{code} must not be retryable");
+        }
+    }
+
+    #[test]
+    fn preserves_provider_metadata() {
+        let error = map_anthropic_error("overloaded_error", "capacity exhausted", None, None);
+
+        match error {
+            ModelError::Provider {
+                provider,
+                code,
+                message,
+                kind,
+                retry_after,
+            } => {
+                assert_eq!(provider, "anthropic");
+                assert_eq!(code, "overloaded_error");
+                assert_eq!(message, "capacity exhausted");
+                assert_eq!(kind, ProviderErrorKind::Overloaded);
+                assert_eq!(retry_after, None);
+            }
+            other => panic!("expected provider error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn transport_does_not_change_known_provider_semantics() {
+        for code in [
+            "rate_limit_error",
+            "overloaded_error",
+            "authentication_error",
+            "invalid_request_error",
+        ] {
+            let http = map_anthropic_error(code, "message", None, Some(500));
+            let sse = map_anthropic_error(code, "message", None, None);
+            assert_eq!(http.is_retryable(), sse.is_retryable(), "{code}");
+            assert_eq!(http.is_rate_limited(), sse.is_rate_limited(), "{code}");
+            assert_eq!(http.is_transient(), sse.is_transient(), "{code}");
+        }
+    }
+}

--- a/serdes-ai-models/src/anthropic/error.rs
+++ b/serdes-ai-models/src/anthropic/error.rs
@@ -26,7 +26,7 @@ pub(super) fn map_anthropic_error(
         _ => ProviderErrorKind::Other,
     };
 
-    ModelError::provider("anthropic", code, message, kind, retry_after)
+    ModelError::provider_with_status("anthropic", code, message, kind, http_status, retry_after)
 }
 
 #[cfg(test)]
@@ -44,6 +44,13 @@ mod tests {
         assert!(rate_limit.is_rate_limited());
         assert!(rate_limit.is_retryable());
         assert_eq!(rate_limit.retry_after(), Some(Duration::from_secs(12)));
+        assert!(matches!(
+            rate_limit,
+            ModelError::Provider {
+                status: Some(429),
+                ..
+            }
+        ));
 
         let overloaded = map_anthropic_error("overloaded_error", "try again", None, Some(529));
         assert!(overloaded.is_transient());
@@ -68,12 +75,14 @@ mod tests {
                 code,
                 message,
                 kind,
+                status,
                 retry_after,
             } => {
                 assert_eq!(provider, "anthropic");
                 assert_eq!(code, "overloaded_error");
                 assert_eq!(message, "capacity exhausted");
                 assert_eq!(kind, ProviderErrorKind::Overloaded);
+                assert_eq!(status, None);
                 assert_eq!(retry_after, None);
             }
             other => panic!("expected provider error, got {other:?}"),

--- a/serdes-ai-models/src/anthropic/mod.rs
+++ b/serdes-ai-models/src/anthropic/mod.rs
@@ -32,6 +32,7 @@
 //! let response = model.request(&messages, &settings, &params).await?;
 //! ```
 
+mod error;
 pub mod model;
 pub mod stream;
 pub mod types;

--- a/serdes-ai-models/src/anthropic/model.rs
+++ b/serdes-ai-models/src/anthropic/model.rs
@@ -705,6 +705,68 @@ mod tests {
         assert!(!auth.is_retryable());
     }
 
+    #[tokio::test]
+    async fn retrying_model_retries_concrete_anthropic_transport() {
+        use crate::{RetryPolicy, RetryingModel, WaitStrategy};
+        use std::sync::atomic::{AtomicU32, Ordering};
+        use std::sync::Arc;
+        use wiremock::{Request, Respond, ResponseTemplate};
+
+        #[derive(Clone)]
+        struct RateLimitThenSuccess {
+            calls: Arc<AtomicU32>,
+        }
+
+        impl Respond for RateLimitThenSuccess {
+            fn respond(&self, _request: &Request) -> ResponseTemplate {
+                if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    ResponseTemplate::new(429)
+                        .insert_header("retry-after", "0")
+                        .set_body_raw(
+                            r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#,
+                            "application/json",
+                        )
+                } else {
+                    ResponseTemplate::new(200).set_body_raw(
+                        r#"{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-test","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}"#,
+                        "application/json",
+                    )
+                }
+            }
+        }
+
+        let server = wiremock::MockServer::start().await;
+        let calls = Arc::new(AtomicU32::new(0));
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/v1/messages"))
+            .respond_with(RateLimitThenSuccess {
+                calls: calls.clone(),
+            })
+            .mount(&server)
+            .await;
+
+        let inner = AnthropicModel::new("claude-test", "key").with_base_url(server.uri());
+        let model = RetryingModel::new(
+            inner,
+            RetryPolicy::for_model_requests()
+                .max_attempts(2)
+                .wait(WaitStrategy::None)
+                .total_timeout(Some(Duration::from_secs(5))),
+        );
+
+        let response = model
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.parts.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
     #[test]
     fn test_anthropic_model_new() {
         let model = AnthropicModel::new("claude-3-5-sonnet-20241022", "sk-test-key");

--- a/serdes-ai-models/src/anthropic/model.rs
+++ b/serdes-ai-models/src/anthropic/model.rs
@@ -1,5 +1,6 @@
 //! Anthropic Claude model implementation.
 
+use super::error::map_anthropic_error;
 use super::stream::AnthropicStreamParser;
 use super::types::*;
 use crate::error::ModelError;
@@ -551,32 +552,19 @@ impl AnthropicModel {
 
     /// Handle API error response.
     fn handle_error_response(&self, status: u16, body: &str, headers: &HeaderMap) -> ModelError {
+        let retry_after = Self::parse_retry_after(headers);
+
         if let Ok(err) = serde_json::from_str::<AnthropicError>(body) {
-            let code = err.error.error_type.clone();
-
-            match status {
-                401 => return ModelError::auth(err.error.message),
-                429 => return ModelError::rate_limited(Self::parse_retry_after(headers)),
-                404 => return ModelError::NotFound(err.error.message),
-                400 => {
-                    if code == "invalid_request_error" {
-                        return ModelError::Api {
-                            message: err.error.message,
-                            code: Some(code),
-                        };
-                    }
-                }
-                _ => {}
-            }
-
-            return ModelError::Api {
-                message: err.error.message,
-                code: Some(code),
-            };
+            return map_anthropic_error(
+                err.error.error_type,
+                err.error.message,
+                retry_after,
+                Some(status),
+            );
         }
 
         if status == 429 {
-            return ModelError::rate_limited(Self::parse_retry_after(headers));
+            return ModelError::rate_limited(retry_after);
         }
 
         ModelError::http(status, body)
@@ -687,6 +675,35 @@ impl Model for AnthropicModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_handle_error_response_uses_provider_semantics() {
+        let model = AnthropicModel::new("claude-3-5-sonnet-20241022", "key");
+        let mut headers = HeaderMap::new();
+        headers.insert("retry-after", "7".parse().unwrap());
+
+        let rate_limit = model.handle_error_response(
+            429,
+            r#"{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}"#,
+            &headers,
+        );
+        assert!(rate_limit.is_rate_limited());
+        assert_eq!(rate_limit.retry_after(), Some(Duration::from_secs(7)));
+
+        let overloaded = model.handle_error_response(
+            529,
+            r#"{"type":"error","error":{"type":"overloaded_error","message":"busy"}}"#,
+            &HeaderMap::new(),
+        );
+        assert!(overloaded.is_transient());
+
+        let auth = model.handle_error_response(
+            401,
+            r#"{"type":"error","error":{"type":"authentication_error","message":"bad key"}}"#,
+            &HeaderMap::new(),
+        );
+        assert!(!auth.is_retryable());
+    }
 
     #[test]
     fn test_anthropic_model_new() {

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides streaming support for Anthropic's Messages API.
 
+use super::error::map_anthropic_error;
 use super::types::{ContentBlockDelta, ContentBlockStart, StreamEvent};
 use crate::error::ModelError;
 use bytes::Bytes;
@@ -537,9 +538,11 @@ fn process_event(
 
         StreamEvent::Ping => None,
 
-        StreamEvent::Error { error } => Some(Err(ModelError::api_with_code(
-            error.message,
+        StreamEvent::Error { error } => Some(Err(map_anthropic_error(
             error.error_type,
+            error.message,
+            None,
+            None,
         ))),
     }
 }
@@ -689,18 +692,48 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_parse_error() {
+    async fn parse_stream_error(code: &str, message: &str) -> ModelError {
         let error =
-            r#"{"type":"error","error":{"type":"rate_limit_error","message":"Rate limited"}}"#;
-        let bytes = vec![Ok(make_sse_bytes("error", error))];
-        let stream = stream::iter(bytes);
+            format!(r#"{{"type":"error","error":{{"type":"{code}","message":"{message}"}}}}"#);
+        let stream = stream::iter(vec![Ok(make_sse_bytes("error", &error))]);
         let mut parser = AnthropicStreamParser::new(stream);
+        parser.next().await.unwrap().unwrap_err()
+    }
 
-        let event = parser.next().await.unwrap();
-        assert!(event.is_err());
-        let err = event.unwrap_err();
-        assert!(err.to_string().contains("Rate limited"));
+    #[tokio::test]
+    async fn test_parse_rate_limit_error() {
+        let err = parse_stream_error("rate_limit_error", "Rate limited").await;
+
+        assert!(err.is_rate_limited());
+        assert!(err.is_retryable());
+        match err {
+            ModelError::Provider {
+                code,
+                message,
+                kind,
+                ..
+            } => {
+                assert_eq!(code, "rate_limit_error");
+                assert_eq!(message, "Rate limited");
+                assert_eq!(kind, crate::ProviderErrorKind::RateLimited);
+            }
+            other => panic!("expected provider error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_parse_overloaded_error() {
+        let err = parse_stream_error("overloaded_error", "Overloaded").await;
+        assert!(err.is_transient());
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn test_parse_permanent_errors() {
+        for code in ["authentication_error", "invalid_request_error"] {
+            let err = parse_stream_error(code, "Permanent").await;
+            assert!(!err.is_retryable(), "{code} must not be retryable");
+        }
     }
 
     #[tokio::test]

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -8,8 +8,8 @@ use bytes::Bytes;
 use futures::Stream;
 use pin_project_lite::pin_project;
 use serdes_ai_core::messages::{
-    ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
-    TextPart, ThinkingPart, ThinkingPartDelta, ToolCallPart,
+    FinishReason, ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent,
+    PartStartEvent, StreamCompleteEvent, TextPart, ThinkingPart, ThinkingPartDelta, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
 use std::collections::HashMap;
@@ -32,6 +32,10 @@ pin_project! {
         output_tokens: u64,
         cache_creation_tokens: Option<u64>,
         cache_read_tokens: Option<u64>,
+        // Provider-reported stop reason from message_delta
+        stop_reason: Option<String>,
+        // Whether message_stop was observed
+        message_stop_seen: bool,
         // Finished
         done: bool,
     }
@@ -77,8 +81,33 @@ where
             output_tokens: 0,
             cache_creation_tokens: None,
             cache_read_tokens: None,
+            stop_reason: None,
+            message_stop_seen: false,
             done: false,
         }
+    }
+
+    /// The provider-reported stop reason (from `message_delta`), if any.
+    ///
+    /// This is only reliable after the stream has completed successfully
+    /// (i.e. `message_stop` was observed).
+    pub fn stop_reason(&self) -> Option<&str> {
+        self.stop_reason.as_deref()
+    }
+
+    /// Whether `message_stop` was observed before the stream ended.
+    pub fn message_stop_seen(&self) -> bool {
+        self.message_stop_seen
+    }
+
+    /// Input tokens reported by the provider.
+    pub fn input_tokens(&self) -> u64 {
+        self.input_tokens
+    }
+
+    /// Output tokens reported by the provider.
+    pub fn output_tokens(&self) -> u64 {
+        self.output_tokens
     }
 }
 
@@ -91,6 +120,7 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
+        // After StreamComplete has been emitted the stream is done.
         if *this.done {
             return Poll::Ready(None);
         }
@@ -111,15 +141,30 @@ where
                             this.output_tokens,
                             this.cache_creation_tokens,
                             this.cache_read_tokens,
+                            this.stop_reason,
+                            this.message_stop_seen,
                             this.done,
                         ) {
+                            // If the result is StreamComplete, mark done so the
+                            // next poll returns None without re-checking EOF.
+                            if let Ok(ModelResponseStreamEvent::StreamComplete(_)) = &result {
+                                *this.done = true;
+                            }
                             return Poll::Ready(Some(result));
                         }
                     }
                     Err(e) => {
+                        *this.done = true;
                         return Poll::Ready(Some(Err(e)));
                     }
                 }
+            }
+
+            // If message_stop was already seen and all buffered events consumed,
+            // we should not poll the inner stream further — just end.
+            if *this.message_stop_seen {
+                *this.done = true;
+                return Poll::Ready(None);
             }
 
             // Need more data
@@ -130,9 +175,20 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
+                    // Inner stream reached EOF. If we haven't seen message_stop,
+                    // this is a premature EOF — emit a typed error.
+                    if !*this.message_stop_seen {
+                        *this.done = true;
+                        return Poll::Ready(Some(Err(ModelError::incomplete_stream(
+                            "stream ended before message_stop was received",
+                        ))));
+                    }
+                    // message_stop was seen but done wasn't set (shouldn't happen
+                    // since StreamComplete sets done, but guard anyway).
                     *this.done = true;
                     return Poll::Ready(None);
                 }
@@ -194,14 +250,18 @@ fn process_event(
     output_tokens: &mut u64,
     cache_creation_tokens: &mut Option<u64>,
     cache_read_tokens: &mut Option<u64>,
+    stop_reason: &mut Option<String>,
+    message_stop_seen: &mut bool,
     done: &mut bool,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
-    // Parse the JSON data
+    // Parse the JSON data — reject malformed events rather than silently dropping them
     let event: StreamEvent = match serde_json::from_str(data) {
         Ok(e) => e,
         Err(e) => {
-            tracing::warn!("Failed to parse stream event: {} - data: {}", e, data);
-            return None;
+            return Some(Err(ModelError::invalid_response(format!(
+                "Failed to parse stream event: {} - data: {}",
+                e, data
+            ))));
         }
     };
 
@@ -271,7 +331,14 @@ fn process_event(
                 }
                 ContentBlockDelta::InputJsonDelta { partial_json } => {
                     if let BlockState::ToolUse { input_json, .. } = state {
-                        input_json.push_str(&partial_json);
+                        // If the accumulated JSON is still just the initial empty
+                        // object, replace it with the first real delta.
+                        if input_json == "{}" {
+                            input_json.clear();
+                            input_json.push_str(&partial_json);
+                        } else {
+                            input_json.push_str(&partial_json);
+                        }
                     }
                     Some(Ok(ModelResponseStreamEvent::PartDelta(
                         PartDeltaEvent::tool_call_args(index, partial_json),
@@ -304,23 +371,58 @@ fn process_event(
         }
 
         StreamEvent::ContentBlockStop { index } => {
+            // Validate tool input JSON before accepting the block as complete.
+            // Skip validation when the input is the default empty object (no
+            // deltas were received).
+            if let Some(BlockState::ToolUse { input_json, .. }) = blocks.get(&index) {
+                if !input_json.is_empty() && input_json != "{}" {
+                    if serde_json::from_str::<serde_json::Value>(input_json).is_err() {
+                        return Some(Err(ModelError::invalid_response(format!(
+                            "content_block_stop for tool at index {} has incomplete JSON input: {}",
+                            index, input_json
+                        ))));
+                    }
+                }
+            }
             blocks.remove(&index);
             Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
                 index,
             })))
         }
 
-        StreamEvent::MessageDelta { delta: _, usage } => {
+        StreamEvent::MessageDelta { delta, usage } => {
+            if let Some(reason) = &delta.stop_reason {
+                *stop_reason = Some(reason.clone());
+            }
             if let Some(u) = usage {
                 *output_tokens = u.output_tokens;
             }
-            // We don't emit finish reason as event since core doesn't have it
             None
         }
 
         StreamEvent::MessageStop => {
-            *done = true;
-            None
+            // Atomically validate terminal state before accepting message_stop.
+            if !blocks.is_empty() {
+                let open_indices: Vec<usize> = blocks.keys().copied().collect();
+                *done = true;
+                return Some(Err(ModelError::incomplete_stream(format!(
+                    "message_stop received with open content block(s) at index/indices: {:?}",
+                    open_indices
+                ))));
+            }
+
+            *message_stop_seen = true;
+
+            // Map the Anthropic stop reason to FinishReason
+            let finish_reason = map_stop_reason(stop_reason.as_deref());
+
+            // Emit StreamComplete with provider terminal metadata
+            let mut event = StreamCompleteEvent::new(finish_reason);
+            event = event
+                .with_input_tokens(*input_tokens)
+                .with_output_tokens(*output_tokens);
+
+            Some(Ok(ModelResponseStreamEvent::StreamComplete(event)))
         }
 
         StreamEvent::Ping => None,
@@ -329,6 +431,17 @@ fn process_event(
             error.message,
             error.error_type,
         ))),
+    }
+}
+
+/// Map an Anthropic stop reason string to a [`FinishReason`].
+fn map_stop_reason(reason: Option<&str>) -> FinishReason {
+    match reason {
+        Some("end_turn") => FinishReason::EndTurn,
+        Some("stop_sequence") => FinishReason::StopSequence,
+        Some("max_tokens") => FinishReason::Length,
+        Some("tool_use") => FinishReason::ToolCall,
+        _ => FinishReason::Stop,
     }
 }
 
@@ -345,13 +458,26 @@ mod tests {
     #[tokio::test]
     async fn test_parse_message_start() {
         let data = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
-        let bytes = vec![Ok(make_sse_bytes("message_start", data))];
+        let msg_stop = r#"{"type":"message_stop"}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", data)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
         let stream = stream::iter(bytes);
         let mut parser = AnthropicStreamParser::new(stream);
 
-        // Message start doesn't emit an event
+        // Message start emits nothing; message_stop emits StreamComplete
         let event = parser.next().await;
-        assert!(event.is_none());
+        assert!(event.is_some());
+        assert!(
+            matches!(
+                event.unwrap().unwrap(),
+                ModelResponseStreamEvent::StreamComplete(_)
+            ),
+            "expected StreamComplete"
+        );
+        // Next poll should be None (done)
+        assert!(parser.next().await.is_none());
     }
 
     #[tokio::test]
@@ -361,12 +487,16 @@ mod tests {
             r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
         let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
         let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
 
         let bytes = vec![
             Ok(make_sse_bytes("message_start", msg_start)),
             Ok(make_sse_bytes("content_block_start", block_start)),
             Ok(make_sse_bytes("content_block_delta", delta)),
             Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_delta", msg_delta)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
         ];
 
         let stream = stream::iter(bytes);
@@ -378,8 +508,8 @@ mod tests {
             events.push(result.unwrap());
         }
 
-        // Should have: PartStart, PartDelta, PartEnd
-        assert_eq!(events.len(), 3, "Expected 3 events, got {:?}", events);
+        // Should have: PartStart, PartDelta, PartEnd, StreamComplete
+        assert_eq!(events.len(), 4, "Expected 4 events, got {:?}", events);
 
         assert!(
             matches!(&events[0], ModelResponseStreamEvent::PartStart(_)),
@@ -393,6 +523,15 @@ mod tests {
             matches!(&events[2], ModelResponseStreamEvent::PartEnd(_)),
             "Third should be PartEnd"
         );
+        assert!(
+            matches!(&events[3], ModelResponseStreamEvent::StreamComplete(_)),
+            "Fourth should be StreamComplete"
+        );
+
+        // Provider terminal metadata should survive
+        assert_eq!(parser.stop_reason(), Some("end_turn"));
+        assert!(parser.message_stop_seen());
+        assert_eq!(parser.output_tokens(), 5);
     }
 
     #[tokio::test]
@@ -402,6 +541,7 @@ mod tests {
         let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"q\":"}}"#;
         let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"rust\"}"}}"#;
         let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
 
         let bytes = vec![
             Ok(make_sse_bytes("message_start", msg_start)),
@@ -409,6 +549,7 @@ mod tests {
             Ok(make_sse_bytes("content_block_delta", delta1)),
             Ok(make_sse_bytes("content_block_delta", delta2)),
             Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
         ];
 
         let stream = stream::iter(bytes);
@@ -419,8 +560,8 @@ mod tests {
             events.push(result.unwrap());
         }
 
-        // Should have: PartStart, PartDelta, PartDelta, PartEnd
-        assert_eq!(events.len(), 4, "Expected 4 events, got {:?}", events);
+        // Should have: PartStart, PartDelta, PartDelta, PartEnd, StreamComplete
+        assert_eq!(events.len(), 5, "Expected 5 events, got {:?}", events);
 
         // First should be PartStart with tool_use
         if let ModelResponseStreamEvent::PartStart(start) = &events[0] {
@@ -431,6 +572,11 @@ mod tests {
         } else {
             panic!("Expected PartStart");
         }
+        // Last should be StreamComplete
+        assert!(
+            matches!(&events[4], ModelResponseStreamEvent::StreamComplete(_)),
+            "Last should be StreamComplete"
+        );
     }
 
     #[tokio::test]
@@ -450,12 +596,351 @@ mod tests {
     #[tokio::test]
     async fn test_parse_ping() {
         let ping = r#"{"type":"ping"}"#;
-        let bytes = vec![Ok(make_sse_bytes("ping", ping))];
+        let msg_stop = r#"{"type":"message_stop"}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes("ping", ping)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
         let stream = stream::iter(bytes);
         let mut parser = AnthropicStreamParser::new(stream);
 
-        // Ping shouldn't emit an event
+        // Ping emits nothing; message_stop emits StreamComplete
         let event = parser.next().await;
-        assert!(event.is_none());
+        assert!(event.is_some());
+        assert!(
+            matches!(
+                event.unwrap().unwrap(),
+                ModelResponseStreamEvent::StreamComplete(_)
+            ),
+            "expected StreamComplete"
+        );
+        // Done
+        assert!(parser.next().await.is_none());
+    }
+
+    // ========================================================================
+    // Regression tests for issue #39: premature EOF must not be treated as
+    // successful completion.
+    // ========================================================================
+
+    /// Helper: build a partial (incomplete) SSE frame as bytes.
+    fn make_partial_sse_bytes(event_type: &str, partial_data: &str) -> Bytes {
+        // Intentionally missing the trailing blank line so the frame is incomplete
+        Bytes::from(format!(
+            "event: {}
+data: {}",
+            event_type, partial_data
+        ))
+    }
+
+    /// Test 1: EOF before any `message_stop`.
+    #[tokio::test]
+    async fn test_eof_before_message_stop() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta =
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            // NO message_delta, NO message_stop — stream just ends
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(had_error, "expected an IncompleteStream error");
+        assert!(!parser.message_stop_seen());
+    }
+
+    /// Test 2: EOF with a partial final SSE record in the buffer.
+    #[tokio::test]
+    async fn test_eof_with_partial_sse_frame() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta =
+            r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            // A partial frame that will never be completed — inner stream ends
+            Ok(make_partial_sse_bytes(
+                "message_delta",
+                r#"{"type":"message_delta","#,
+            )),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for partial frame, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for partial SSE frame"
+        );
+    }
+
+    /// Test 3: EOF with an open text block.
+    #[tokio::test]
+    async fn test_eof_with_open_text_block() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        // NO content_block_stop, NO message_stop
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for open text block, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for open text block"
+        );
+    }
+
+    /// Test 4: EOF with an open thinking block.
+    #[tokio::test]
+    async fn test_eof_with_open_thinking_block() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start = r#"{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Hmm"}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for open thinking block, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for open thinking block"
+        );
+    }
+
+    /// Test 5: EOF with an open tool-use block (incomplete tool JSON).
+    #[tokio::test]
+    async fn test_eof_with_open_tool_use_block() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start = r#"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tool_1","name":"search","input":{}}}"#;
+        let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"q\":"}}"#;
+        // Second delta makes the JSON incomplete (missing closing brace)
+        let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"rust\""}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta1)),
+            Ok(make_sse_bytes("content_block_delta", delta2)),
+            // NO content_block_stop, NO message_stop
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream for open tool block, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(
+            had_error,
+            "expected IncompleteStream error for open tool-use block"
+        );
+    }
+
+    /// Test 6: `content_block_stop` followed by EOF without `message_stop`.
+    #[tokio::test]
+    async fn test_content_block_stop_then_eof_without_message_stop() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            // block is closed but no message_stop
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut had_error = false;
+        while let Some(result) = parser.next().await {
+            if let Err(ref e) = result {
+                assert!(
+                    matches!(e, ModelError::IncompleteStream(_)),
+                    "expected IncompleteStream without message_stop, got: {:?}",
+                    e
+                );
+                had_error = true;
+            }
+        }
+        assert!(had_error, "expected IncompleteStream error");
+        assert!(!parser.message_stop_seen());
+    }
+
+    /// Test 7: A valid sequence ending in `message_stop` produces no error.
+    #[tokio::test]
+    async fn test_valid_stream_with_message_stop() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_delta", msg_delta)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut saw_stream_complete = false;
+        while let Some(result) = parser.next().await {
+            match result {
+                Ok(ModelResponseStreamEvent::StreamComplete(sc)) => {
+                    saw_stream_complete = true;
+                    assert_eq!(sc.finish_reason, FinishReason::EndTurn);
+                    assert_eq!(sc.input_tokens, Some(10));
+                    assert_eq!(sc.output_tokens, Some(5));
+                }
+                Ok(_) => {}
+                Err(e) => panic!("valid stream should not produce error: {:?}", e),
+            }
+        }
+        assert!(
+            saw_stream_complete,
+            "valid stream should emit StreamComplete"
+        );
+        assert!(parser.message_stop_seen());
+        assert_eq!(parser.stop_reason(), Some("end_turn"));
+        assert_eq!(parser.output_tokens(), 5);
+        assert_eq!(parser.input_tokens(), 10);
+    }
+
+    /// Test 8: Premature EOF after visible text produces an error and no
+    /// further successful events.
+    #[tokio::test]
+    async fn test_premature_eof_after_text_produces_error() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta1)),
+            Ok(make_sse_bytes("content_block_delta", delta2)),
+            // Stream ends here — open text block, no message_stop
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let mut text_deltas_seen = 0;
+        let mut error_seen = false;
+        while let Some(result) = parser.next().await {
+            match result {
+                Ok(ModelResponseStreamEvent::PartDelta(PartDeltaEvent {
+                    delta: ModelResponsePartDelta::Text(_),
+                    ..
+                })) => {
+                    text_deltas_seen += 1;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    assert!(
+                        matches!(e, ModelError::IncompleteStream(_)),
+                        "expected IncompleteStream, got: {:?}",
+                        e
+                    );
+                    error_seen = true;
+                }
+            }
+        }
+        assert!(text_deltas_seen >= 2, "should have seen text deltas");
+        assert!(error_seen, "must see IncompleteStream error");
+        assert!(!parser.message_stop_seen());
     }
 }

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -385,10 +385,15 @@ fn process_event(
             let finish_reason = map_stop_reason(stop_reason.as_deref());
 
             // Emit StreamComplete with provider terminal metadata
-            let mut event = StreamCompleteEvent::new(finish_reason);
-            event = event
+            let mut event = StreamCompleteEvent::new(finish_reason)
                 .with_input_tokens(*input_tokens)
                 .with_output_tokens(*output_tokens);
+            if let Some(tokens) = *cache_creation_tokens {
+                event = event.with_cache_creation_tokens(tokens);
+            }
+            if let Some(tokens) = *cache_read_tokens {
+                event = event.with_cache_read_tokens(tokens);
+            }
 
             Some(Ok(ModelResponseStreamEvent::StreamComplete(event)))
         }
@@ -854,7 +859,7 @@ data: {}",
     /// Test 7: A valid sequence ending in `message_stop` produces no error.
     #[tokio::test]
     async fn test_valid_stream_with_message_stop() {
-        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":3,"cache_read_input_tokens":7}}}"#;
         let block_start =
             r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
         let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
@@ -882,6 +887,8 @@ data: {}",
                     assert_eq!(sc.finish_reason, FinishReason::EndTurn);
                     assert_eq!(sc.input_tokens, Some(10));
                     assert_eq!(sc.output_tokens, Some(5));
+                    assert_eq!(sc.cache_creation_tokens, Some(3));
+                    assert_eq!(sc.cache_read_tokens, Some(7));
                 }
                 Ok(_) => {}
                 Err(e) => panic!("valid stream should not produce error: {:?}", e),

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -21,7 +21,7 @@ pin_project! {
     pub struct AnthropicStreamParser<S> {
         #[pin]
         inner: S,
-        buffer: String,
+        buffer: Vec<u8>,
         // Track content blocks in progress
         blocks: HashMap<usize, BlockState>,
         // Message metadata
@@ -73,7 +73,7 @@ where
     pub fn new(inner: S) -> Self {
         Self {
             inner,
-            buffer: String::new(),
+            buffer: Vec::new(),
             blocks: HashMap::new(),
             message_id: None,
             model: None,
@@ -126,9 +126,19 @@ where
         }
 
         loop {
-            // Check if we have complete events in the buffer
-            // Anthropic uses "event: type\ndata: json\n\n" format
-            while let Some(event_result) = parse_next_event(this.buffer) {
+            // Check for irrecoverably invalid UTF-8 in the buffer before
+            // attempting to parse events. Incomplete multibyte sequences at
+            // the tail are held until the next chunk arrives.
+            if let Err(e) = decode_utf8_prefix(&this.buffer) {
+                *this.done = true;
+                return Poll::Ready(Some(Err(ModelError::invalid_response(format!(
+                    "invalid UTF-8 in stream data: {}",
+                    e
+                )))));
+            }
+
+            // Process complete SSE events from the byte buffer.
+            while let Some(event_result) = parse_next_event(&mut this.buffer) {
                 match event_result {
                     Ok((event_type, data)) => {
                         if let Some(result) = process_event(
@@ -145,9 +155,12 @@ where
                             this.message_stop_seen,
                             this.done,
                         ) {
-                            // If the result is StreamComplete, mark done so the
-                            // next poll returns None without re-checking EOF.
-                            if let Ok(ModelResponseStreamEvent::StreamComplete(_)) = &result {
+                            if result.is_err()
+                                || matches!(
+                                    result,
+                                    Ok(ModelResponseStreamEvent::StreamComplete(_))
+                                )
+                            {
                                 *this.done = true;
                             }
                             return Poll::Ready(Some(result));
@@ -170,26 +183,35 @@ where
             // Need more data
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        this.buffer.push_str(text);
-                    }
+                    this.buffer.extend_from_slice(&bytes);
                 }
                 Poll::Ready(Some(Err(e))) => {
                     *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
-                    // Inner stream reached EOF. If we haven't seen message_stop,
-                    // this is a premature EOF — emit a typed error.
+                    *this.done = true;
+
+                    if let Err(e) = std::str::from_utf8(&this.buffer) {
+                        return Poll::Ready(Some(Err(ModelError::invalid_response(format!(
+                            "stream ended with incomplete or invalid UTF-8 in buffer: {}",
+                            e
+                        )))));
+                    }
+
+                    if !this.buffer.is_empty() {
+                        return Poll::Ready(Some(Err(ModelError::invalid_response(format!(
+                            "stream ended with {} bytes of unparsed SSE data remaining in buffer",
+                            this.buffer.len()
+                        )))));
+                    }
+
                     if !*this.message_stop_seen {
-                        *this.done = true;
                         return Poll::Ready(Some(Err(ModelError::incomplete_stream(
                             "stream ended before message_stop was received",
                         ))));
                     }
-                    // message_stop was seen but done wasn't set (shouldn't happen
-                    // since StreamComplete sets done, but guard anyway).
-                    *this.done = true;
+
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -198,43 +220,134 @@ where
     }
 }
 
-/// Parse the next complete event from the buffer.
-/// Returns Some((event_type, data)) if a complete event was found.
-fn parse_next_event(buffer: &mut String) -> Option<Result<(String, String), ModelError>> {
-    // Look for event: and data: lines followed by blank line
+/// Decode the longest valid UTF-8 prefix from the byte buffer.
+/// Returns `Ok` if the buffer is valid UTF-8 or ends with an incomplete
+/// multibyte sequence (which will be completed by the next chunk).
+/// Returns `Err` for irrecoverably invalid UTF-8.
+fn decode_utf8_prefix(buffer: &[u8]) -> Result<(), std::str::Utf8Error> {
+    match std::str::from_utf8(buffer) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            let valid_up_to = e.valid_up_to();
+            if valid_up_to < buffer.len() {
+                let remaining = &buffer[valid_up_to..];
+                // If the remaining bytes are a valid (but incomplete) multibyte
+                // prefix, wait for more data.
+                if is_incomplete_multibyte_prefix(remaining) {
+                    return Ok(());
+                }
+            }
+            Err(e)
+        }
+    }
+}
+
+/// Check if the given bytes are a valid (incomplete) prefix of a UTF-8
+/// multibyte sequence.
+fn is_incomplete_multibyte_prefix(bytes: &[u8]) -> bool {
+    if bytes.is_empty() {
+        return false;
+    }
+    let first = bytes[0];
+    let expected_len = if first < 0x80 {
+        1
+    } else if first >> 5 == 0b110 {
+        2
+    } else if first >> 4 == 0b1110 {
+        3
+    } else if first >> 3 == 0b11110 {
+        4
+    } else {
+        // Invalid leading byte
+        return false;
+    };
+
+    // Check that all continuation bytes so far are valid
+    for &b in &bytes[1..] {
+        if b >> 6 != 0b10 {
+            // Not a continuation byte — invalid
+            return false;
+        }
+    }
+
+    bytes.len() < expected_len
+}
+
+/// Parse the next complete SSE event from the byte buffer.
+///
+/// Scans the buffer for an `event:` / `data:` pair terminated by a blank line.
+/// On success, drains the consumed bytes from `buffer` and returns the event.
+/// Returns `None` if no complete event is found yet.
+fn parse_next_event(buffer: &mut Vec<u8>) -> Option<Result<(String, String), ModelError>> {
+    let (blank_pos, term_len) = find_blank_line(buffer)?;
+    let consume = blank_pos + term_len;
+
+    // Extract the event bytes up to (but not including) the blank line
+    let event_bytes = &buffer[..blank_pos];
+
+    let event_str = match std::str::from_utf8(event_bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            buffer.drain(..consume);
+            return Some(Err(ModelError::invalid_response(format!(
+                "invalid UTF-8 in SSE event: {}",
+                e
+            ))));
+        }
+    };
+
+    // Parse event_type and data from the lines
     let mut event_type = None;
     let mut data = None;
-    let mut end_pos = 0;
-    let mut found_event = false;
 
-    for (i, line) in buffer.lines().enumerate() {
+    for line in event_str.lines() {
         if let Some(stripped) = line.strip_prefix("event: ") {
             event_type = Some(stripped.to_string());
         } else if let Some(stripped) = line.strip_prefix("data: ") {
             data = Some(stripped.to_string());
-        } else if line.is_empty() && (event_type.is_some() || data.is_some()) {
-            // Calculate position after this empty line
-            end_pos = buffer
-                .lines()
-                .take(i + 1)
-                .map(|l| l.len() + 1) // +1 for newline
-                .sum();
-            found_event = true;
-            break;
         }
     }
 
-    if found_event {
-        // Remove processed content from buffer
-        buffer.drain(..end_pos.min(buffer.len()));
+    // Drain processed bytes from buffer (in-place, no allocation)
+    buffer.drain(..consume);
 
-        match (event_type, data) {
-            (Some(et), Some(d)) => return Some(Ok((et, d))),
-            (None, Some(d)) => return Some(Ok(("message".to_string(), d))),
-            _ => {}
+    match (event_type, data) {
+        (Some(et), Some(d)) => Some(Ok((et, d))),
+        (None, Some(d)) => Some(Ok(("message".to_string(), d))),
+        _ => None,
+    }
+}
+
+/// Find the position of the first blank line (two consecutive newlines) in
+/// the buffer. Returns the byte index of the first newline of the pair, or
+/// `None`.
+/// Find the first blank line terminator in the buffer. Returns the byte
+/// index of the start of the terminator and its length (2 for LF+LF,
+/// 4 for CRLF+CRLF, 3 for mixed).
+fn find_blank_line(buffer: &[u8]) -> Option<(usize, usize)> {
+    for i in 0..buffer.len().saturating_sub(1) {
+        // LF LF
+        if buffer[i] == 0x0a && buffer[i + 1] == 0x0a {
+            return Some((i, 2));
+        }
+        // CRLF CRLF
+        if i + 3 < buffer.len()
+            && buffer[i] == 0x0d
+            && buffer[i + 1] == 0x0a
+            && buffer[i + 2] == 0x0d
+            && buffer[i + 3] == 0x0a
+        {
+            return Some((i, 4));
+        }
+        // Mixed LF + CRLF
+        if i + 2 < buffer.len()
+            && buffer[i] == 0x0a
+            && buffer[i + 1] == 0x0d
+            && buffer[i + 2] == 0x0a
+        {
+            return Some((i, 3));
         }
     }
-
     None
 }
 
@@ -942,5 +1055,315 @@ data: {}",
         assert!(text_deltas_seen >= 2, "should have seen text deltas");
         assert!(error_seen, "must see IncompleteStream error");
         assert!(!parser.message_stop_seen());
+    }
+
+    // =====================================================
+    // Issue #40 regression tests
+    // =====================================================
+
+    /// Helper: create a stream that feeds bytes one chunk at a time.
+    fn make_byte_chunks(full: &[u8], chunk_size: usize) -> Vec<Result<Bytes, reqwest::Error>> {
+        full.chunks(chunk_size)
+            .map(|c| Ok(Bytes::copy_from_slice(c)))
+            .collect()
+    }
+
+    /// Full valid stream as raw bytes (message_start through message_stop).
+    fn full_valid_stream_bytes() -> Vec<u8> {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&make_sse_bytes("message_start", msg_start));
+        bytes.extend_from_slice(&make_sse_bytes("content_block_start", block_start));
+        bytes.extend_from_slice(&make_sse_bytes("content_block_delta", delta));
+        bytes.extend_from_slice(&make_sse_bytes("content_block_stop", block_stop));
+        bytes.extend_from_slice(&make_sse_bytes("message_delta", r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#));
+        bytes.extend_from_slice(&make_sse_bytes("message_stop", msg_stop));
+        bytes
+    }
+
+    /// Collect all events from a parser, returning Ok(events) or Err(error).
+    async fn collect_events<S>(
+        mut parser: AnthropicStreamParser<S>,
+    ) -> Result<Vec<ModelResponseStreamEvent>, ModelError>
+    where
+        S: Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
+    {
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            match result {
+                Ok(e) => events.push(e),
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(events)
+    }
+
+    #[tokio::test]
+    async fn test_byte_fragmentation_all_boundaries() {
+        let full = full_valid_stream_bytes();
+
+        for chunk_size in 1..=full.len() {
+            let chunks = make_byte_chunks(&full, chunk_size);
+            let stream = stream::iter(chunks);
+            let parser = AnthropicStreamParser::new(stream);
+
+            let events = collect_events(parser).await.unwrap_or_else(|e| {
+                panic!("chunk_size {}: stream failed with error: {}", chunk_size, e);
+            });
+
+            assert_eq!(
+                events.len(),
+                3,
+                "chunk_size {}: expected 3 events (PartStart, PartDelta, PartEnd), got {}",
+                chunk_size,
+                events.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_multibyte_utf8_split_at_every_boundary() {
+        // Use a multibyte character (U+00E9 = C3 A9) in the text delta
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"caf\u00e9"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let full = {
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&make_sse_bytes("message_start", msg_start));
+            bytes.extend_from_slice(&make_sse_bytes("content_block_start", block_start));
+            bytes.extend_from_slice(&make_sse_bytes("content_block_delta", delta));
+            bytes.extend_from_slice(&make_sse_bytes("content_block_stop", block_stop));
+            bytes.extend_from_slice(&make_sse_bytes("message_stop", msg_stop));
+            bytes
+        };
+
+        // Split at every byte boundary — must reconstruct perfectly
+        for split_point in 1..full.len() {
+            let chunks = vec![
+                Ok(Bytes::copy_from_slice(&full[..split_point])),
+                Ok(Bytes::copy_from_slice(&full[split_point..])),
+            ];
+            let stream = stream::iter(chunks);
+            let parser = AnthropicStreamParser::new(stream);
+
+            let events = collect_events(parser).await.unwrap_or_else(|e| {
+                panic!(
+                    "split_point {}: stream failed with error: {}",
+                    split_point, e
+                );
+            });
+
+            assert_eq!(
+                events.len(),
+                3,
+                "split_point {}: expected 3 events",
+                split_point
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_malformed_json_yields_typed_error() {
+        let bad_data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"broken"#;
+        let bytes = vec![Ok(make_sse_bytes("content_block_delta", bad_data))];
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let event = parser.next().await.unwrap();
+        assert!(event.is_err(), "expected error for malformed JSON");
+        let err = event.unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to parse stream event"),
+            "error should mention parse failure, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_irrecoverably_invalid_utf8_yields_error() {
+        // Build a valid SSE frame but inject invalid UTF-8 byte (0xFF)
+        let valid = make_sse_bytes("ping", r#"{"type":"ping"}"#);
+        let mut bad_bytes = valid.to_vec();
+        // Insert an invalid UTF-8 byte in the data portion
+        bad_bytes.insert(20, 0xFF);
+
+        let bytes = vec![Ok(Bytes::from(bad_bytes))];
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        let event = parser.next().await;
+        assert!(event.is_some(), "expected an error event for invalid UTF-8");
+        if let Some(Err(err)) = event {
+            assert!(
+                err.to_string().contains("invalid UTF-8"),
+                "error should mention invalid UTF-8, got: {}",
+                err
+            );
+        } else {
+            panic!("expected Err, got Ok or None");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_malformed_record_between_valid_deltas_no_success() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta1 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let bad_data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"broken"#;
+        let delta2 = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"World"}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta1)),
+            Ok(make_sse_bytes("content_block_delta", bad_data)),
+            Ok(make_sse_bytes("content_block_delta", delta2)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let parser = AnthropicStreamParser::new(stream);
+
+        let result = collect_events(parser).await;
+
+        assert!(
+            result.is_err(),
+            "stream with malformed JSON between valid deltas must produce an error"
+        );
+
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("Failed to parse stream event"),
+            "error should mention parse failure, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_events_after_fatal_parse_error() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let bad_data = r#"not valid json at all"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"should-not-see"}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_delta", bad_data)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+        ];
+
+        let stream = stream::iter(bytes);
+        let mut parser = AnthropicStreamParser::new(stream);
+
+        // First poll should return the error
+        let event = parser.next().await;
+        assert!(event.is_some(), "expected error event");
+        assert!(
+            event.as_ref().unwrap().is_err(),
+            "expected Err for malformed JSON"
+        );
+
+        // Subsequent polls should return None (parser is done)
+        let after = parser.next().await;
+        assert!(
+            after.is_none(),
+            "no events should be emitted after fatal parse error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fragmentation_preserves_event_sequence() {
+        // Verify that byte-level fragmentation doesn't change the event sequence
+        let full = full_valid_stream_bytes();
+
+        // Single chunk (baseline)
+        let single = make_byte_chunks(&full, full.len());
+        let single_events = collect_events(AnthropicStreamParser::new(stream::iter(single)))
+            .await
+            .unwrap();
+
+        // Fragmented into 1-byte chunks (worst case)
+        let fragmented = make_byte_chunks(&full, 1);
+        let frag_events = collect_events(AnthropicStreamParser::new(stream::iter(fragmented)))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            single_events.len(),
+            frag_events.len(),
+            "fragmented stream should produce same number of events"
+        );
+
+        for (i, (s, f)) in single_events.iter().zip(frag_events.iter()).enumerate() {
+            assert_eq!(
+                std::mem::discriminant(s),
+                std::mem::discriminant(f),
+                "event {} type mismatch: single={:?} fragmented={:?}",
+                i,
+                s,
+                f
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_invalid_utf8_byte_split_across_chunks() {
+        // A 3-byte UTF-8 character (U+4E9C = E4 BA 9C) split so byte 1 is in
+        // chunk 1 and bytes 2-3 are in chunk 2.
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","usage":{"input_tokens":10,"output_tokens":0}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        // The delta contains the multibyte char embedded in JSON
+        let delta_json = "{\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"\u{4E9C}\"}}";
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let full = {
+            let mut bytes = Vec::new();
+            bytes.extend_from_slice(&make_sse_bytes("message_start", msg_start));
+            bytes.extend_from_slice(&make_sse_bytes("content_block_start", block_start));
+            bytes.extend_from_slice(&make_sse_bytes("content_block_delta", delta_json));
+            bytes.extend_from_slice(&make_sse_bytes("content_block_stop", block_stop));
+            bytes.extend_from_slice(&make_sse_bytes("message_stop", msg_stop));
+            bytes
+        };
+
+        // Find the byte position of the multibyte char in the full stream
+        let char_bytes = "\u{4E9C}".as_bytes(); // E4 BA 9C
+        let char_pos = full
+            .windows(char_bytes.len())
+            .position(|w| w == char_bytes)
+            .expect("multibyte char should be in stream");
+
+        // Split right in the middle of the multibyte char
+        for split_offset in 1..char_bytes.len() {
+            let split_point = char_pos + split_offset;
+            let chunks = vec![
+                Ok(Bytes::copy_from_slice(&full[..split_point])),
+                Ok(Bytes::copy_from_slice(&full[split_point..])),
+            ];
+            let stream = stream::iter(chunks);
+            let parser = AnthropicStreamParser::new(stream);
+
+            let events = collect_events(parser).await.unwrap_or_else(|e| {
+                panic!("split_offset {}: failed with error: {}", split_offset, e);
+            });
+
+            assert_eq!(
+                events.len(),
+                3,
+                "split_offset {}: expected 3 events",
+                split_offset
+            );
+        }
     }
 }

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -13,6 +13,7 @@ use serdes_ai_core::messages::{
     PartStartEvent, StreamCompleteEvent, TextPart, ThinkingPart, ThinkingPartDelta, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
+use serdes_ai_streaming::{SseParser, StreamError};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -22,7 +23,7 @@ pin_project! {
     pub struct AnthropicStreamParser<S> {
         #[pin]
         inner: S,
-        buffer: Vec<u8>,
+        sse: SseParser,
         // Track content blocks in progress
         blocks: HashMap<usize, BlockState>,
         // Message metadata
@@ -74,7 +75,7 @@ where
     pub fn new(inner: S) -> Self {
         Self {
             inner,
-            buffer: Vec::new(),
+            sse: SseParser::new(),
             blocks: HashMap::new(),
             message_id: None,
             model: None,
@@ -127,47 +128,27 @@ where
         }
 
         loop {
-            // Check for irrecoverably invalid UTF-8 in the buffer before
-            // attempting to parse events. Incomplete multibyte sequences at
-            // the tail are held until the next chunk arrives.
-            if let Err(e) = decode_utf8_prefix(&this.buffer) {
-                *this.done = true;
-                return Poll::Ready(Some(Err(ModelError::invalid_response(format!(
-                    "invalid UTF-8 in stream data: {}",
-                    e
-                )))));
-            }
-
-            // Process complete SSE events from the byte buffer.
-            while let Some(event_result) = parse_next_event(&mut this.buffer) {
-                match event_result {
-                    Ok((event_type, data)) => {
-                        if let Some(result) = process_event(
-                            &event_type,
-                            &data,
-                            this.blocks,
-                            this.message_id,
-                            this.model,
-                            this.input_tokens,
-                            this.output_tokens,
-                            this.cache_creation_tokens,
-                            this.cache_read_tokens,
-                            this.stop_reason,
-                            this.message_stop_seen,
-                            this.done,
-                        ) {
-                            if result.is_err()
-                                || matches!(result, Ok(ModelResponseStreamEvent::StreamComplete(_)))
-                            {
-                                *this.done = true;
-                            }
-                            return Poll::Ready(Some(result));
-                        }
-                    }
-                    Err(e) => {
+            while let Some(event) = this.sse.next_event() {
+                if let Some(result) = process_event(
+                    event.event.as_deref().unwrap_or("message"),
+                    &event.data,
+                    this.blocks,
+                    this.message_id,
+                    this.model,
+                    this.input_tokens,
+                    this.output_tokens,
+                    this.cache_creation_tokens,
+                    this.cache_read_tokens,
+                    this.stop_reason,
+                    this.message_stop_seen,
+                    this.done,
+                ) {
+                    if result.is_err()
+                        || matches!(result, Ok(ModelResponseStreamEvent::StreamComplete(_)))
+                    {
                         *this.done = true;
-                        return Poll::Ready(Some(Err(e)));
                     }
+                    return Poll::Ready(Some(result));
                 }
             }
 
@@ -181,7 +162,10 @@ where
             // Need more data
             match this.inner.as_mut().poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
-                    this.buffer.extend_from_slice(&bytes);
+                    if let Err(error) = this.sse.feed(&bytes) {
+                        *this.done = true;
+                        return Poll::Ready(Some(Err(map_sse_error(error))));
+                    }
                 }
                 Poll::Ready(Some(Err(e))) => {
                     *this.done = true;
@@ -190,18 +174,8 @@ where
                 Poll::Ready(None) => {
                     *this.done = true;
 
-                    if let Err(e) = std::str::from_utf8(&this.buffer) {
-                        return Poll::Ready(Some(Err(ModelError::invalid_response(format!(
-                            "stream ended with incomplete or invalid UTF-8 in buffer: {}",
-                            e
-                        )))));
-                    }
-
-                    if !this.buffer.is_empty() {
-                        return Poll::Ready(Some(Err(ModelError::incomplete_stream(format!(
-                            "stream ended with {} bytes of unparsed SSE data remaining in buffer",
-                            this.buffer.len()
-                        )))));
+                    if let Err(error) = this.sse.finish() {
+                        return Poll::Ready(Some(Err(map_sse_error(error))));
                     }
 
                     if !*this.message_stop_seen {
@@ -218,135 +192,17 @@ where
     }
 }
 
-/// Decode the longest valid UTF-8 prefix from the byte buffer.
-/// Returns `Ok` if the buffer is valid UTF-8 or ends with an incomplete
-/// multibyte sequence (which will be completed by the next chunk).
-/// Returns `Err` for irrecoverably invalid UTF-8.
-fn decode_utf8_prefix(buffer: &[u8]) -> Result<(), std::str::Utf8Error> {
-    match std::str::from_utf8(buffer) {
-        Ok(_) => Ok(()),
-        Err(e) => {
-            let valid_up_to = e.valid_up_to();
-            if valid_up_to < buffer.len() {
-                let remaining = &buffer[valid_up_to..];
-                // If the remaining bytes are a valid (but incomplete) multibyte
-                // prefix, wait for more data.
-                if is_incomplete_multibyte_prefix(remaining) {
-                    return Ok(());
-                }
-            }
-            Err(e)
+fn map_sse_error(error: StreamError) -> ModelError {
+    match error {
+        StreamError::IncompleteSse => {
+            ModelError::incomplete_stream("stream ended with an incomplete SSE record")
         }
+        StreamError::InvalidUtf8 => ModelError::invalid_response("invalid UTF-8 in SSE stream"),
+        StreamError::BufferOverflow => {
+            ModelError::invalid_response("SSE record exceeded buffer limit")
+        }
+        other => ModelError::invalid_response(other.to_string()),
     }
-}
-
-/// Check if the given bytes are a valid (incomplete) prefix of a UTF-8
-/// multibyte sequence.
-fn is_incomplete_multibyte_prefix(bytes: &[u8]) -> bool {
-    if bytes.is_empty() {
-        return false;
-    }
-    let first = bytes[0];
-    let expected_len = if first < 0x80 {
-        1
-    } else if first >> 5 == 0b110 {
-        2
-    } else if first >> 4 == 0b1110 {
-        3
-    } else if first >> 3 == 0b11110 {
-        4
-    } else {
-        // Invalid leading byte
-        return false;
-    };
-
-    // Check that all continuation bytes so far are valid
-    for &b in &bytes[1..] {
-        if b >> 6 != 0b10 {
-            // Not a continuation byte — invalid
-            return false;
-        }
-    }
-
-    bytes.len() < expected_len
-}
-
-/// Parse the next complete SSE event from the byte buffer.
-///
-/// Scans the buffer for an `event:` / `data:` pair terminated by a blank line.
-/// On success, drains the consumed bytes from `buffer` and returns the event.
-/// Returns `None` if no complete event is found yet.
-fn parse_next_event(buffer: &mut Vec<u8>) -> Option<Result<(String, String), ModelError>> {
-    let (blank_pos, term_len) = find_blank_line(buffer)?;
-    let consume = blank_pos + term_len;
-
-    // Extract the event bytes up to (but not including) the blank line
-    let event_bytes = &buffer[..blank_pos];
-
-    let event_str = match std::str::from_utf8(event_bytes) {
-        Ok(s) => s,
-        Err(e) => {
-            buffer.drain(..consume);
-            return Some(Err(ModelError::invalid_response(format!(
-                "invalid UTF-8 in SSE event: {}",
-                e
-            ))));
-        }
-    };
-
-    // Parse event_type and data from the lines
-    let mut event_type = None;
-    let mut data = None;
-
-    for line in event_str.lines() {
-        if let Some(stripped) = line.strip_prefix("event: ") {
-            event_type = Some(stripped.to_string());
-        } else if let Some(stripped) = line.strip_prefix("data: ") {
-            data = Some(stripped.to_string());
-        }
-    }
-
-    // Drain processed bytes from buffer (in-place, no allocation)
-    buffer.drain(..consume);
-
-    match (event_type, data) {
-        (Some(et), Some(d)) => Some(Ok((et, d))),
-        (None, Some(d)) => Some(Ok(("message".to_string(), d))),
-        _ => None,
-    }
-}
-
-/// Find the position of the first blank line (two consecutive newlines) in
-/// the buffer. Returns the byte index of the first newline of the pair, or
-/// `None`.
-/// Find the first blank line terminator in the buffer. Returns the byte
-/// index of the start of the terminator and its length (2 for LF+LF,
-/// 4 for CRLF+CRLF, 3 for mixed).
-fn find_blank_line(buffer: &[u8]) -> Option<(usize, usize)> {
-    for i in 0..buffer.len().saturating_sub(1) {
-        // LF LF
-        if buffer[i] == 0x0a && buffer[i + 1] == 0x0a {
-            return Some((i, 2));
-        }
-        // CRLF CRLF
-        if i + 3 < buffer.len()
-            && buffer[i] == 0x0d
-            && buffer[i + 1] == 0x0a
-            && buffer[i + 2] == 0x0d
-            && buffer[i + 3] == 0x0a
-        {
-            return Some((i, 4));
-        }
-        // Mixed LF + CRLF
-        if i + 2 < buffer.len()
-            && buffer[i] == 0x0a
-            && buffer[i + 1] == 0x0d
-            && buffer[i + 2] == 0x0a
-        {
-            return Some((i, 3));
-        }
-    }
-    None
 }
 
 /// Process a parsed event into a stream event.

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -156,10 +156,7 @@ where
                             this.done,
                         ) {
                             if result.is_err()
-                                || matches!(
-                                    result,
-                                    Ok(ModelResponseStreamEvent::StreamComplete(_))
-                                )
+                                || matches!(result, Ok(ModelResponseStreamEvent::StreamComplete(_)))
                             {
                                 *this.done = true;
                             }
@@ -200,7 +197,7 @@ where
                     }
 
                     if !this.buffer.is_empty() {
-                        return Poll::Ready(Some(Err(ModelError::invalid_response(format!(
+                        return Poll::Ready(Some(Err(ModelError::incomplete_stream(format!(
                             "stream ended with {} bytes of unparsed SSE data remaining in buffer",
                             this.buffer.len()
                         )))));
@@ -1119,8 +1116,8 @@ data: {}",
 
             assert_eq!(
                 events.len(),
-                3,
-                "chunk_size {}: expected 3 events (PartStart, PartDelta, PartEnd), got {}",
+                4,
+                "chunk_size {}: expected 4 events (PartStart, PartDelta, PartEnd), got {}",
                 chunk_size,
                 events.len()
             );
@@ -1165,8 +1162,8 @@ data: {}",
 
             assert_eq!(
                 events.len(),
-                3,
-                "split_point {}: expected 3 events",
+                4,
+                "split_point {}: expected 4 events",
                 split_point
             );
         }
@@ -1360,8 +1357,8 @@ data: {}",
 
             assert_eq!(
                 events.len(),
-                3,
-                "split_offset {}: expected 3 events",
+                4,
+                "split_offset {}: expected 4 events",
                 split_offset
             );
         }

--- a/serdes-ai-models/src/anthropic/stream.rs
+++ b/serdes-ai-models/src/anthropic/stream.rs
@@ -342,13 +342,14 @@ fn process_event(
             // Skip validation when the input is the default empty object (no
             // deltas were received).
             if let Some(BlockState::ToolUse { input_json, .. }) = blocks.get(&index) {
-                if !input_json.is_empty() && input_json != "{}" {
-                    if serde_json::from_str::<serde_json::Value>(input_json).is_err() {
-                        return Some(Err(ModelError::invalid_response(format!(
-                            "content_block_stop for tool at index {} has incomplete JSON input: {}",
-                            index, input_json
-                        ))));
-                    }
+                if !input_json.is_empty()
+                    && input_json != "{}"
+                    && serde_json::from_str::<serde_json::Value>(input_json).is_err()
+                {
+                    return Some(Err(ModelError::invalid_response(format!(
+                        "content_block_stop for tool at index {} has incomplete JSON input: {}",
+                        index, input_json
+                    ))));
                 }
             }
             blocks.remove(&index);

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -113,6 +113,16 @@ pub enum ModelError {
     #[error("Network error: {0}")]
     Network(String),
 
+    /// Every eligible model in a fallback chain failed before producing output.
+    #[error("All fallback models failed after {attempts_len} attempts: {last_error}", attempts_len = .attempts.len())]
+    FallbackExhausted {
+        /// Normalized failure metadata for each attempted model.
+        attempts: Vec<ModelFailure>,
+        /// Final concrete error retained as the source.
+        #[source]
+        last_error: Box<ModelError>,
+    },
+
     /// Retry attempts against the same model were exhausted.
     #[error("Model request failed after {attempts} attempts over {elapsed:?}: {last_error}")]
     RetryExhausted {
@@ -180,7 +190,8 @@ impl ModelError {
                 .find(|(name, _)| name.eq_ignore_ascii_case("retry-after"))
                 .and_then(|(_, value)| value.parse::<u64>().ok())
                 .map(Duration::from_secs),
-            ModelError::RetryExhausted { last_error, .. } => last_error.retry_after(),
+            ModelError::FallbackExhausted { last_error, .. }
+            | ModelError::RetryExhausted { last_error, .. } => last_error.retry_after(),
             ModelError::RetryDeadlineExceeded {
                 last_error: Some(last_error),
                 ..
@@ -383,6 +394,14 @@ impl ClassifyModelFailure for ModelError {
             }
             Self::Serialization(error) => {
                 ModelFailure::new(ModelFailureKind::InvalidResponse, error.to_string())
+            }
+            Self::FallbackExhausted {
+                attempts,
+                last_error,
+            } => {
+                let mut failure = last_error.model_failure();
+                failure.attempt = Some(attempts.len() as u32);
+                return failure;
             }
             Self::RetryExhausted {
                 attempts,

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -63,6 +63,8 @@ pub enum ModelError {
         message: String,
         /// Semantic classification used by retry and fallback policies.
         kind: ProviderErrorKind,
+        /// HTTP status for transport-reported errors.
+        status: Option<u16>,
         /// Suggested retry delay, when supplied by the provider.
         retry_after: Option<Duration>,
     },
@@ -131,6 +133,30 @@ pub enum ModelError {
     #[error("Network error: {0}")]
     Network(String),
 
+    /// Retry attempts against the same model were exhausted.
+    #[error("Model request failed after {attempts} attempts over {elapsed:?}: {last_error}")]
+    RetryExhausted {
+        /// Number of attempts made.
+        attempts: u32,
+        /// Total time spent under the retry policy.
+        elapsed: Duration,
+        /// Final classified model error.
+        #[source]
+        last_error: Box<ModelError>,
+    },
+
+    /// The total retry deadline expired.
+    #[error("Model request deadline expired after {attempts} attempts over {elapsed:?}")]
+    RetryDeadlineExceeded {
+        /// Number of attempts started.
+        attempts: u32,
+        /// Total time spent under the retry policy.
+        elapsed: Duration,
+        /// Most recent classified model error, if any.
+        #[source]
+        last_error: Option<Box<ModelError>>,
+    },
+
     /// Other error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -146,14 +172,20 @@ impl ModelError {
     /// Check if this error represents rate limiting.
     #[must_use]
     pub fn is_rate_limited(&self) -> bool {
-        matches!(self, ModelError::RateLimited { .. })
-            || matches!(
-                self,
-                ModelError::Provider {
-                    kind: ProviderErrorKind::RateLimited,
-                    ..
-                }
-            )
+        match self {
+            ModelError::RateLimited { .. } => true,
+            ModelError::Http { status: 429, .. } => true,
+            ModelError::Provider {
+                kind: ProviderErrorKind::RateLimited,
+                ..
+            } => true,
+            ModelError::RetryExhausted { last_error, .. } => last_error.is_rate_limited(),
+            ModelError::RetryDeadlineExceeded {
+                last_error: Some(last_error),
+                ..
+            } => last_error.is_rate_limited(),
+            _ => false,
+        }
     }
 
     /// Check if this error is transient, excluding rate limits.
@@ -164,13 +196,18 @@ impl ModelError {
             | ModelError::Connection(_)
             | ModelError::Network(_)
             | ModelError::IncompleteStream(_) => true,
-            ModelError::Http { status, .. } => *status >= 500,
+            ModelError::Http { status, .. } => (500..=599).contains(status),
             ModelError::Provider { kind, .. } => {
                 matches!(
                     kind,
                     ProviderErrorKind::Overloaded | ProviderErrorKind::Server
                 )
             }
+            ModelError::RetryExhausted { last_error, .. } => last_error.is_transient(),
+            ModelError::RetryDeadlineExceeded {
+                last_error: Some(last_error),
+                ..
+            } => last_error.is_transient(),
             _ => false,
         }
     }
@@ -181,6 +218,16 @@ impl ModelError {
         match self {
             ModelError::RateLimited { retry_after } => *retry_after,
             ModelError::Provider { retry_after, .. } => *retry_after,
+            ModelError::Http { headers, .. } => headers
+                .iter()
+                .find(|(name, _)| name.eq_ignore_ascii_case("retry-after"))
+                .and_then(|(_, value)| value.parse::<u64>().ok())
+                .map(Duration::from_secs),
+            ModelError::RetryExhausted { last_error, .. } => last_error.retry_after(),
+            ModelError::RetryDeadlineExceeded {
+                last_error: Some(last_error),
+                ..
+            } => last_error.retry_after(),
             _ => None,
         }
     }
@@ -214,11 +261,24 @@ impl ModelError {
         kind: ProviderErrorKind,
         retry_after: Option<Duration>,
     ) -> Self {
+        Self::provider_with_status(provider, code, message, kind, None, retry_after)
+    }
+
+    /// Create a structured provider error with HTTP status metadata.
+    pub fn provider_with_status(
+        provider: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+        kind: ProviderErrorKind,
+        status: Option<u16>,
+        retry_after: Option<Duration>,
+    ) -> Self {
         Self::Provider {
             provider: provider.into(),
             code: code.into(),
             message: message.into(),
             kind,
+            status,
             retry_after,
         }
     }

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -83,6 +83,10 @@ pub enum ModelError {
     #[error("Configuration error: {0}")]
     Configuration(String),
 
+    /// Stream ended prematurely (e.g. transport EOF before a terminal event).
+    #[error("Incomplete stream: {0}")]
+    IncompleteStream(String),
+
     /// Network error.
     #[error("Network error: {0}")]
     Network(String),
@@ -100,6 +104,7 @@ impl ModelError {
             ModelError::Timeout(_) => true,
             ModelError::RateLimited { .. } => true,
             ModelError::Connection(_) => true,
+            ModelError::IncompleteStream(_) => true,
             ModelError::Http { status, .. } => *status >= 500,
             _ => false,
         }
@@ -165,6 +170,11 @@ impl ModelError {
     /// Create an invalid response error.
     pub fn invalid_response(message: impl Into<String>) -> Self {
         Self::InvalidResponse(message.into())
+    }
+
+    /// Create an incomplete-stream error.
+    pub fn incomplete_stream(message: impl Into<String>) -> Self {
+        Self::IncompleteStream(message.into())
     }
 
     /// Create a not supported error.

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -4,6 +4,31 @@ use std::collections::HashMap;
 use std::time::Duration;
 use thiserror::Error;
 
+/// Semantic classification for a provider-reported API error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderErrorKind {
+    /// The provider rate-limited the request.
+    RateLimited,
+    /// The provider is temporarily overloaded.
+    Overloaded,
+    /// The provider reported a transient server failure.
+    Server,
+    /// Authentication failed.
+    Authentication,
+    /// The request was invalid.
+    InvalidRequest,
+    /// The requested resource was not found.
+    NotFound,
+    /// The caller lacks permission for the request.
+    PermissionDenied,
+    /// The account cannot make the request for billing reasons.
+    Billing,
+    /// The request exceeded the provider's size limit.
+    RequestTooLarge,
+    /// An unclassified provider error.
+    Other,
+}
+
 /// Model-related errors.
 #[derive(Debug, Error)]
 pub enum ModelError {
@@ -25,6 +50,21 @@ pub enum ModelError {
         message: String,
         /// Error code.
         code: Option<String>,
+    },
+
+    /// Structured error reported by a model provider.
+    #[error("{provider} API error ({code}): {message}")]
+    Provider {
+        /// Provider name.
+        provider: String,
+        /// Provider-specific error type or code.
+        code: String,
+        /// Provider-supplied error message.
+        message: String,
+        /// Semantic classification used by retry and fallback policies.
+        kind: ProviderErrorKind,
+        /// Suggested retry delay, when supplied by the provider.
+        retry_after: Option<Duration>,
     },
 
     /// Request timeout.
@@ -100,12 +140,37 @@ impl ModelError {
     /// Check if this error is retryable.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
+        self.is_rate_limited() || self.is_transient()
+    }
+
+    /// Check if this error represents rate limiting.
+    #[must_use]
+    pub fn is_rate_limited(&self) -> bool {
+        matches!(self, ModelError::RateLimited { .. })
+            || matches!(
+                self,
+                ModelError::Provider {
+                    kind: ProviderErrorKind::RateLimited,
+                    ..
+                }
+            )
+    }
+
+    /// Check if this error is transient, excluding rate limits.
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
         match self {
-            ModelError::Timeout(_) => true,
-            ModelError::RateLimited { .. } => true,
-            ModelError::Connection(_) => true,
-            ModelError::IncompleteStream(_) => true,
+            ModelError::Timeout(_)
+            | ModelError::Connection(_)
+            | ModelError::Network(_)
+            | ModelError::IncompleteStream(_) => true,
             ModelError::Http { status, .. } => *status >= 500,
+            ModelError::Provider { kind, .. } => {
+                matches!(
+                    kind,
+                    ProviderErrorKind::Overloaded | ProviderErrorKind::Server
+                )
+            }
             _ => false,
         }
     }
@@ -115,6 +180,7 @@ impl ModelError {
     pub fn retry_after(&self) -> Option<Duration> {
         match self {
             ModelError::RateLimited { retry_after } => *retry_after,
+            ModelError::Provider { retry_after, .. } => *retry_after,
             _ => None,
         }
     }
@@ -138,6 +204,23 @@ impl ModelError {
     /// Create a rate limited error.
     pub fn rate_limited(retry_after: Option<Duration>) -> Self {
         Self::RateLimited { retry_after }
+    }
+
+    /// Create a structured provider error.
+    pub fn provider(
+        provider: impl Into<String>,
+        code: impl Into<String>,
+        message: impl Into<String>,
+        kind: ProviderErrorKind,
+        retry_after: Option<Duration>,
+    ) -> Self {
+        Self::Provider {
+            provider: provider.into(),
+            code: code.into(),
+            message: message.into(),
+            kind,
+            retry_after,
+        }
     }
 
     /// Create an HTTP error.

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -149,15 +149,27 @@ pub enum ModelError {
 
     /// Legacy core API error retained as the source during migration.
     #[error("Core model API error: {0}")]
-    CoreApi(#[from] ModelApiError),
+    CoreApi(#[source] Box<ModelApiError>),
 
     /// Legacy core HTTP error retained as the source during migration.
     #[error("Core model HTTP error: {0}")]
-    CoreHttp(#[from] ModelHttpError),
+    CoreHttp(#[source] Box<ModelHttpError>),
 
     /// Other error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl From<ModelApiError> for ModelError {
+    fn from(error: ModelApiError) -> Self {
+        Self::CoreApi(Box::new(error))
+    }
+}
+
+impl From<ModelHttpError> for ModelError {
+    fn from(error: ModelHttpError) -> Self {
+        Self::CoreHttp(Box::new(error))
+    }
 }
 
 impl ModelError {

--- a/serdes-ai-models/src/error.rs
+++ b/serdes-ai-models/src/error.rs
@@ -1,33 +1,13 @@
 //! Model-related error types.
 
+use serdes_ai_core::errors::{ModelApiError, ModelHttpError};
+use serdes_ai_core::{ClassifyModelFailure, ModelFailure, ModelFailureKind};
 use std::collections::HashMap;
 use std::time::Duration;
 use thiserror::Error;
 
-/// Semantic classification for a provider-reported API error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ProviderErrorKind {
-    /// The provider rate-limited the request.
-    RateLimited,
-    /// The provider is temporarily overloaded.
-    Overloaded,
-    /// The provider reported a transient server failure.
-    Server,
-    /// Authentication failed.
-    Authentication,
-    /// The request was invalid.
-    InvalidRequest,
-    /// The requested resource was not found.
-    NotFound,
-    /// The caller lacks permission for the request.
-    PermissionDenied,
-    /// The account cannot make the request for billing reasons.
-    Billing,
-    /// The request exceeded the provider's size limit.
-    RequestTooLarge,
-    /// An unclassified provider error.
-    Other,
-}
+/// Backward-compatible name for the canonical model failure category.
+pub type ProviderErrorKind = ModelFailureKind;
 
 /// Model-related errors.
 #[derive(Debug, Error)]
@@ -157,6 +137,14 @@ pub enum ModelError {
         last_error: Option<Box<ModelError>>,
     },
 
+    /// Legacy core API error retained as the source during migration.
+    #[error("Core model API error: {0}")]
+    CoreApi(#[from] ModelApiError),
+
+    /// Legacy core HTTP error retained as the source during migration.
+    #[error("Core model HTTP error: {0}")]
+    CoreHttp(#[from] ModelHttpError),
+
     /// Other error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -166,50 +154,19 @@ impl ModelError {
     /// Check if this error is retryable.
     #[must_use]
     pub fn is_retryable(&self) -> bool {
-        self.is_rate_limited() || self.is_transient()
+        self.model_failure().is_retryable()
     }
 
     /// Check if this error represents rate limiting.
     #[must_use]
     pub fn is_rate_limited(&self) -> bool {
-        match self {
-            ModelError::RateLimited { .. } => true,
-            ModelError::Http { status: 429, .. } => true,
-            ModelError::Provider {
-                kind: ProviderErrorKind::RateLimited,
-                ..
-            } => true,
-            ModelError::RetryExhausted { last_error, .. } => last_error.is_rate_limited(),
-            ModelError::RetryDeadlineExceeded {
-                last_error: Some(last_error),
-                ..
-            } => last_error.is_rate_limited(),
-            _ => false,
-        }
+        self.model_failure().kind.is_rate_limited()
     }
 
     /// Check if this error is transient, excluding rate limits.
     #[must_use]
     pub fn is_transient(&self) -> bool {
-        match self {
-            ModelError::Timeout(_)
-            | ModelError::Connection(_)
-            | ModelError::Network(_)
-            | ModelError::IncompleteStream(_) => true,
-            ModelError::Http { status, .. } => (500..=599).contains(status),
-            ModelError::Provider { kind, .. } => {
-                matches!(
-                    kind,
-                    ProviderErrorKind::Overloaded | ProviderErrorKind::Server
-                )
-            }
-            ModelError::RetryExhausted { last_error, .. } => last_error.is_transient(),
-            ModelError::RetryDeadlineExceeded {
-                last_error: Some(last_error),
-                ..
-            } => last_error.is_transient(),
-            _ => false,
-        }
+        self.model_failure().kind.is_transient()
     }
 
     /// Get the retry-after duration if applicable.
@@ -349,6 +306,119 @@ impl ModelError {
         }
     }
 }
+impl ClassifyModelFailure for ModelError {
+    fn model_failure(&self) -> ModelFailure {
+        let mut failure = match self {
+            Self::Http { status, body, .. } => {
+                let kind = match *status {
+                    429 => ModelFailureKind::RateLimited,
+                    500..=599 => ModelFailureKind::Server,
+                    400 => ModelFailureKind::InvalidRequest,
+                    401 => ModelFailureKind::Authentication,
+                    403 => ModelFailureKind::PermissionDenied,
+                    404 => ModelFailureKind::NotFound,
+                    _ => ModelFailureKind::Other,
+                };
+                let mut failure = ModelFailure::new(kind, body.clone());
+                failure.status = Some(*status);
+                failure
+            }
+            Self::Api { message, code } => {
+                let kind = match code.as_deref() {
+                    Some("rate_limit_error") => ModelFailureKind::RateLimited,
+                    Some("overloaded_error") => ModelFailureKind::Overloaded,
+                    Some("authentication_error") => ModelFailureKind::Authentication,
+                    Some("invalid_request_error") => ModelFailureKind::InvalidRequest,
+                    _ => ModelFailureKind::Other,
+                };
+                let mut failure = ModelFailure::new(kind, message.clone());
+                failure.provider_code = code.clone();
+                failure
+            }
+            Self::Provider {
+                provider,
+                code,
+                message,
+                kind,
+                status,
+                retry_after,
+            } => {
+                let mut failure = ModelFailure::new(*kind, message.clone());
+                failure.provider = Some(provider.clone());
+                failure.provider_code = Some(code.clone());
+                failure.status = *status;
+                failure.retry_after = *retry_after;
+                failure
+            }
+            Self::Timeout(duration) => ModelFailure::new(
+                ModelFailureKind::Timeout,
+                format!("request timeout after {duration:?}"),
+            ),
+            Self::RateLimited { retry_after } => {
+                let mut failure = ModelFailure::new(ModelFailureKind::RateLimited, "rate limited");
+                failure.retry_after = *retry_after;
+                failure
+            }
+            Self::Authentication(message) => {
+                ModelFailure::new(ModelFailureKind::Authentication, message.clone())
+            }
+            Self::InvalidResponse(message) => {
+                ModelFailure::new(ModelFailureKind::InvalidResponse, message.clone())
+            }
+            Self::NotFound(message) => {
+                ModelFailure::new(ModelFailureKind::NotFound, message.clone())
+            }
+            Self::Cancelled => ModelFailure::new(ModelFailureKind::Cancelled, "request cancelled"),
+            Self::Connection(message) | Self::Network(message) => {
+                ModelFailure::new(ModelFailureKind::Connection, message.clone())
+            }
+            Self::ContextLengthExceeded { .. } => {
+                ModelFailure::new(ModelFailureKind::InvalidRequest, self.to_string())
+            }
+            Self::Configuration(message) | Self::NotSupported(message) => {
+                ModelFailure::new(ModelFailureKind::Configuration, message.clone())
+            }
+            Self::IncompleteStream(message) => {
+                ModelFailure::new(ModelFailureKind::IncompleteStream, message.clone())
+            }
+            Self::Serialization(error) => {
+                ModelFailure::new(ModelFailureKind::InvalidResponse, error.to_string())
+            }
+            Self::RetryExhausted {
+                attempts,
+                last_error,
+                ..
+            } => {
+                let mut failure = last_error.model_failure();
+                failure.attempt = Some(*attempts);
+                return failure;
+            }
+            Self::RetryDeadlineExceeded {
+                attempts,
+                last_error: Some(last_error),
+                ..
+            } => {
+                let mut failure = last_error.model_failure();
+                failure.attempt = Some(*attempts);
+                return failure;
+            }
+            Self::RetryDeadlineExceeded { attempts, .. } => {
+                let mut failure = ModelFailure::new(ModelFailureKind::Timeout, self.to_string());
+                failure.attempt = Some(*attempts);
+                failure
+            }
+            Self::ContentFiltered(message) => {
+                ModelFailure::new(ModelFailureKind::Other, message.clone())
+            }
+            Self::Other(error) => ModelFailure::new(ModelFailureKind::Other, error.to_string()),
+            Self::CoreApi(error) => return error.model_failure(),
+            Self::CoreHttp(error) => return error.model_failure(),
+        };
+        failure.retry_after = failure.retry_after.or_else(|| self.retry_after());
+        failure.cause = Some(self.to_string());
+        failure
+    }
+}
 
 impl From<reqwest::Error> for ModelError {
     fn from(err: reqwest::Error) -> Self {
@@ -408,5 +478,101 @@ mod tests {
 
         let err = ModelError::http(404, "Not found");
         assert!(err.to_string().contains("404"));
+    }
+
+    #[test]
+    fn canonical_classification_matrix() {
+        let cases = [
+            (
+                ModelError::http(429, "limited"),
+                ModelFailureKind::RateLimited,
+                true,
+            ),
+            (
+                ModelError::http(500, "server"),
+                ModelFailureKind::Server,
+                true,
+            ),
+            (
+                ModelError::http(503, "unavailable"),
+                ModelFailureKind::Server,
+                true,
+            ),
+            (
+                ModelError::http(400, "bad"),
+                ModelFailureKind::InvalidRequest,
+                false,
+            ),
+            (
+                ModelError::http(401, "auth"),
+                ModelFailureKind::Authentication,
+                false,
+            ),
+            (
+                ModelError::Timeout(Duration::from_secs(1)),
+                ModelFailureKind::Timeout,
+                true,
+            ),
+            (
+                ModelError::Connection("reset".into()),
+                ModelFailureKind::Connection,
+                true,
+            ),
+            (
+                ModelError::invalid_response("bad json"),
+                ModelFailureKind::InvalidResponse,
+                false,
+            ),
+            (ModelError::Cancelled, ModelFailureKind::Cancelled, false),
+        ];
+
+        for (error, expected_kind, retryable) in cases {
+            let failure = error.model_failure();
+            assert_eq!(failure.kind, expected_kind);
+            assert_eq!(failure.is_retryable(), retryable);
+            assert_eq!(error.is_retryable(), retryable);
+        }
+    }
+
+    #[test]
+    fn provider_metadata_and_retry_context_survive_classification() {
+        let error = ModelError::RetryExhausted {
+            attempts: 3,
+            elapsed: Duration::from_secs(2),
+            last_error: Box::new(ModelError::provider_with_status(
+                "anthropic",
+                "rate_limit_error",
+                "slow down",
+                ModelFailureKind::RateLimited,
+                Some(429),
+                Some(Duration::from_secs(7)),
+            )),
+        };
+
+        let failure = error.model_failure();
+        assert_eq!(failure.kind, ModelFailureKind::RateLimited);
+        assert_eq!(failure.status, Some(429));
+        assert_eq!(failure.provider.as_deref(), Some("anthropic"));
+        assert_eq!(failure.provider_code.as_deref(), Some("rate_limit_error"));
+        assert_eq!(failure.retry_after, Some(Duration::from_secs(7)));
+        assert_eq!(failure.attempt, Some(3));
+    }
+
+    #[test]
+    fn legacy_core_errors_convert_without_losing_source_or_metadata() {
+        let mut headers = HashMap::new();
+        headers.insert("Retry-After".to_string(), "5".to_string());
+        let core_error = ModelApiError::new(429, "limited")
+            .with_message("slow down")
+            .with_error_code("rate_limit_error")
+            .with_headers(headers);
+        let error = ModelError::from(core_error);
+        let failure = error.model_failure();
+
+        assert_eq!(failure.kind, ModelFailureKind::RateLimited);
+        assert_eq!(failure.status, Some(429));
+        assert_eq!(failure.provider_code.as_deref(), Some("rate_limit_error"));
+        assert_eq!(failure.retry_after, Some(Duration::from_secs(5)));
+        assert!(std::error::Error::source(&error).is_some());
     }
 }

--- a/serdes-ai-models/src/fallback.rs
+++ b/serdes-ai-models/src/fallback.rs
@@ -23,7 +23,10 @@ use crate::error::ModelError;
 use crate::model::{Model, ModelRequestParameters, StreamedResponse};
 use crate::profile::ModelProfile;
 use async_trait::async_trait;
-use serdes_ai_core::{ModelRequest, ModelResponse, ModelSettings};
+use futures::{stream, StreamExt};
+use serdes_ai_core::{
+    ClassifyModelFailure, ModelFailure, ModelRequest, ModelResponse, ModelSettings,
+};
 use tracing::{debug, warn};
 
 /// Policy for determining when to retry with the next model.
@@ -42,10 +45,11 @@ impl RetryOn {
     /// Check if the given error should trigger a retry.
     #[must_use]
     pub fn should_retry(&self, error: &ModelError) -> bool {
+        let failure = error.model_failure();
         match self {
             RetryOn::AnyError => true,
-            RetryOn::RateLimits => error.is_rate_limited(),
-            RetryOn::Transient => error.is_transient(),
+            RetryOn::RateLimits => failure.kind.is_rate_limited(),
+            RetryOn::Transient => failure.kind.is_transient(),
         }
     }
 }
@@ -56,6 +60,13 @@ impl RetryOn {
 /// - Implementing fallback strategies (e.g., try Claude first, fall back to GPT-4)
 /// - Handling rate limits by falling back to alternative models
 /// - Testing model behavior with mock fallbacks
+///
+/// Streaming fallback is allowed only before the caller observes any stream
+/// event. Every event, including metadata and terminal events, establishes the
+/// selected attempt. Errors after that boundary are propagated from that model
+/// and never trigger output replay or concatenation. The wrapper polls at most
+/// one event before returning, so buffering and backpressure remain bounded; a
+/// losing stream is dropped before the next model is attempted.
 pub struct FallbackModel {
     models: Vec<Box<dyn Model>>,
     retry_on: RetryOn,
@@ -141,6 +152,33 @@ impl FallbackModel {
         self.models.is_empty()
     }
 
+    fn contextual_failure(error: &ModelError, model: &dyn Model, attempt: usize) -> ModelFailure {
+        let mut failure = error.model_failure();
+        if failure.provider.is_none() {
+            failure.provider = Some(model.system().to_string());
+        }
+        failure.model = Some(model.identifier());
+        failure.attempt = Some(attempt as u32);
+        failure
+    }
+
+    fn finish_failure(
+        mut attempts: Vec<ModelFailure>,
+        error: ModelError,
+        model: &dyn Model,
+        attempt: usize,
+    ) -> ModelError {
+        attempts.push(Self::contextual_failure(&error, model, attempt));
+        if attempts.len() == 1 {
+            error
+        } else {
+            ModelError::FallbackExhausted {
+                attempts,
+                last_error: Box::new(error),
+            }
+        }
+    }
+
     /// Check if we should retry with the next model for the given error.
     fn should_retry(&self, error: &ModelError) -> bool {
         self.retry_on.should_retry(error)
@@ -176,59 +214,44 @@ impl Model for FallbackModel {
             return Err(ModelError::configuration("No models in fallback chain"));
         }
 
-        let mut last_error: Option<ModelError> = None;
+        let mut attempts = Vec::new();
 
         for (i, model) in self.models.iter().enumerate() {
-            let is_last = i == self.models.len() - 1;
+            let attempt = i + 1;
+            let is_last = attempt == self.models.len();
 
             debug!(
                 model = %model.identifier(),
-                attempt = i + 1,
+                attempt,
                 total = self.models.len(),
                 "Trying model in fallback chain"
             );
 
             match model.request(messages, settings, params).await {
-                Ok(response) => {
-                    if i > 0 {
-                        debug!(
-                            model = %model.identifier(),
-                            "Fallback model succeeded after {} previous attempts",
-                            i
-                        );
-                    }
-                    return Ok(response);
-                }
-                Err(e) => {
+                Ok(response) => return Ok(response),
+                Err(error) => {
                     warn!(
                         model = %model.identifier(),
-                        error = %e,
+                        error = %error,
                         "Model request failed"
                     );
 
-                    if is_last {
-                        // No more models to try
-                        return Err(e);
-                    }
-
-                    if self.should_retry(&e) {
-                        debug!(
-                            error_type = ?std::mem::discriminant(&e),
-                            "Error is retryable, trying next model"
-                        );
-                        last_error = Some(e);
+                    if !is_last && self.should_retry(&error) {
+                        attempts.push(Self::contextual_failure(&error, model.as_ref(), attempt));
                         continue;
                     }
 
-                    // Non-retryable error, propagate immediately
-                    return Err(e);
+                    return Err(Self::finish_failure(
+                        attempts,
+                        error,
+                        model.as_ref(),
+                        attempt,
+                    ));
                 }
             }
         }
 
-        // This shouldn't be reached due to the is_last check above,
-        // but handle it gracefully just in case
-        Err(last_error.unwrap_or_else(|| ModelError::configuration("No models in fallback chain")))
+        Err(ModelError::configuration("No models in fallback chain"))
     }
 
     async fn request_stream(
@@ -241,55 +264,57 @@ impl Model for FallbackModel {
             return Err(ModelError::configuration("No models in fallback chain"));
         }
 
-        let mut last_error: Option<ModelError> = None;
+        let mut attempts = Vec::new();
 
         for (i, model) in self.models.iter().enumerate() {
-            let is_last = i == self.models.len() - 1;
+            let attempt = i + 1;
+            let is_last = attempt == self.models.len();
 
             debug!(
                 model = %model.identifier(),
-                attempt = i + 1,
+                attempt,
                 total = self.models.len(),
                 "Trying model in fallback chain (streaming)"
             );
 
-            match model.request_stream(messages, settings, params).await {
-                Ok(stream) => {
-                    if i > 0 {
-                        debug!(
-                            model = %model.identifier(),
-                            "Fallback model succeeded after {} previous attempts",
-                            i
-                        );
-                    }
-                    return Ok(stream);
-                }
-                Err(e) => {
-                    warn!(
-                        model = %model.identifier(),
-                        error = %e,
-                        "Model stream request failed"
-                    );
-
-                    if is_last {
-                        return Err(e);
-                    }
-
-                    if self.should_retry(&e) {
-                        debug!(
-                            error_type = ?std::mem::discriminant(&e),
-                            "Error is retryable, trying next model"
-                        );
-                        last_error = Some(e);
+            let stream = match model.request_stream(messages, settings, params).await {
+                Ok(stream) => stream,
+                Err(error) => {
+                    if !is_last && self.should_retry(&error) {
+                        attempts.push(Self::contextual_failure(&error, model.as_ref(), attempt));
                         continue;
                     }
-
-                    return Err(e);
+                    return Err(Self::finish_failure(
+                        attempts,
+                        error,
+                        model.as_ref(),
+                        attempt,
+                    ));
                 }
+            };
+
+            let mut stream = stream;
+            match stream.next().await {
+                Some(Ok(event)) => {
+                    return Ok(stream::once(async move { Ok(event) }).chain(stream).boxed());
+                }
+                Some(Err(error)) => {
+                    if !is_last && self.should_retry(&error) {
+                        attempts.push(Self::contextual_failure(&error, model.as_ref(), attempt));
+                        continue;
+                    }
+                    return Err(Self::finish_failure(
+                        attempts,
+                        error,
+                        model.as_ref(),
+                        attempt,
+                    ));
+                }
+                None => return Ok(stream),
             }
         }
 
-        Err(last_error.unwrap_or_else(|| ModelError::configuration("No models in fallback chain")))
+        Err(ModelError::configuration("No models in fallback chain"))
     }
 }
 
@@ -298,7 +323,7 @@ mod tests {
     use super::*;
     use crate::error::ProviderErrorKind;
     use crate::mock::MockModel;
-    use serdes_ai_core::messages::TextPart;
+    use serdes_ai_core::messages::{ModelResponseStreamEvent, StreamCompleteEvent, TextPart};
     use serdes_ai_core::{FinishReason, ModelResponsePart};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
@@ -624,12 +649,15 @@ mod tests {
         assert_eq!(call_count1.load(Ordering::SeqCst), 1);
         assert_eq!(call_count2.load(Ordering::SeqCst), 1);
 
-        // Should return error
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            ModelError::RateLimited { .. }
-        ));
+        // Preserve both failed model attempts and the final concrete source.
+        match result.unwrap_err() {
+            ModelError::FallbackExhausted { attempts, .. } => {
+                assert_eq!(attempts.len(), 2);
+                assert_eq!(attempts[0].model.as_deref(), Some("failing-mock:model1"));
+                assert_eq!(attempts[1].model.as_deref(), Some("failing-mock:model2"));
+            }
+            other => panic!("expected fallback context, got {other}"),
+        }
     }
 
     #[tokio::test]
@@ -882,5 +910,311 @@ mod tests {
             }
             _ => panic!("Expected Configuration error"),
         }
+    }
+
+    struct StreamingMockModel {
+        name: String,
+        events: std::sync::Mutex<Option<Vec<Result<ModelResponseStreamEvent, ModelError>>>>,
+        calls: Arc<AtomicUsize>,
+        profile: ModelProfile,
+    }
+
+    impl StreamingMockModel {
+        fn new(
+            name: impl Into<String>,
+            events: Vec<Result<ModelResponseStreamEvent, ModelError>>,
+        ) -> Self {
+            Self {
+                name: name.into(),
+                events: std::sync::Mutex::new(Some(events)),
+                calls: Arc::new(AtomicUsize::new(0)),
+                profile: ModelProfile::default(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Model for StreamingMockModel {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn system(&self) -> &str {
+            "streaming-mock"
+        }
+
+        fn profile(&self) -> &ModelProfile {
+            &self.profile
+        }
+
+        async fn request(
+            &self,
+            _messages: &[ModelRequest],
+            _settings: &ModelSettings,
+            _params: &ModelRequestParameters,
+        ) -> Result<ModelResponse, ModelError> {
+            Err(ModelError::not_supported("non-streaming request"))
+        }
+
+        async fn request_stream(
+            &self,
+            _messages: &[ModelRequest],
+            _settings: &ModelSettings,
+            _params: &ModelRequestParameters,
+        ) -> Result<StreamedResponse, ModelError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let events = self.events.lock().unwrap().take().unwrap_or_default();
+            Ok(Box::pin(futures::stream::iter(events)))
+        }
+    }
+
+    #[tokio::test]
+    async fn stream_falls_back_after_retryable_error_before_first_event() {
+        let primary =
+            StreamingMockModel::new("primary", vec![Err(ModelError::Connection("reset".into()))]);
+        let backup = StreamingMockModel::new(
+            "backup",
+            vec![Ok(ModelResponseStreamEvent::part_start(
+                0,
+                ModelResponsePart::Text(TextPart::new("backup")),
+            ))],
+        );
+        let backup_calls = Arc::clone(&backup.calls);
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let mut stream = fallback
+            .request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(ModelResponseStreamEvent::PartStart(_)))
+        ));
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_does_not_fallback_after_any_event_is_exposed() {
+        let primary = StreamingMockModel::new(
+            "primary",
+            vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("primary")),
+                )),
+                Err(ModelError::Connection("late reset".into())),
+            ],
+        );
+        let backup = StreamingMockModel::new(
+            "backup",
+            vec![Ok(ModelResponseStreamEvent::part_start(
+                0,
+                ModelResponsePart::Text(TextPart::new("backup")),
+            ))],
+        );
+        let backup_calls = Arc::clone(&backup.calls);
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let mut stream = fallback
+            .request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(stream.next().await.unwrap().is_ok());
+        assert!(matches!(
+            stream.next().await,
+            Some(Err(ModelError::Connection(message))) if message == "late reset"
+        ));
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 0);
+    }
+    #[tokio::test]
+    async fn terminal_metadata_event_also_prevents_fallback() {
+        let primary = StreamingMockModel::new(
+            "primary",
+            vec![
+                Ok(ModelResponseStreamEvent::StreamComplete(
+                    StreamCompleteEvent::new(FinishReason::Stop),
+                )),
+                Err(ModelError::Connection("after metadata".into())),
+            ],
+        );
+        let backup = StreamingMockModel::new("backup", vec![]);
+        let backup_calls = Arc::clone(&backup.calls);
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let mut stream = fallback
+            .request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            stream.next().await,
+            Some(Ok(ModelResponseStreamEvent::StreamComplete(_)))
+        ));
+        assert!(matches!(
+            stream.next().await,
+            Some(Err(ModelError::Connection(message))) if message == "after metadata"
+        ));
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn non_retryable_pre_output_error_does_not_try_backup() {
+        let primary = StreamingMockModel::new(
+            "primary",
+            vec![Err(ModelError::Authentication("bad key".into()))],
+        );
+        let backup = StreamingMockModel::new("backup", vec![]);
+        let backup_calls = Arc::clone(&backup.calls);
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let result = fallback
+            .request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await;
+
+        assert!(matches!(result, Err(ModelError::Authentication(_))));
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn all_pre_output_failures_preserve_model_attempt_context() {
+        let primary = StreamingMockModel::new(
+            "primary",
+            vec![Err(ModelError::Connection("primary reset".into()))],
+        );
+        let backup = StreamingMockModel::new(
+            "backup",
+            vec![Err(ModelError::Timeout(Duration::from_secs(1)))],
+        );
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let error = match fallback
+            .request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+        {
+            Err(error) => error,
+            Ok(_) => panic!("all candidates should fail"),
+        };
+
+        match error {
+            ModelError::FallbackExhausted { attempts, .. } => {
+                assert_eq!(attempts.len(), 2);
+                assert_eq!(attempts[0].model.as_deref(), Some("streaming-mock:primary"));
+                assert_eq!(attempts[0].attempt, Some(1));
+                assert_eq!(attempts[1].model.as_deref(), Some("streaming-mock:backup"));
+                assert_eq!(attempts[1].attempt, Some(2));
+            }
+            other => panic!("expected fallback context, got {other}"),
+        }
+    }
+
+    struct PendingStreamingModel {
+        calls: Arc<AtomicUsize>,
+        drops: Arc<AtomicUsize>,
+        profile: ModelProfile,
+    }
+
+    struct StreamDropGuard(Arc<AtomicUsize>);
+
+    impl Drop for StreamDropGuard {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl Model for PendingStreamingModel {
+        fn name(&self) -> &str {
+            "pending"
+        }
+
+        fn system(&self) -> &str {
+            "streaming-mock"
+        }
+
+        fn profile(&self) -> &ModelProfile {
+            &self.profile
+        }
+
+        async fn request(
+            &self,
+            _messages: &[ModelRequest],
+            _settings: &ModelSettings,
+            _params: &ModelRequestParameters,
+        ) -> Result<ModelResponse, ModelError> {
+            unreachable!()
+        }
+
+        async fn request_stream(
+            &self,
+            _messages: &[ModelRequest],
+            _settings: &ModelSettings,
+            _params: &ModelRequestParameters,
+        ) -> Result<StreamedResponse, ModelError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let guard = StreamDropGuard(Arc::clone(&self.drops));
+            Ok(Box::pin(futures::stream::unfold(
+                guard,
+                |guard| async move {
+                    futures::future::pending::<()>().await;
+                    Some((Err(ModelError::Connection("unreachable".into())), guard))
+                },
+            )))
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelling_initial_poll_closes_stream_without_trying_backup() {
+        let primary_calls = Arc::new(AtomicUsize::new(0));
+        let primary_drops = Arc::new(AtomicUsize::new(0));
+        let primary = PendingStreamingModel {
+            calls: Arc::clone(&primary_calls),
+            drops: Arc::clone(&primary_drops),
+            profile: ModelProfile::default(),
+        };
+        let backup = StreamingMockModel::new("backup", vec![]);
+        let backup_calls = Arc::clone(&backup.calls);
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)]);
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(10),
+            fallback.request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            ),
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(primary_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(primary_drops.load(Ordering::SeqCst), 1);
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 0);
     }
 }

--- a/serdes-ai-models/src/fallback.rs
+++ b/serdes-ai-models/src/fallback.rs
@@ -44,12 +44,8 @@ impl RetryOn {
     pub fn should_retry(&self, error: &ModelError) -> bool {
         match self {
             RetryOn::AnyError => true,
-            RetryOn::RateLimits => matches!(error, ModelError::RateLimited { .. }),
-            RetryOn::Transient => match error {
-                ModelError::Timeout(_) | ModelError::Connection(_) | ModelError::Network(_) => true,
-                ModelError::Http { status, .. } => *status >= 500,
-                _ => false,
-            },
+            RetryOn::RateLimits => error.is_rate_limited(),
+            RetryOn::Transient => error.is_transient(),
         }
     }
 }
@@ -300,6 +296,7 @@ impl Model for FallbackModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ProviderErrorKind;
     use crate::mock::MockModel;
     use serdes_ai_core::messages::TextPart;
     use serdes_ai_core::{FinishReason, ModelResponsePart};
@@ -360,6 +357,19 @@ mod tests {
                 ModelError::Timeout(d) => Err(ModelError::Timeout(*d)),
                 ModelError::Connection(msg) => Err(ModelError::Connection(msg.clone())),
                 ModelError::Authentication(msg) => Err(ModelError::Authentication(msg.clone())),
+                ModelError::Provider {
+                    provider,
+                    code,
+                    message,
+                    kind,
+                    retry_after,
+                } => Err(ModelError::Provider {
+                    provider: provider.clone(),
+                    code: code.clone(),
+                    message: message.clone(),
+                    kind: *kind,
+                    retry_after: *retry_after,
+                }),
                 ModelError::Http {
                     status,
                     body,
@@ -462,6 +472,14 @@ mod tests {
         assert!(RetryOn::RateLimits.should_retry(&ModelError::rate_limited(None)));
         assert!(!RetryOn::RateLimits.should_retry(&ModelError::api("test")));
         assert!(!RetryOn::RateLimits.should_retry(&ModelError::Timeout(Duration::from_secs(30))));
+        let provider_rate_limit = ModelError::provider(
+            "anthropic",
+            "rate_limit_error",
+            "slow down",
+            ProviderErrorKind::RateLimited,
+            None,
+        );
+        assert!(RetryOn::RateLimits.should_retry(&provider_rate_limit));
 
         // Transient retries on timeout, connection, network, and 5xx errors
         assert!(RetryOn::Transient.should_retry(&ModelError::Timeout(Duration::from_secs(30))));
@@ -471,6 +489,14 @@ mod tests {
         assert!(RetryOn::Transient.should_retry(&ModelError::http(502, "Bad gateway")));
         assert!(!RetryOn::Transient.should_retry(&ModelError::http(400, "Bad request")));
         assert!(!RetryOn::Transient.should_retry(&ModelError::api("test")));
+        let provider_overload = ModelError::provider(
+            "anthropic",
+            "overloaded_error",
+            "busy",
+            ProviderErrorKind::Overloaded,
+            None,
+        );
+        assert!(RetryOn::Transient.should_retry(&provider_overload));
         assert!(!RetryOn::Transient.should_retry(&ModelError::rate_limited(None)));
     }
 
@@ -771,6 +797,64 @@ mod tests {
         } else {
             panic!("Expected text response");
         }
+    }
+
+    #[tokio::test]
+    async fn test_fallback_rate_limit_policy_accepts_provider_classification() {
+        let primary = FailingMockModel::new(
+            "primary",
+            ModelError::provider(
+                "anthropic",
+                "rate_limit_error",
+                "slow down",
+                ProviderErrorKind::RateLimited,
+                Some(Duration::from_secs(3)),
+            ),
+        );
+        let backup = SucceedingMockModel::new("backup", "ok");
+        let backup_calls = backup.call_count.clone();
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::RateLimits);
+
+        let result = fallback
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fallback_transient_policy_accepts_provider_overload() {
+        let primary = FailingMockModel::new(
+            "primary",
+            ModelError::provider(
+                "anthropic",
+                "overloaded_error",
+                "busy",
+                ProviderErrorKind::Overloaded,
+                None,
+            ),
+        );
+        let backup = SucceedingMockModel::new("backup", "ok");
+        let backup_calls = backup.call_count.clone();
+        let fallback = FallbackModel::new(vec![Box::new(primary), Box::new(backup)])
+            .with_retry_on(RetryOn::Transient);
+
+        let result = fallback
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await;
+
+        assert!(result.is_ok());
+        assert_eq!(backup_calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/serdes-ai-models/src/fallback.rs
+++ b/serdes-ai-models/src/fallback.rs
@@ -362,12 +362,14 @@ mod tests {
                     code,
                     message,
                     kind,
+                    status,
                     retry_after,
                 } => Err(ModelError::Provider {
                     provider: provider.clone(),
                     code: code.clone(),
                     message: message.clone(),
                     kind: *kind,
+                    status: *status,
                     retry_after: *retry_after,
                 }),
                 ModelError::Http {

--- a/serdes-ai-models/src/lib.rs
+++ b/serdes-ai-models/src/lib.rs
@@ -162,7 +162,7 @@ pub use antigravity::AntigravityModel;
 pub mod mock;
 
 // Re-exports
-pub use error::{ModelError, ModelResult};
+pub use error::{ModelError, ModelResult, ProviderErrorKind};
 pub use fallback::{FallbackModel, RetryOn};
 pub use mock::{FunctionModel, MockModel, TestModel};
 pub use model::{

--- a/serdes-ai-models/src/lib.rs
+++ b/serdes-ai-models/src/lib.rs
@@ -160,6 +160,8 @@ pub use antigravity::AntigravityModel;
 
 // Mock for testing
 pub mod mock;
+/// Provider-neutral same-model retry orchestration.
+pub mod retry;
 
 // Re-exports
 pub use error::{ModelError, ModelResult, ProviderErrorKind};
@@ -174,7 +176,9 @@ pub use profile::{
     openai_gpt4o_profile, openai_o1_profile, qwen_profile, ModelProfile, OutputMode,
     DEFAULT_PROFILE, DEFAULT_PROMPTED_OUTPUT_TEMPLATE,
 };
+pub use retry::{ModelRetryExt, RetryingModel};
 pub use schema_transformer::JsonSchemaTransformer;
+pub use serdes_ai_retries::{RetryDecision, RetryFailure, RetryPolicy, WaitStrategy};
 
 // Re-export provider types for convenience
 #[cfg(feature = "openai")]
@@ -205,8 +209,8 @@ pub use bedrock::BedrockModel;
 pub mod prelude {
     pub use crate::{
         BoxedModel, FallbackModel, FunctionModel, MockModel, Model, ModelCapability, ModelError,
-        ModelProfile, ModelRequestParameters, ModelResult, RetryOn, StreamedResponse, TestModel,
-        ToolChoice,
+        ModelProfile, ModelRequestParameters, ModelResult, ModelRetryExt, RetryOn, RetryPolicy,
+        RetryingModel, StreamedResponse, TestModel, ToolChoice, WaitStrategy,
     };
 
     #[cfg(feature = "openai")]
@@ -285,7 +289,7 @@ pub fn infer_model(identifier: &str) -> ModelResult<std::sync::Arc<dyn Model>> {
             #[cfg(feature = "openai")]
             {
                 let model = OpenAIChatModel::from_env(model_name)?;
-                Ok(Arc::new(model))
+                Ok(Arc::new(model) as Arc<dyn Model>)
             }
             #[cfg(not(feature = "openai"))]
             {
@@ -298,7 +302,7 @@ pub fn infer_model(identifier: &str) -> ModelResult<std::sync::Arc<dyn Model>> {
             #[cfg(feature = "anthropic")]
             {
                 let model = AnthropicModel::from_env(model_name)?;
-                Ok(Arc::new(model))
+                Ok(Arc::new(model) as Arc<dyn Model>)
             }
             #[cfg(not(feature = "anthropic"))]
             {
@@ -310,37 +314,37 @@ pub fn infer_model(identifier: &str) -> ModelResult<std::sync::Arc<dyn Model>> {
         #[cfg(feature = "groq")]
         "groq" => {
             let model = GroqModel::from_env(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "mistral")]
         "mistral" => {
             let model = MistralModel::from_env(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "ollama")]
         "ollama" => {
             let model = OllamaModel::from_env(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "bedrock")]
         "bedrock" | "aws" => {
             let model = BedrockModel::new(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "openrouter")]
         "openrouter" | "or" => {
             let model = OpenRouterModel::from_env(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "huggingface")]
         "huggingface" | "hf" => {
             let model = HuggingFaceModel::from_env(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "cohere")]
         "cohere" | "co" => {
             let model = CohereModel::from_env(model_name)?;
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         _ => Err(ModelError::Configuration(format!(
             "Unknown provider: {}. Supported: openai, anthropic, groq, mistral, ollama, bedrock, openrouter, huggingface, cohere",
@@ -392,7 +396,7 @@ pub fn build_model_with_config(
                     model
                 };
 
-                Ok(Arc::new(model))
+                Ok(Arc::new(model) as Arc<dyn Model>)
             }
             #[cfg(not(feature = "openai"))]
             {
@@ -423,7 +427,7 @@ pub fn build_model_with_config(
                     model
                 };
 
-                Ok(Arc::new(model))
+                Ok(Arc::new(model) as Arc<dyn Model>)
             }
             #[cfg(not(feature = "anthropic"))]
             {
@@ -444,7 +448,7 @@ pub fn build_model_with_config(
             // GroqModel doesn't have with_base_url/with_timeout
             let _ = (base_url, timeout);
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "mistral")]
         "mistral" => {
@@ -466,7 +470,7 @@ pub fn build_model_with_config(
                 model
             };
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "ollama")]
         "ollama" => {
@@ -481,7 +485,7 @@ pub fn build_model_with_config(
             // Ollama doesn't use API keys or timeouts in the same way
             let _ = (api_key, timeout);
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "google")]
         "google" | "gemini" => {
@@ -507,7 +511,7 @@ pub fn build_model_with_config(
 
             let _ = timeout; // Google model doesn't have with_timeout
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         _ => Err(ModelError::Configuration(format!(
             "Unknown or unsupported provider: '{}'. Supported providers depend on enabled features: \
@@ -555,6 +559,8 @@ pub struct ExtendedModelConfig {
     pub thinking_budget: Option<u64>,
     /// Reasoning effort (OpenAI o1/o3)
     pub reasoning_effort: Option<String>,
+    /// Optional same-model retry policy. Retries are disabled when omitted.
+    pub retry_policy: Option<RetryPolicy>,
 }
 
 impl ExtendedModelConfig {
@@ -599,6 +605,18 @@ impl ExtendedModelConfig {
         self.reasoning_effort = Some(effort.into());
         self
     }
+
+    /// Enable same-model retries with the supplied policy.
+    pub fn with_retries(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = Some(policy);
+        self
+    }
+
+    /// Explicitly disable same-model retries.
+    pub fn without_retries(mut self) -> Self {
+        self.retry_policy = None;
+        self
+    }
 }
 
 /// Build a model with extended configuration options.
@@ -630,7 +648,8 @@ pub fn build_model_extended(
 ) -> ModelResult<std::sync::Arc<dyn Model>> {
     use std::sync::Arc;
 
-    match provider {
+    let retry_policy = config.retry_policy.clone();
+    let model: Arc<dyn Model> = match provider {
         "openai" | "gpt" => {
             #[cfg(feature = "openai")]
             {
@@ -660,7 +679,7 @@ pub fn build_model_extended(
                     model
                 };
 
-                Ok(Arc::new(model))
+                Ok(Arc::new(model) as Arc<dyn Model>)
             }
             #[cfg(not(feature = "openai"))]
             {
@@ -704,7 +723,7 @@ pub fn build_model_extended(
                     model
                 };
 
-                Ok(Arc::new(model))
+                Ok(Arc::new(model) as Arc<dyn Model>)
             }
             #[cfg(not(feature = "anthropic"))]
             {
@@ -728,7 +747,7 @@ pub fn build_model_extended(
                 model
             };
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "mistral")]
         "mistral" => {
@@ -756,7 +775,7 @@ pub fn build_model_extended(
                 model
             };
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "ollama")]
         "ollama" => {
@@ -774,7 +793,7 @@ pub fn build_model_extended(
                 model
             };
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         #[cfg(feature = "google")]
         "google" | "gemini" => {
@@ -802,11 +821,16 @@ pub fn build_model_extended(
                 model
             };
 
-            Ok(Arc::new(model))
+            Ok(Arc::new(model) as Arc<dyn Model>)
         }
         _ => Err(ModelError::Configuration(format!(
             "Unknown or unsupported provider: '{}'. Supported providers depend on enabled features.",
             provider
         ))),
-    }
+    }?;
+
+    Ok(match retry_policy {
+        Some(policy) => Arc::new(RetryingModel::from_arc(model, policy)),
+        None => model,
+    })
 }

--- a/serdes-ai-models/src/retry.rs
+++ b/serdes-ai-models/src/retry.rs
@@ -1,0 +1,497 @@
+//! Provider-neutral model retry orchestration.
+
+use crate::{
+    BoxedModel, Model, ModelError, ModelProfile, ModelRequestParameters, StreamedResponse,
+};
+use async_trait::async_trait;
+use futures::{stream, StreamExt};
+use serdes_ai_core::{ModelRequest, ModelResponse, ModelSettings};
+use serdes_ai_retries::{with_retry_policy, RetryDecision, RetryFailure, RetryPolicy};
+use std::sync::Arc;
+
+/// A model decorator that retries safe failures against the same model.
+pub struct RetryingModel {
+    inner: BoxedModel,
+    policy: RetryPolicy,
+}
+
+impl std::fmt::Debug for RetryingModel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RetryingModel")
+            .field("model", &self.inner.identifier())
+            .field("policy", &self.policy)
+            .finish()
+    }
+}
+
+impl RetryingModel {
+    /// Wrap a concrete model with a retry policy.
+    pub fn new<M: Model + 'static>(inner: M, policy: RetryPolicy) -> Self {
+        Self::from_arc(Arc::new(inner), policy)
+    }
+
+    /// Wrap a dynamically dispatched model with a retry policy.
+    pub fn from_arc(inner: BoxedModel, policy: RetryPolicy) -> Self {
+        Self { inner, policy }
+    }
+
+    /// Return the configured retry policy.
+    #[must_use]
+    pub fn policy(&self) -> &RetryPolicy {
+        &self.policy
+    }
+
+    /// Return the wrapped model.
+    #[must_use]
+    pub fn inner(&self) -> &BoxedModel {
+        &self.inner
+    }
+}
+
+/// Extension trait for adding same-model retries to a concrete model.
+pub trait ModelRetryExt: Model + Sized + 'static {
+    /// Wrap this model with the supplied retry policy.
+    fn with_retries(self, policy: RetryPolicy) -> RetryingModel {
+        RetryingModel::new(self, policy)
+    }
+}
+
+impl<M: Model + Sized + 'static> ModelRetryExt for M {}
+
+fn classify(error: &ModelError) -> RetryDecision {
+    if error.is_retryable() {
+        RetryDecision::Retry {
+            retry_after: error.retry_after(),
+        }
+    } else {
+        RetryDecision::DoNotRetry
+    }
+}
+
+fn adapt_failure(failure: RetryFailure<ModelError>) -> ModelError {
+    match failure {
+        RetryFailure::Permanent { error, .. } => error,
+        RetryFailure::Exhausted {
+            error, attempts: 1, ..
+        } => error,
+        RetryFailure::Exhausted {
+            error,
+            attempts,
+            elapsed,
+        } => ModelError::RetryExhausted {
+            attempts,
+            elapsed,
+            last_error: Box::new(error),
+        },
+        RetryFailure::DeadlineExceeded {
+            last_error,
+            attempts,
+            elapsed,
+        } => ModelError::RetryDeadlineExceeded {
+            attempts,
+            elapsed,
+            last_error: last_error.map(Box::new),
+        },
+    }
+}
+
+#[async_trait]
+impl Model for RetryingModel {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn system(&self) -> &str {
+        self.inner.system()
+    }
+
+    fn identifier(&self) -> String {
+        self.inner.identifier()
+    }
+
+    async fn request(
+        &self,
+        messages: &[ModelRequest],
+        settings: &ModelSettings,
+        params: &ModelRequestParameters,
+    ) -> Result<ModelResponse, ModelError> {
+        with_retry_policy(
+            &self.policy,
+            || self.inner.request(messages, settings, params),
+            classify,
+        )
+        .await
+        .map_err(adapt_failure)
+    }
+
+    async fn request_stream(
+        &self,
+        messages: &[ModelRequest],
+        settings: &ModelSettings,
+        params: &ModelRequestParameters,
+    ) -> Result<StreamedResponse, ModelError> {
+        with_retry_policy(
+            &self.policy,
+            || async {
+                let mut response = self
+                    .inner
+                    .request_stream(messages, settings, params)
+                    .await?;
+
+                match response.next().await {
+                    Some(Ok(event)) => Ok(Box::pin(
+                        stream::once(async move { Ok(event) }).chain(response),
+                    ) as StreamedResponse),
+                    Some(Err(error)) => Err(error),
+                    None => Ok(Box::pin(stream::empty()) as StreamedResponse),
+                }
+            },
+            classify,
+        )
+        .await
+        .map_err(adapt_failure)
+    }
+
+    fn profile(&self) -> &ModelProfile {
+        self.inner.profile()
+    }
+
+    async fn count_tokens(&self, messages: &[ModelRequest]) -> Result<u64, ModelError> {
+        // Token counting is intentionally not retried: providers currently implement it
+        // locally, while this policy governs model request transport operations.
+        self.inner.count_tokens(messages).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{FunctionModel, ProviderErrorKind, DEFAULT_PROFILE};
+    use futures::{stream, StreamExt};
+    use serdes_ai_core::{ModelResponsePart, TextPart};
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    #[derive(Debug)]
+    struct ScriptedRequestModel {
+        calls: Arc<AtomicU32>,
+        mode: RequestMode,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum RequestMode {
+        TransientThenSuccess,
+        Permanent,
+        ProviderOverload,
+    }
+
+    #[async_trait]
+    impl Model for ScriptedRequestModel {
+        fn name(&self) -> &str {
+            "scripted"
+        }
+
+        fn system(&self) -> &str {
+            "test"
+        }
+
+        async fn request(
+            &self,
+            _messages: &[ModelRequest],
+            _settings: &ModelSettings,
+            _params: &ModelRequestParameters,
+        ) -> Result<ModelResponse, ModelError> {
+            let attempt = self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.mode {
+                RequestMode::TransientThenSuccess if attempt == 0 => {
+                    Err(ModelError::Connection("reset".into()))
+                }
+                RequestMode::TransientThenSuccess => Ok(ModelResponse::text("ok")),
+                RequestMode::Permanent => Err(ModelError::auth("bad key")),
+                RequestMode::ProviderOverload => Err(ModelError::provider(
+                    "anthropic",
+                    "overloaded_error",
+                    "busy",
+                    ProviderErrorKind::Overloaded,
+                    Some(Duration::from_secs(2)),
+                )),
+            }
+        }
+
+        async fn request_stream(
+            &self,
+            _messages: &[ModelRequest],
+            _settings: &ModelSettings,
+            _params: &ModelRequestParameters,
+        ) -> Result<StreamedResponse, ModelError> {
+            Err(ModelError::not_supported("streaming"))
+        }
+
+        fn profile(&self) -> &ModelProfile {
+            &DEFAULT_PROFILE
+        }
+    }
+
+    fn request_args() -> (Vec<ModelRequest>, ModelSettings, ModelRequestParameters) {
+        (
+            vec![ModelRequest::new()],
+            ModelSettings::default(),
+            ModelRequestParameters::new(),
+        )
+    }
+
+    #[tokio::test]
+    async fn retries_transient_failure_then_succeeds() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let model = ScriptedRequestModel {
+            calls: calls.clone(),
+            mode: RequestMode::TransientThenSuccess,
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(2)
+                .wait(serdes_ai_retries::WaitStrategy::None)
+                .total_timeout(None),
+        );
+        let (messages, settings, params) = request_args();
+
+        let response = model.request(&messages, &settings, &params).await.unwrap();
+
+        assert_eq!(response.parts.len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn permanent_error_is_not_retried() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let model = ScriptedRequestModel {
+            calls: calls.clone(),
+            mode: RequestMode::Permanent,
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(3)
+                .wait(serdes_ai_retries::WaitStrategy::None),
+        );
+        let (messages, settings, params) = request_args();
+
+        let error = model
+            .request(&messages, &settings, &params)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, ModelError::Authentication(_)));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exhaustion_preserves_provider_metadata() {
+        let model = ScriptedRequestModel {
+            calls: Arc::new(AtomicU32::new(0)),
+            mode: RequestMode::ProviderOverload,
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(2)
+                .wait(serdes_ai_retries::WaitStrategy::None)
+                .total_timeout(None),
+        );
+        let (messages, settings, params) = request_args();
+
+        let error = model
+            .request(&messages, &settings, &params)
+            .await
+            .unwrap_err();
+
+        assert!(error.is_transient());
+        assert_eq!(error.retry_after(), Some(Duration::from_secs(2)));
+        match error {
+            ModelError::RetryExhausted {
+                attempts,
+                last_error,
+                ..
+            } => {
+                assert_eq!(attempts, 2);
+                assert!(matches!(
+                    *last_error,
+                    ModelError::Provider {
+                        code,
+                        message,
+                        ..
+                    } if code == "overloaded_error" && message == "busy"
+                ));
+            }
+            other => panic!("expected retry exhaustion, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn retries_first_stream_error_before_visible_output() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let model = {
+            let calls = calls.clone();
+            FunctionModel::with_stream(move |_, _| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Box::pin(stream::iter(vec![Err(ModelError::Connection(
+                        "reset".into(),
+                    ))]))
+                } else {
+                    Box::pin(stream::iter(vec![Ok(
+                        serdes_ai_core::ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("ok")),
+                        ),
+                    )]))
+                }
+            })
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(2)
+                .wait(serdes_ai_retries::WaitStrategy::None)
+                .total_timeout(None),
+        );
+        let (messages, settings, params) = request_args();
+
+        let events: Vec<_> = model
+            .request_stream(&messages, &settings, &params)
+            .await
+            .unwrap()
+            .collect()
+            .await;
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stream_retry_after_delays_before_visible_output() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let model = {
+            let calls = calls.clone();
+            FunctionModel::with_stream(move |_, _| {
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    Box::pin(stream::iter(vec![Err(ModelError::provider(
+                        "anthropic",
+                        "overloaded_error",
+                        "busy",
+                        ProviderErrorKind::Overloaded,
+                        Some(Duration::from_secs(2)),
+                    ))]))
+                } else {
+                    Box::pin(stream::iter(vec![Ok(
+                        serdes_ai_core::ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("ok")),
+                        ),
+                    )]))
+                }
+            })
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(2)
+                .wait(serdes_ai_retries::WaitStrategy::RetryAfter {
+                    fallback: Box::new(serdes_ai_retries::WaitStrategy::None),
+                    max_wait: Duration::from_secs(10),
+                })
+                .total_timeout(Some(Duration::from_secs(5))),
+        );
+        let (messages, settings, params) = request_args();
+
+        let started = tokio::time::Instant::now();
+        let events: Vec<_> = model
+            .request_stream(&messages, &settings, &params)
+            .await
+            .unwrap()
+            .collect()
+            .await;
+
+        assert_eq!(events.len(), 1);
+        assert!(events[0].is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+        assert_eq!(started.elapsed(), Duration::from_secs(2));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stream_acquisition_respects_total_deadline() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let model = {
+            let calls = calls.clone();
+            FunctionModel::with_stream(move |_, _| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Box::pin(stream::once(async {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    Err(ModelError::Connection("late reset".into()))
+                }))
+            })
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(3)
+                .wait(serdes_ai_retries::WaitStrategy::None)
+                .total_timeout(Some(Duration::from_secs(5))),
+        );
+        let (messages, settings, params) = request_args();
+
+        let error = match model.request_stream(&messages, &settings, &params).await {
+            Ok(_) => panic!("expected stream deadline error"),
+            Err(error) => error,
+        };
+
+        assert!(matches!(
+            error,
+            ModelError::RetryDeadlineExceeded {
+                attempts: 1,
+                last_error: None,
+                ..
+            }
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_replay_stream_after_visible_output() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let model = {
+            let calls = calls.clone();
+            FunctionModel::with_stream(move |_, _| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Box::pin(stream::iter(vec![
+                    Ok(serdes_ai_core::ModelResponseStreamEvent::part_start(
+                        0,
+                        ModelResponsePart::Text(TextPart::new("visible")),
+                    )),
+                    Err(ModelError::Connection("reset".into())),
+                ]))
+            })
+        };
+        let model = RetryingModel::new(
+            model,
+            RetryPolicy::for_model_requests()
+                .max_attempts(3)
+                .wait(serdes_ai_retries::WaitStrategy::None)
+                .total_timeout(None),
+        );
+        let (messages, settings, params) = request_args();
+
+        let events: Vec<_> = model
+            .request_stream(&messages, &settings, &params)
+            .await
+            .unwrap()
+            .collect()
+            .await;
+
+        assert_eq!(events.len(), 2);
+        assert!(events[0].is_ok());
+        assert!(matches!(events[1], Err(ModelError::Connection(_))));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+}

--- a/serdes-ai-providers/src/provider.rs
+++ b/serdes-ai-providers/src/provider.rs
@@ -151,7 +151,10 @@ impl ProviderConfig {
     }
 }
 
-/// Provider error types.
+/// Provider discovery and configuration errors.
+///
+/// Model-call transport/API failures use `serdes_ai_models::ModelError` and its
+/// canonical `serdes_ai_core::ModelFailure` classification instead.
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     /// Missing API key.

--- a/serdes-ai-retries/README.md
+++ b/serdes-ai-retries/README.md
@@ -22,18 +22,39 @@ serdes-ai-retries = "0.1"
 
 ## Usage
 
-```rust
-use serdes_ai_retries::{RetryStrategy, ExponentialBackoff};
+The provider-neutral executor retains the operation's original error type. Policies
+count total attempts, include backoff in the total time budget, and honor
+`Retry-After` when the classifier supplies it.
 
-let strategy = ExponentialBackoff::new()
-    .max_retries(3)
-    .initial_delay(Duration::from_millis(100))
-    .max_delay(Duration::from_secs(10));
+```rust,no_run
+use serdes_ai_retries::{
+    with_retry_policy, RetryDecision, RetryPolicy, WaitStrategy,
+};
+use std::time::Duration;
 
-let agent = Agent::new(model)
-    .retry_strategy(strategy)
-    .build();
+# async fn example() {
+let policy = RetryPolicy::for_model_requests()
+    .max_attempts(3)
+    .wait(WaitStrategy::Fixed(Duration::from_millis(100)))
+    .total_timeout(Some(Duration::from_secs(10)));
+
+let result = with_retry_policy(
+    &policy,
+    || async { Ok::<_, std::io::Error>("success") },
+    |error| match error.kind() {
+        std::io::ErrorKind::TimedOut | std::io::ErrorKind::ConnectionReset => {
+            RetryDecision::Retry { retry_after: None }
+        }
+        _ => RetryDecision::DoNotRetry,
+    },
+).await;
+# assert_eq!(result.unwrap(), "success");
+# }
 ```
+
+Dropping the returned future cancels an in-flight attempt or backoff immediately;
+the executor does not spawn a background retry task. Use
+`RetryPolicy::disabled()` for an explicit one-attempt policy.
 
 ## Part of SerdesAI
 

--- a/serdes-ai-retries/src/config.rs
+++ b/serdes-ai-retries/src/config.rs
@@ -3,6 +3,91 @@
 use crate::error::RetryableError;
 use std::time::Duration;
 
+/// Provider-neutral retry policy for operations that preserve their error type.
+///
+/// Unlike [`RetryConfig`], this policy counts total attempts. One attempt
+/// therefore disables retries while still executing the operation once.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    max_attempts: u32,
+    wait: WaitStrategy,
+    total_timeout: Option<Duration>,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self::for_model_requests()
+    }
+}
+
+impl RetryPolicy {
+    /// Create a policy with model-request defaults.
+    #[must_use]
+    pub fn for_model_requests() -> Self {
+        Self {
+            max_attempts: 3,
+            wait: WaitStrategy::RetryAfter {
+                fallback: Box::new(WaitStrategy::ExponentialJitter {
+                    initial: Duration::from_millis(500),
+                    max: Duration::from_secs(30),
+                    multiplier: 2.0,
+                    jitter: 0.1,
+                }),
+                max_wait: Duration::from_secs(60),
+            },
+            total_timeout: Some(Duration::from_secs(120)),
+        }
+    }
+
+    /// Create a policy that executes exactly one attempt.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self {
+            max_attempts: 1,
+            wait: WaitStrategy::None,
+            total_timeout: None,
+        }
+    }
+
+    /// Set the maximum number of attempts, clamped to at least one.
+    #[must_use]
+    pub fn max_attempts(mut self, max_attempts: u32) -> Self {
+        self.max_attempts = max_attempts.max(1);
+        self
+    }
+
+    /// Set the wait strategy between attempts.
+    #[must_use]
+    pub fn wait(mut self, wait: WaitStrategy) -> Self {
+        self.wait = wait;
+        self
+    }
+
+    /// Set the total time budget for attempts and backoff.
+    #[must_use]
+    pub fn total_timeout(mut self, total_timeout: Option<Duration>) -> Self {
+        self.total_timeout = total_timeout;
+        self
+    }
+
+    /// Return the maximum number of attempts.
+    #[must_use]
+    pub fn maximum_attempts(&self) -> u32 {
+        self.max_attempts
+    }
+
+    /// Return the configured wait strategy.
+    #[must_use]
+    pub fn wait_strategy(&self) -> &WaitStrategy {
+        &self.wait
+    }
+
+    /// Return the total time budget.
+    #[must_use]
+    pub fn total_time_budget(&self) -> Option<Duration> {
+        self.total_timeout
+    }
+}
 /// Configuration for retry behavior.
 #[derive(Debug, Clone)]
 pub struct RetryConfig {

--- a/serdes-ai-retries/src/error.rs
+++ b/serdes-ai-retries/src/error.rs
@@ -3,6 +3,37 @@
 use std::time::Duration;
 use thiserror::Error;
 
+/// Reason an operation governed by a [`crate::RetryPolicy`] did not succeed.
+#[derive(Debug)]
+pub enum RetryFailure<E> {
+    /// The error was classified as permanent.
+    Permanent {
+        /// Original error, preserved without conversion.
+        error: E,
+        /// Number of attempts made.
+        attempts: u32,
+        /// Time elapsed under the policy.
+        elapsed: Duration,
+    },
+    /// The maximum number of attempts was reached.
+    Exhausted {
+        /// Final error, preserved without conversion.
+        error: E,
+        /// Number of attempts made.
+        attempts: u32,
+        /// Time elapsed under the policy.
+        elapsed: Duration,
+    },
+    /// The total time budget expired.
+    DeadlineExceeded {
+        /// Most recent error, if an attempt failed before the deadline.
+        last_error: Option<E>,
+        /// Number of attempts started.
+        attempts: u32,
+        /// Time elapsed under the policy.
+        elapsed: Duration,
+    },
+}
 /// Errors that can be retried.
 #[derive(Debug, Error)]
 pub enum RetryableError {

--- a/serdes-ai-retries/src/error.rs
+++ b/serdes-ai-retries/src/error.rs
@@ -34,7 +34,10 @@ pub enum RetryFailure<E> {
         elapsed: Duration,
     },
 }
-/// Errors that can be retried.
+/// Legacy transport-level retry errors.
+///
+/// Model-call failures use `serdes_ai_core::ModelFailure`; this type remains
+/// scoped to the standalone HTTP retry client for backward compatibility.
 #[derive(Debug, Error)]
 pub enum RetryableError {
     /// HTTP error with status code.

--- a/serdes-ai-retries/src/executor.rs
+++ b/serdes-ai-retries/src/executor.rs
@@ -1,11 +1,109 @@
 //! Retry executor for running operations with retries.
 
-use crate::config::RetryConfig;
-use crate::error::{RetryResult, RetryableError};
+use crate::config::{RetryConfig, RetryPolicy};
+use crate::error::{RetryFailure, RetryResult, RetryableError};
 use std::future::Future;
 use std::time::Duration;
-use tokio::time::sleep;
+use tokio::time::{sleep, sleep_until, timeout_at, Instant};
 use tracing::{debug, warn};
+
+/// Classification returned to the generic retry executor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetryDecision {
+    /// Retry the operation, optionally honoring a provider-supplied delay.
+    Retry {
+        /// Provider-supplied minimum delay.
+        retry_after: Option<Duration>,
+    },
+    /// Return the original error without another attempt.
+    DoNotRetry,
+}
+
+/// Execute an operation under a provider-neutral retry policy.
+///
+/// The original error type is retained. Dropping this future cancels an
+/// in-flight attempt or backoff because no background task is spawned.
+pub async fn with_retry_policy<F, Fut, T, E, C>(
+    policy: &RetryPolicy,
+    mut operation: F,
+    classify: C,
+) -> Result<T, RetryFailure<E>>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    C: Fn(&E) -> RetryDecision,
+{
+    let started = Instant::now();
+    let deadline = policy.total_time_budget().map(|budget| started + budget);
+    let mut attempts = 0;
+    let mut last_error = None;
+
+    loop {
+        attempts += 1;
+        let result = if let Some(deadline) = deadline {
+            match timeout_at(deadline, operation()).await {
+                Ok(result) => result,
+                Err(_) => {
+                    return Err(RetryFailure::DeadlineExceeded {
+                        last_error,
+                        attempts,
+                        elapsed: started.elapsed(),
+                    });
+                }
+            }
+        } else {
+            operation().await
+        };
+
+        match result {
+            Ok(value) => return Ok(value),
+            Err(error) => match classify(&error) {
+                RetryDecision::DoNotRetry => {
+                    return Err(RetryFailure::Permanent {
+                        error,
+                        attempts,
+                        elapsed: started.elapsed(),
+                    });
+                }
+                RetryDecision::Retry { retry_after } => {
+                    if attempts >= policy.maximum_attempts() {
+                        return Err(RetryFailure::Exhausted {
+                            error,
+                            attempts,
+                            elapsed: started.elapsed(),
+                        });
+                    }
+
+                    let wait = policy.wait_strategy().calculate(attempts, retry_after);
+                    if let Some(deadline) = deadline {
+                        let now = Instant::now();
+                        if now >= deadline {
+                            return Err(RetryFailure::DeadlineExceeded {
+                                last_error: Some(error),
+                                attempts,
+                                elapsed: started.elapsed(),
+                            });
+                        }
+
+                        let wake_at = now.checked_add(wait).unwrap_or(deadline);
+                        if wake_at >= deadline {
+                            last_error = Some(error);
+                            sleep_until(deadline).await;
+                            return Err(RetryFailure::DeadlineExceeded {
+                                last_error,
+                                attempts,
+                                elapsed: started.elapsed(),
+                            });
+                        }
+                    }
+
+                    last_error = Some(error);
+                    sleep(wait).await;
+                }
+            },
+        }
+    }
+}
 
 /// State of a retry attempt.
 #[derive(Debug, Clone)]
@@ -285,6 +383,111 @@ mod tests {
 
         assert!(result.is_err());
         // Should only try once since 400 is not retryable
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn generic_policy_honors_retry_after() {
+        let policy = RetryPolicy::for_model_requests()
+            .max_attempts(2)
+            .wait(crate::WaitStrategy::RetryAfter {
+                fallback: Box::new(crate::WaitStrategy::None),
+                max_wait: Duration::from_secs(60),
+            })
+            .total_timeout(Some(Duration::from_secs(30)));
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+
+        let task = tokio::spawn(async move {
+            with_retry_policy(
+                &policy,
+                || {
+                    let counter = counter.clone();
+                    async move {
+                        if counter.fetch_add(1, Ordering::SeqCst) == 0 {
+                            Err::<u32, &'static str>("rate limited")
+                        } else {
+                            Ok(42)
+                        }
+                    }
+                },
+                |_| RetryDecision::Retry {
+                    retry_after: Some(Duration::from_secs(5)),
+                },
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        tokio::time::advance(Duration::from_secs(4)).await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        tokio::time::advance(Duration::from_secs(1)).await;
+        assert_eq!(task.await.unwrap().unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn total_deadline_prevents_another_attempt() {
+        let policy = RetryPolicy::for_model_requests()
+            .max_attempts(3)
+            .wait(crate::WaitStrategy::Fixed(Duration::from_secs(10)))
+            .total_timeout(Some(Duration::from_secs(3)));
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+
+        let task = tokio::spawn(async move {
+            with_retry_policy(
+                &policy,
+                || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Err::<(), &'static str>("transient")
+                    }
+                },
+                |_| RetryDecision::Retry { retry_after: None },
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        assert!(matches!(
+            task.await.unwrap(),
+            Err(RetryFailure::DeadlineExceeded { attempts: 1, .. })
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropping_future_cancels_backoff() {
+        let policy = RetryPolicy::for_model_requests()
+            .max_attempts(3)
+            .wait(crate::WaitStrategy::Fixed(Duration::from_secs(10)))
+            .total_timeout(None);
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+
+        let task = tokio::spawn(async move {
+            with_retry_policy(
+                &policy,
+                || {
+                    let counter = counter.clone();
+                    async move {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        Err::<(), &'static str>("transient")
+                    }
+                },
+                |_| RetryDecision::Retry { retry_after: None },
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+        task.abort();
+        tokio::time::advance(Duration::from_secs(20)).await;
         assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 

--- a/serdes-ai-retries/src/lib.rs
+++ b/serdes-ai-retries/src/lib.rs
@@ -63,17 +63,20 @@ pub mod transport;
 
 // Re-exports
 pub use backoff::{ExponentialBackoff, ExponentialBackoffBuilder, FixedDelay, LinearBackoff};
-pub use config::{RetryCondition, RetryConfig, WaitStrategy};
-pub use error::{RetryResult, RetryableError};
-pub use executor::{with_retry, with_retry_state, AttemptInfo, Retry, RetryState};
+pub use config::{RetryCondition, RetryConfig, RetryPolicy, WaitStrategy};
+pub use error::{RetryFailure, RetryResult, RetryableError};
+pub use executor::{
+    with_retry, with_retry_policy, with_retry_state, AttemptInfo, Retry, RetryDecision, RetryState,
+};
 pub use strategy::{NoRetry, RetryStrategy};
 pub use transport::{RetryClient, RetryClientBuilder};
 
 /// Prelude for common imports.
 pub mod prelude {
     pub use crate::{
-        with_retry, ExponentialBackoff, Retry, RetryClient, RetryConfig, RetryResult,
-        RetryStrategy, RetryableError, WaitStrategy,
+        with_retry, with_retry_policy, ExponentialBackoff, Retry, RetryClient, RetryConfig,
+        RetryDecision, RetryFailure, RetryPolicy, RetryResult, RetryStrategy, RetryableError,
+        WaitStrategy,
     };
 }
 

--- a/serdes-ai-streaming/src/error.rs
+++ b/serdes-ai-streaming/src/error.rs
@@ -61,6 +61,14 @@ pub enum StreamError {
     #[error("SSE buffer exceeded maximum size")]
     BufferOverflow,
 
+    /// The SSE byte stream contained invalid UTF-8.
+    #[error("SSE stream contained invalid UTF-8")]
+    InvalidUtf8,
+
+    /// The transport ended with an unterminated SSE record.
+    #[error("SSE stream ended with an incomplete record")]
+    IncompleteSse,
+
     /// Other error.
     #[error("{0}")]
     Other(String),

--- a/serdes-ai-streaming/src/sse.rs
+++ b/serdes-ai-streaming/src/sse.rs
@@ -62,11 +62,23 @@ impl SseEvent {
 }
 
 /// Parser for Server-Sent Events streams.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SseParser {
-    buffer: String,
+    buffer: Vec<u8>,
     events: VecDeque<SseEvent>,
     last_event_id: Option<String>,
+    max_buffer_size: usize,
+}
+
+impl Default for SseParser {
+    fn default() -> Self {
+        Self {
+            buffer: Vec::new(),
+            events: VecDeque::new(),
+            last_event_id: None,
+            max_buffer_size: MAX_BUFFER_SIZE,
+        }
+    }
 }
 
 impl SseParser {
@@ -76,40 +88,34 @@ impl SseParser {
         Self::default()
     }
 
+    /// Set the maximum number of unframed bytes retained by the parser.
+    #[must_use]
+    pub fn with_max_buffer_size(mut self, max_buffer_size: usize) -> Self {
+        self.max_buffer_size = max_buffer_size;
+        self
+    }
+
     /// Feed bytes into the parser.
     pub fn feed(&mut self, bytes: &Bytes) -> StreamResult<Vec<SseEvent>> {
-        let chunk = String::from_utf8_lossy(bytes);
-        self.feed_str(&chunk)
+        self.buffer.extend_from_slice(bytes);
+        self.validate_buffer()?;
+        self.parse_buffer()
     }
 
     /// Feed a string into the parser.
     pub fn feed_str(&mut self, s: &str) -> StreamResult<Vec<SseEvent>> {
-        self.buffer.push_str(s);
-
-        if self.buffer.len() > MAX_BUFFER_SIZE {
-            return Err(StreamError::BufferOverflow);
-        }
-
-        self.parse_buffer()
+        self.feed(&Bytes::copy_from_slice(s.as_bytes()))
     }
 
-    /// Call when stream ends to flush any remaining event.
+    /// Validate that EOF occurred at an SSE record boundary.
     pub fn finish(&mut self) -> StreamResult<Vec<SseEvent>> {
-        let mut events = self.parse_buffer()?;
-
-        if !self.buffer.trim().is_empty() {
-            if let Some(event) = self.parse_event(self.buffer.trim_end_matches(['\n', '\r'])) {
-                if let Some(id) = &event.id {
-                    self.last_event_id = Some(id.clone());
-                }
-                self.events.push_back(event.clone());
-                events.push(event);
-            }
+        let events = self.parse_buffer()?;
+        if self.buffer.is_empty() {
+            Ok(events)
+        } else {
+            self.validate_buffer()?;
+            Err(StreamError::IncompleteSse)
         }
-
-        self.buffer.clear();
-
-        Ok(events)
     }
 
     /// Get the next parsed event.
@@ -133,16 +139,27 @@ impl SseParser {
         self.events.clear();
     }
 
+    fn validate_buffer(&self) -> StreamResult<()> {
+        if self.buffer.len() > self.max_buffer_size {
+            return Err(StreamError::BufferOverflow);
+        }
+        if let Err(error) = std::str::from_utf8(&self.buffer) {
+            if error.error_len().is_some() {
+                return Err(StreamError::InvalidUtf8);
+            }
+        }
+        Ok(())
+    }
+
     fn parse_buffer(&mut self) -> StreamResult<Vec<SseEvent>> {
         let mut parsed_events = Vec::new();
 
-        // Split by double newlines (event boundaries)
-        while let Some((pos, delimiter_len)) = self.find_event_boundary() {
-            let event_str = self.buffer[..pos].to_string();
-            self.buffer = self.buffer[pos + delimiter_len..].to_string();
-            self.buffer = self.buffer.trim_start_matches(['\n', '\r']).to_string();
+        while let Some((pos, delimiter_len)) = find_event_boundary(&self.buffer) {
+            let frame = self.buffer[..pos].to_vec();
+            self.buffer.drain(..pos + delimiter_len);
+            let event_str = std::str::from_utf8(&frame).map_err(|_| StreamError::InvalidUtf8)?;
 
-            if let Some(event) = self.parse_event(&event_str) {
+            if let Some(event) = self.parse_event(event_str) {
                 if let Some(id) = &event.id {
                     self.last_event_id = Some(id.clone());
                 }
@@ -151,19 +168,8 @@ impl SseParser {
             }
         }
 
+        self.validate_buffer()?;
         Ok(parsed_events)
-    }
-
-    fn find_event_boundary(&self) -> Option<(usize, usize)> {
-        let newline = self.buffer.find("\n\n").map(|pos| (pos, 2));
-        let carriage = self.buffer.find("\r\n\r\n").map(|pos| (pos, 4));
-
-        match (newline, carriage) {
-            (Some(nl), Some(cr)) => Some(if cr.0 < nl.0 { cr } else { nl }),
-            (Some(nl), None) => Some(nl),
-            (None, Some(cr)) => Some(cr),
-            (None, None) => None,
-        }
     }
 
     fn parse_event(&self, s: &str) -> Option<SseEvent> {
@@ -171,24 +177,24 @@ impl SseParser {
         let mut data_lines = Vec::new();
         let mut id = None;
         let mut retry = None;
+        let normalized = s.replace("\r\n", "\n").replace('\r', "\n");
 
-        for line in s.lines() {
+        for line in normalized.split('\n') {
             if line.is_empty() || line.starts_with(':') {
-                // Comment or empty line
                 continue;
             }
 
-            if let Some(value) = line.strip_prefix("event:") {
-                event = Some(value.trim().to_string());
-            } else if let Some(value) = line.strip_prefix("data:") {
-                data_lines.push(value.trim_start().to_string());
-            } else if let Some(value) = line.strip_prefix("id:") {
-                id = Some(value.trim().to_string());
-            } else if let Some(value) = line.strip_prefix("retry:") {
-                retry = value.trim().parse().ok();
-            } else if line.starts_with("data") {
-                // "data" without colon means empty data line
-                data_lines.push(String::new());
+            let (field, value) = match line.split_once(':') {
+                Some((field, value)) => (field, value.strip_prefix(' ').unwrap_or(value)),
+                None => (line, ""),
+            };
+
+            match field {
+                "event" => event = Some(value.to_string()),
+                "data" => data_lines.push(value.to_string()),
+                "id" if !value.contains('\0') => id = Some(value.to_string()),
+                "retry" => retry = value.parse().ok(),
+                _ => {}
             }
         }
 
@@ -205,11 +211,25 @@ impl SseParser {
     }
 }
 
+fn find_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
+    const DELIMITERS: [&[u8]; 3] = [b"\r\n\r\n", b"\n\n", b"\r\r"];
+    DELIMITERS
+        .iter()
+        .filter_map(|delimiter| {
+            buffer
+                .windows(delimiter.len())
+                .position(|window| window == *delimiter)
+                .map(|position| (position, delimiter.len()))
+        })
+        .min_by_key(|(position, _)| *position)
+}
+
 pin_project! {
     /// Stream adapter that parses SSE from a byte stream.
     pub struct SseStream<S> {
         #[pin]
         inner: S,
+
         parser: SseParser,
         finished: bool,
     }
@@ -441,12 +461,10 @@ mod tests {
 
     #[test]
     fn test_sse_to_response_delta() {
-        // Test [DONE] event
         let done_event = SseEvent::data("[DONE]");
         let delta = done_event.to_response_delta().unwrap();
         assert!(matches!(delta, ResponseDelta::Finish { .. }));
 
-        // Test OpenAI format
         let openai_event = SseEvent::data(r#"{"choices":[{"delta":{"content":"Hello"}}]}"#);
         let delta = openai_event.to_response_delta().unwrap();
         if let ResponseDelta::Text { content, .. } = delta {
@@ -454,5 +472,64 @@ mod tests {
         } else {
             panic!("Expected text delta");
         }
+    }
+
+    #[test]
+    fn strict_framing_corpus() {
+        for input in ["data: no-space\n\n", "data:no-space\r\n\r\n"] {
+            let mut parser = SseParser::new();
+            parser.feed_str(input).unwrap();
+            assert_eq!(parser.next_event().unwrap().data, "no-space");
+        }
+
+        let mut parser = SseParser::new();
+        parser
+            .feed_str(": comment\r\nevent: update\r\nid: 7\r\nretry: 100\r\ndata: one\r\ndata:two\r\n\r\n")
+            .unwrap();
+        let event = parser.next_event().unwrap();
+        assert_eq!(event.event.as_deref(), Some("update"));
+        assert_eq!(event.id.as_deref(), Some("7"));
+        assert_eq!(event.retry, Some(100));
+        assert_eq!(event.data, "one\ntwo");
+
+        let mut parser = SseParser::new();
+        parser.feed_str(": comment only\n\n").unwrap();
+        assert!(parser.next_event().is_none());
+    }
+
+    #[test]
+    fn framing_is_invariant_at_every_byte_boundary() {
+        let input = "event: message\ndata: héllo\n\n".as_bytes();
+        for split in 0..=input.len() {
+            let mut parser = SseParser::new();
+            parser
+                .feed(&Bytes::copy_from_slice(&input[..split]))
+                .unwrap();
+            parser
+                .feed(&Bytes::copy_from_slice(&input[split..]))
+                .unwrap();
+            let event = parser.next_event().unwrap();
+            assert_eq!(event.event.as_deref(), Some("message"));
+            assert_eq!(event.data, "héllo");
+        }
+    }
+
+    #[test]
+    fn strict_parser_rejects_invalid_utf8_incomplete_eof_and_overflow() {
+        let mut parser = SseParser::new();
+        assert!(matches!(
+            parser.feed(&Bytes::from_static(b"data: \xff\n\n")),
+            Err(StreamError::InvalidUtf8)
+        ));
+
+        let mut parser = SseParser::new();
+        parser.feed_str("data: partial").unwrap();
+        assert!(matches!(parser.finish(), Err(StreamError::IncompleteSse)));
+
+        let mut parser = SseParser::new().with_max_buffer_size(4);
+        assert!(matches!(
+            parser.feed_str("data:"),
+            Err(StreamError::BufferOverflow)
+        ));
     }
 }

--- a/serdes-ai-streaming/src/sse.rs
+++ b/serdes-ai-streaming/src/sse.rs
@@ -98,8 +98,13 @@ impl SseParser {
     /// Feed bytes into the parser.
     pub fn feed(&mut self, bytes: &Bytes) -> StreamResult<Vec<SseEvent>> {
         self.buffer.extend_from_slice(bytes);
-        self.validate_buffer()?;
-        self.parse_buffer()
+        match self.parse_buffer() {
+            Ok(events) => Ok(events),
+            Err(error) => {
+                self.clear();
+                Err(error)
+            }
+        }
     }
 
     /// Feed a string into the parser.
@@ -109,11 +114,17 @@ impl SseParser {
 
     /// Validate that EOF occurred at an SSE record boundary.
     pub fn finish(&mut self) -> StreamResult<Vec<SseEvent>> {
-        let events = self.parse_buffer()?;
+        let events = match self.parse_buffer() {
+            Ok(events) => events,
+            Err(error) => {
+                self.clear();
+                return Err(error);
+            }
+        };
         if self.buffer.is_empty() {
             Ok(events)
         } else {
-            self.validate_buffer()?;
+            self.clear();
             Err(StreamError::IncompleteSse)
         }
     }
@@ -137,6 +148,7 @@ impl SseParser {
     pub fn clear(&mut self) {
         self.buffer.clear();
         self.events.clear();
+        self.last_event_id = None;
     }
 
     fn validate_buffer(&self) -> StreamResult<()> {
@@ -155,6 +167,9 @@ impl SseParser {
         let mut parsed_events = Vec::new();
 
         while let Some((pos, delimiter_len)) = find_event_boundary(&self.buffer) {
+            if pos > self.max_buffer_size {
+                return Err(StreamError::BufferOverflow);
+            }
             let frame = self.buffer[..pos].to_vec();
             self.buffer.drain(..pos + delimiter_len);
             let event_str = std::str::from_utf8(&frame).map_err(|_| StreamError::InvalidUtf8)?;
@@ -271,6 +286,7 @@ where
         match this.inner.poll_next_unpin(cx) {
             Poll::Ready(Some(Ok(bytes))) => {
                 if let Err(error) = this.parser.feed(&bytes) {
+                    *this.finished = true;
                     return Poll::Ready(Some(Err(error)));
                 }
 
@@ -281,7 +297,11 @@ where
                     Poll::Pending
                 }
             }
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(StreamError::Io(e)))),
+            Poll::Ready(Some(Err(e))) => {
+                *this.finished = true;
+                this.parser.clear();
+                Poll::Ready(Some(Err(StreamError::Io(e))))
+            }
             Poll::Ready(None) => {
                 *this.finished = true;
 
@@ -521,15 +541,45 @@ mod tests {
             parser.feed(&Bytes::from_static(b"data: \xff\n\n")),
             Err(StreamError::InvalidUtf8)
         ));
+        assert!(!parser.has_events());
 
         let mut parser = SseParser::new();
         parser.feed_str("data: partial").unwrap();
         assert!(matches!(parser.finish(), Err(StreamError::IncompleteSse)));
+        assert!(!parser.has_events());
 
         let mut parser = SseParser::new().with_max_buffer_size(4);
         assert!(matches!(
             parser.feed_str("data:"),
             Err(StreamError::BufferOverflow)
         ));
+
+        let mut parser = SseParser::new().with_max_buffer_size(4);
+        assert!(matches!(
+            parser.feed_str("data: oversized\n\n"),
+            Err(StreamError::BufferOverflow)
+        ));
+    }
+
+    #[test]
+    fn buffer_limit_applies_per_frame_and_residual_not_aggregate_chunk() {
+        let mut parser = SseParser::new().with_max_buffer_size(8);
+        let input = "data: a\n\n".repeat(32);
+
+        let events = parser.feed_str(&input).unwrap();
+
+        assert_eq!(events.len(), 32);
+        assert!(events.iter().all(|event| event.data == "a"));
+    }
+
+    #[test]
+    fn parse_error_discards_events_parsed_from_the_same_chunk() {
+        let mut parser = SseParser::new().with_max_buffer_size(8);
+
+        assert!(matches!(
+            parser.feed_str("data: a\n\ndata: oversized\n\n"),
+            Err(StreamError::BufferOverflow)
+        ));
+        assert!(!parser.has_events());
     }
 }

--- a/serdes-ai/Cargo.toml
+++ b/serdes-ai/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serdes-ai"
-description = "Type-safe, production-ready AI agent framework for Rust - a full port of pydantic-ai"
+description = "Type-safe Rust AI agent framework inspired by pydantic-ai"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/serdes-ai/README.md
+++ b/serdes-ai/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://docs.rs/serdes-ai/badge.svg)](https://docs.rs/serdes-ai)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/janfeddersen-wq/serdesAI/blob/main/LICENSE)
 
-> Type-safe, production-ready AI agent framework for Rust - a full port of pydantic-ai
+> Type-safe Rust AI agent framework inspired by pydantic-ai; parity is ongoing
 
 This is the main facade crate that re-exports all SerdesAI functionality for convenient use.
 
@@ -57,8 +57,19 @@ let agent = AgentBuilder::new(model).build();
 ```
 
 Retries are opt-in and repeat the same model. `FallbackModel` remains the
-separate mechanism for selecting another model. Streaming acquisition can retry
-before its first visible event; errors after that boundary are never replayed.
+separate mechanism for selecting another model. A streaming retry or fallback
+can occur only before its first event; metadata also counts as exposure. Errors
+after that boundary are propagated without replay or concatenation.
+
+## Parity and readiness
+
+SerdesAI provides Rust-native typed agents, tools, streaming, retries, fallback,
+graphs, MCP, embeddings, and evaluation crates. It does not currently claim full
+API or behavioral parity with pydantic-ai. The capability audit is tied to this
+repository's upstream revision
+`be5774b5c618a71fe899ac5b8c6a5e958ea42a5d` (2026-07-13); consult the root
+README capability matrix and test the exact providers and features required by
+your deployment before treating a configuration as production-ready.
 
 ## Part of SerdesAI
 

--- a/serdes-ai/README.md
+++ b/serdes-ai/README.md
@@ -65,11 +65,12 @@ after that boundary are propagated without replay or concatenation.
 
 SerdesAI provides Rust-native typed agents, tools, streaming, retries, fallback,
 graphs, MCP, embeddings, and evaluation crates. It does not currently claim full
-API or behavioral parity with pydantic-ai. The capability audit is tied to this
-repository's upstream revision
-`be5774b5c618a71fe899ac5b8c6a5e958ea42a5d` (2026-07-13); consult the root
-README capability matrix and test the exact providers and features required by
-your deployment before treating a configuration as production-ready.
+API or behavioral parity with pydantic-ai. The capability matrix uses pydantic-ai
+v2.9.1 (`bf9a2435de41aaf269fc6bc72fe641f2fa0465c6`) as its comparison target and
+SerdesAI upstream revision `be5774b5c618a71fe899ac5b8c6a5e958ea42a5d` as the
+implementation audit baseline. Consult the root README matrix and test the exact
+providers and features required by your deployment before treating a
+configuration as production-ready.
 
 ## Part of SerdesAI
 

--- a/serdes-ai/README.md
+++ b/serdes-ai/README.md
@@ -42,6 +42,24 @@ async fn main() -> anyhow::Result<()> {
 - 🔄 **Smart Retries** - Configurable retry strategies
 - 🔀 **Graph Workflows** - Complex multi-agent orchestration
 
+## Configuring retries
+
+```rust,ignore
+use serdes_ai::prelude::*;
+use std::time::Duration;
+
+let model = OpenAIChatModel::from_env("gpt-4o")?.with_retries(
+    RetryPolicy::for_model_requests()
+        .max_attempts(3)
+        .total_timeout(Some(Duration::from_secs(30))),
+);
+let agent = AgentBuilder::new(model).build();
+```
+
+Retries are opt-in and repeat the same model. `FallbackModel` remains the
+separate mechanism for selecting another model. Streaming acquisition can retry
+before its first visible event; errors after that boundary are never replayed.
+
 ## Part of SerdesAI
 
 This crate is part of the [SerdesAI](https://github.com/janfeddersen-wq/serdesAI) workspace.

--- a/serdes-ai/src/lib.rs
+++ b/serdes-ai/src/lib.rs
@@ -360,8 +360,10 @@ pub use serdes_ai_output::{
 pub use serdes_ai_streaming::{ResponseDelta, ResponseStream};
 
 // Retries
+pub use serdes_ai_models::{ModelRetryExt, RetryingModel};
 pub use serdes_ai_retries::{
-    ExponentialBackoff, FixedDelay, LinearBackoff, RetryConfig, RetryStrategy,
+    ExponentialBackoff, FixedDelay, LinearBackoff, RetryConfig, RetryDecision, RetryFailure,
+    RetryPolicy, RetryStrategy, WaitStrategy,
 };
 
 // Direct model access
@@ -428,7 +430,7 @@ pub mod prelude {
     };
 
     // Models
-    pub use crate::models::Model;
+    pub use crate::models::{Model, ModelRetryExt, RetryingModel};
 
     #[cfg(feature = "openai")]
     pub use crate::models::openai::OpenAIChatModel;
@@ -453,7 +455,10 @@ pub mod prelude {
     pub use crate::streaming::{ResponseDelta, ResponseStream};
 
     // Retries
-    pub use crate::retries::{ExponentialBackoff, RetryConfig, RetryStrategy};
+    pub use crate::retries::{
+        ExponentialBackoff, RetryConfig, RetryDecision, RetryFailure, RetryPolicy, RetryStrategy,
+        WaitStrategy,
+    };
 
     // Direct model access
     pub use crate::direct::{model_request, model_request_stream, DirectError, ModelSpec};

--- a/serdes-ai/src/lib.rs
+++ b/serdes-ai/src/lib.rs
@@ -1,7 +1,7 @@
 //! # SerdesAI - Type-Safe AI Agent Framework for Rust
 //!
 //! SerdesAI is a comprehensive Rust library for building AI agents that interact with
-//! large language models (LLMs). It is a complete port of [pydantic-ai](https://github.com/pydantic/pydantic-ai)
+//! large language models (LLMs). It is inspired by [pydantic-ai](https://github.com/pydantic/pydantic-ai), with parity work ongoing,
 //! to Rust, providing type-safe, ergonomic APIs for creating intelligent agents.
 //!
 //! ## Quick Start


### PR DESCRIPTION
## Summary

Closes the streaming-integrity and resilience gaps tracked by #46 and implements the child work in #39, #40, #41, #42, #43, #44, and #45.

- require provider-confirmed terminal events before committing streamed responses
- reject premature EOF, malformed JSON, invalid UTF-8, incomplete SSE records, and open content blocks
- preserve Anthropic finish reasons and complete token/cache usage metadata
- classify provider/model failures consistently with source, status, retry, and attempt context
- wire opt-in same-model retries with deadline, cancellation, and `Retry-After` behavior
- permit streaming retry/fallback only before the first caller-visible event
- share strict bounded SSE framing and avoid aggregate-chunk false overflows
- qualify readiness claims and tie the capability matrix to pydantic-ai v2.9.1
- disable incremental workspace builds to prevent all-feature verification from exhausting disk

## Issue classification

- **Correctness:** #39, #40, #41
- **Advertised-feature gaps:** #42, #43
- **Architecture:** #44, #45
- **Tracking/documentation:** #46

## Streaming invariants

- Every emitted event, including metadata and terminal events, counts as caller-visible exposure.
- Retry or fallback may occur only before the first event is exposed.
- Errors after exposure propagate without replaying or concatenating output.
- Anthropic success requires `message_stop`, complete framing, closed content blocks, and valid tool JSON.
- Invalid partial responses are never committed to canonical history or executed as complete tool calls.

## Verification

Run from a clean build with Cargo incremental compilation disabled:

- `CARGO_TERM_COLOR=always RUSTFLAGS=-Dwarnings cargo check --workspace --all-features`
- `CARGO_TERM_COLOR=always RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-features -- -D warnings`
- `CARGO_TERM_COLOR=always RUSTFLAGS=-Dwarnings cargo test --workspace --all-features`
- `CARGO_TERM_COLOR=always RUSTFLAGS=-Dwarnings cargo fmt --all -- --check`
- `git diff --check`

All passed locally on Rust 1.97.0.

Closes #39
Closes #40
Closes #41
Closes #42
Closes #43
Closes #44
Closes #45
Closes #46
