### PR TITLE
Nix: fix native-tls builds and update toolchain.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773476965,
-        "narHash": "sha256-Laaj25PvGeoP5SPhMfMGxvWqM6ZjZ6LdUeEhP6b3czY=",
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f82ce7af0b79ac154b12e27ed800aeb97413723c",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773457417,
-        "narHash": "sha256-waABTSxPdbxml4BhcabHhyQF02Qnj27qRU4ard0mTQo=",
+        "lastModified": 1787281715,
+        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "055977c30249484010750e03074c744dcdaa0d23",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,12 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = [ rust pkgs.openssl pkgs.pkg-config pkgs.clang pkgs.lld ];
+          # openssl-sys discovery: explicit lib/include dirs; pkg-config as fallback.
+          OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+          OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+          # Runtime resolution of libssl.so.3 for binaries built in the shell.
+          LD_LIBRARY_PATH = "${pkgs.openssl.out}/lib";
         };
       }
     );


### PR DESCRIPTION
## Summary
- Bump nixpkgs lock from 2026-03-14 to 2026-08-20.
- Update rust-overlay, which moves the locked Rust stable toolchain.
- Export OpenSSL paths in the devshell so `native-tls` builds work.
  `OPENSSL_LIB_DIR` and `OPENSSL_INCLUDE_DIR` pin openssl-sys to the
  shell's store OpenSSL; `PKG_CONFIG_PATH` adds a pkg-config fallback.
- Set `LD_LIBRARY_PATH` so builds with `native-tls` work.

## Why
`native-tls` was borked on Nix.