### PR TITLE
Emit StreamComplete for run_stream with token usage stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "futures",
  "pretty_assertions",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-a2a"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-agent"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-core"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-embeddings"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-evals"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-graph"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-macros"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-mcp"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-models"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-output"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-providers"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-retries"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-streaming"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-tools"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-toolsets"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-ui"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["serdes-ai contributors"]
@@ -93,21 +93,21 @@ pretty_assertions = "1.4"
 regex = "1.12"
 
 # Internal crates
-serdes-ai-core = { path = "serdes-ai-core", version = "0.2.6" }
-serdes-ai-agent = { path = "serdes-ai-agent", version = "0.2.6" }
-serdes-ai-models = { path = "serdes-ai-models", version = "0.2.6" }
-serdes-ai-providers = { path = "serdes-ai-providers", version = "0.2.6" }
-serdes-ai-tools = { path = "serdes-ai-tools", version = "0.2.6" }
-serdes-ai-toolsets = { path = "serdes-ai-toolsets", version = "0.2.6" }
-serdes-ai-output = { path = "serdes-ai-output", version = "0.2.6" }
-serdes-ai-streaming = { path = "serdes-ai-streaming", version = "0.2.6" }
-serdes-ai-mcp = { path = "serdes-ai-mcp", version = "0.2.6" }
-serdes-ai-embeddings = { path = "serdes-ai-embeddings", version = "0.2.6" }
-serdes-ai-retries = { path = "serdes-ai-retries", version = "0.2.6" }
-serdes-ai-graph = { path = "serdes-ai-graph", version = "0.2.6" }
-serdes-ai-evals = { path = "serdes-ai-evals", version = "0.2.6" }
-serdes-ai-macros = { path = "serdes-ai-macros", version = "0.2.6" }
-serdes-ai-a2a = { path = "serdes-ai-a2a", version = "0.2.6" }
+serdes-ai-core = { path = "serdes-ai-core", version = "0.3.0" }
+serdes-ai-agent = { path = "serdes-ai-agent", version = "0.3.0" }
+serdes-ai-models = { path = "serdes-ai-models", version = "0.3.0" }
+serdes-ai-providers = { path = "serdes-ai-providers", version = "0.3.0" }
+serdes-ai-tools = { path = "serdes-ai-tools", version = "0.3.0" }
+serdes-ai-toolsets = { path = "serdes-ai-toolsets", version = "0.3.0" }
+serdes-ai-output = { path = "serdes-ai-output", version = "0.3.0" }
+serdes-ai-streaming = { path = "serdes-ai-streaming", version = "0.3.0" }
+serdes-ai-mcp = { path = "serdes-ai-mcp", version = "0.3.0" }
+serdes-ai-embeddings = { path = "serdes-ai-embeddings", version = "0.3.0" }
+serdes-ai-retries = { path = "serdes-ai-retries", version = "0.3.0" }
+serdes-ai-graph = { path = "serdes-ai-graph", version = "0.3.0" }
+serdes-ai-evals = { path = "serdes-ai-evals", version = "0.3.0" }
+serdes-ai-macros = { path = "serdes-ai-macros", version = "0.3.0" }
+serdes-ai-a2a = { path = "serdes-ai-a2a", version = "0.3.0" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/serdes-ai-models/src/antigravity/model.rs
+++ b/serdes-ai-models/src/antigravity/model.rs
@@ -643,3 +643,81 @@ impl Model for AntigravityModel {
         &self.profile
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A streamed generation over real HTTP ends with exactly one terminal
+    /// StreamComplete carrying the final chunk's mapped finishReason and
+    /// usageMetadata counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hello\"}]}}]}}\n\n",
+            "data: {\"response\":{\"candidates\":[{\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15,\"cachedContentTokenCount\":3}}}\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/v1internal:streamGenerateContent",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let config = AntigravityConfig {
+            endpoint: server.uri(),
+            ..Default::default()
+        };
+        let model = AntigravityModel::new("gemini-3-flash", "test-token", "test-project")
+            .with_config(config);
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+}

--- a/serdes-ai-models/src/antigravity/stream.rs
+++ b/serdes-ai-models/src/antigravity/stream.rs
@@ -8,8 +8,8 @@ use bytes::Bytes;
 use futures::Stream;
 use pin_project_lite::pin_project;
 use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent, TextPart, ThinkingPart,
-    ToolCallPart,
+    FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
+    StreamCompleteEvent, TextPart, ThinkingPart, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
 use std::collections::HashMap;
@@ -27,7 +27,13 @@ pin_project! {
         parts: HashMap<usize, PartState>,
         // Current part index
         next_part_index: usize,
-        // Finished
+        // Finish reason mapped from the final chunk's candidate finishReason
+        finish_reason: Option<FinishReason>,
+        // Usage metadata from the wrapped response when present
+        usage: Option<UsageMetadata>,
+        // Open part indices awaiting a PartEnd before the terminal event
+        pending_part_ends: Vec<usize>,
+        // Finished: terminal event emitted, stream ended, or stream failed
         done: bool,
     }
 }
@@ -52,6 +58,9 @@ where
             buffer: String::new(),
             parts: HashMap::new(),
             next_part_index: 0,
+            finish_reason: None,
+            usage: None,
+            pending_part_ends: Vec::new(),
             done: false,
         }
     }
@@ -70,7 +79,32 @@ where
             return Poll::Ready(None);
         }
 
-        loop {
+        'outer: loop {
+            // Finish observed: close every open part, then emit the terminal
+            // event exactly once as the stream's last event.
+            if let Some(reason) = *this.finish_reason {
+                if let Some(idx) = this.pending_part_ends.pop() {
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: idx },
+                    ))));
+                }
+                if !this.parts.is_empty() {
+                    // Close parts in ascending index order: pop() takes from
+                    // the end, so queue the remaining indices descending.
+                    let mut indices: Vec<usize> = this.parts.drain().map(|(idx, _)| idx).collect();
+                    indices.sort_unstable();
+                    indices.reverse();
+                    let first = indices.pop().expect("parts checked non-empty");
+                    *this.pending_part_ends = indices;
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: first },
+                    ))));
+                }
+
+                *this.done = true;
+                return Poll::Ready(Some(Ok(stream_complete_event(reason, this.usage.as_ref()))));
+            }
+
             // Try both \r\n\r\n (Windows) and \n\n (Unix) line endings
             let separator = if this.buffer.contains("\r\n\r\n") {
                 "\r\n\r\n"
@@ -90,6 +124,11 @@ where
                     if let Some(data) = line.strip_prefix("data: ") {
                         // Handle [DONE] marker
                         if data == "[DONE]" {
+                            // Without an observed finishReason the stream is
+                            // truncated: end without the terminal event.
+                            if this.finish_reason.is_some() {
+                                continue 'outer;
+                            }
                             *this.done = true;
                             return Poll::Ready(None);
                         }
@@ -97,13 +136,23 @@ where
                         // Parse the JSON response
                         match serde_json::from_str::<AntigravityResponse>(data) {
                             Ok(response) => {
-                                if let Some(event) = process_response(
+                                // Capture terminal metadata before part events
+                                // so it survives final chunks that also carry
+                                // content.
+                                capture_terminal_metadata(
                                     &response,
-                                    this.parts,
-                                    this.next_part_index,
-                                    this.done,
-                                ) {
+                                    this.finish_reason,
+                                    this.usage,
+                                );
+                                if let Some(event) =
+                                    process_response(&response, this.parts, this.next_part_index)
+                                {
                                     return Poll::Ready(Some(event));
+                                }
+                                // The finishReason chunk is final: no later
+                                // chunk produces events.
+                                if this.finish_reason.is_some() {
+                                    continue 'outer;
                                 }
                             }
                             Err(e) => {
@@ -123,11 +172,13 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    // Mark done so no event (including the terminal event)
+                    // is emitted after an error.
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
-                    *this.done = true;
-                    // Process any remaining buffer
+                    // Process any remaining buffer without a trailing separator
                     if !this.buffer.is_empty() {
                         let remaining = std::mem::take(this.buffer);
                         for line in remaining.lines() {
@@ -136,11 +187,15 @@ where
                                     if let Ok(response) =
                                         serde_json::from_str::<AntigravityResponse>(data)
                                     {
+                                        capture_terminal_metadata(
+                                            &response,
+                                            this.finish_reason,
+                                            this.usage,
+                                        );
                                         if let Some(event) = process_response(
                                             &response,
                                             this.parts,
                                             this.next_part_index,
-                                            this.done,
                                         ) {
                                             return Poll::Ready(Some(event));
                                         }
@@ -149,6 +204,12 @@ where
                             }
                         }
                     }
+
+                    if this.finish_reason.is_some() {
+                        continue 'outer;
+                    }
+
+                    *this.done = true;
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -157,12 +218,32 @@ where
     }
 }
 
+/// Capture the terminal metadata a chunk carries: a candidate `finishReason`
+/// (the final chunk's completion signal) and the wrapped response's
+/// `usageMetadata`, so both survive final chunks that also carry content.
+fn capture_terminal_metadata(
+    response: &AntigravityResponse,
+    finish_reason: &mut Option<FinishReason>,
+    usage: &mut Option<UsageMetadata>,
+) {
+    if let Some(reason) = response
+        .response
+        .candidates
+        .first()
+        .and_then(|candidate| candidate.finish_reason.as_deref())
+    {
+        *finish_reason = Some(map_finish_reason(reason));
+    }
+    if let Some(metadata) = &response.response.usage_metadata {
+        *usage = Some(metadata.clone());
+    }
+}
+
 /// Process a response chunk into stream events.
 fn process_response(
     response: &AntigravityResponse,
     parts: &mut HashMap<usize, PartState>,
     next_part_index: &mut usize,
-    done: &mut bool,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
     // Get the first candidate from the wrapped response
     let candidate = response.response.candidates.first()?;
@@ -293,17 +374,320 @@ fn process_response(
         }
     }
 
-    // Check for finish
-    if candidate.finish_reason.is_some() {
-        *done = true;
+    None
+}
 
-        // Emit end events for all parts
-        if let Some((idx, _)) = parts.drain().next() {
-            return Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
-                index: idx,
-            })));
+/// Build the terminal event from the captured finish reason and usage
+/// metadata; the optional cached count maps to `cache_read_tokens` only when
+/// reported, and the wire format has no cache-creation count.
+fn stream_complete_event(
+    finish_reason: FinishReason,
+    usage: Option<&UsageMetadata>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason);
+
+    if let Some(u) = usage {
+        if let Some(tokens) = u.prompt_token_count {
+            event = event.with_input_tokens(tokens as u64);
+        }
+        if let Some(tokens) = u.candidates_token_count {
+            event = event.with_output_tokens(tokens as u64);
+        }
+        if let Some(cached) = u.cached_content_token_count {
+            event = event.with_cache_read_tokens(cached as u64);
         }
     }
 
-    None
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+/// Map an Antigravity finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::EndTurn`], matching the
+/// non-streaming response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "STOP" => FinishReason::EndTurn,
+        "MAX_TOKENS" => FinishReason::Length,
+        "SAFETY" => FinishReason::ContentFilter,
+        _ => FinishReason::EndTurn,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use futures::StreamExt;
+
+    fn make_sse_bytes(data: &str) -> Bytes {
+        Bytes::from(format!("data: {}\n\n", data))
+    }
+
+    /// A final chunk carrying finishReason and usageMetadata ends the stream
+    /// with exactly one terminal event, emitted last, mapping the finish
+    /// reason and the prompt, candidates, and cached counts.
+    #[tokio::test]
+    async fn final_chunk_with_finish_and_usage_emits_terminal_stream_complete() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":" World"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15,"cachedContentTokenCount":3}}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(make_sse_bytes(finish_chunk)),
+            // A trailing [DONE] marker must not suppress the terminal event.
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Content part events precede the part end and the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                // The wire format reports cached tokens but no cache-creation
+                // count.
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish chunk without usageMetadata still ends the stream with
+    /// exactly one terminal event; every token field stays `None`.
+    #[tokio::test]
+    async fn finish_without_usage_metadata_yields_none_token_fields() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"MAX_TOKENS"}]}}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(make_sse_bytes(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// The terminal event follows every open part's PartEnd when the finish
+    /// chunk arrives with multiple parts open.
+    #[tokio::test]
+    async fn terminal_event_follows_all_open_part_ends() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let tool_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"search","args":{"q":"rust"}}}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(make_sse_bytes(tool_chunk)),
+            Ok(make_sse_bytes(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            5,
+            "Expected 2 PartStart, 2 PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match (&events[2], &events[3]) {
+            (
+                ModelResponseStreamEvent::PartEnd(first),
+                ModelResponseStreamEvent::PartEnd(second),
+            ) => {
+                assert_eq!(first.index, 0, "lowest open part closes first");
+                assert_eq!(second.index, 1);
+            }
+            other => panic!(
+                "expected PartEnd events before the terminal, got {:?}",
+                other
+            ),
+        }
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(8));
+                assert_eq!(complete.output_tokens, Some(4));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream that ends without a finish reason emits no terminal event, so
+    /// consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn stream_end_without_finish_reason_emits_no_terminal_event() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let bytes = vec![Ok(make_sse_bytes(text_chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the part event, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
+        );
+    }
+
+    /// A transport error ends the stream with the error; a finish chunk that
+    /// arrives after it produces no terminal event.
+    #[tokio::test]
+    async fn stream_error_suppresses_terminal_event() {
+        // reqwest::Error has no public constructor; a refused connection to a
+        // closed loopback port is the cheapest real one to obtain.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let err = client
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .err()
+            .expect("connection to closed loopback port must fail");
+
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Err(err),
+            Ok(make_sse_bytes(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result);
+        }
+
+        assert!(
+            events.last().is_some_and(|e| e.is_err()),
+            "expected the stream to end with the error, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Ok(ModelResponseStreamEvent::StreamComplete(_)))),
+            "no terminal event may be emitted after an error"
+        );
+    }
+
+    /// A SAFETY finish reason maps to ContentFilter on the terminal event,
+    /// matching the non-streaming response mapping.
+    #[tokio::test]
+    async fn safety_finish_reason_maps_to_content_filter() {
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"SAFETY"}]}}"#;
+        let bytes = vec![Ok(make_sse_bytes(finish_chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::ContentFilter);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish chunk arriving without a trailing separator still ends the
+    /// stream with the terminal event after the remaining buffer is drained
+    /// at EOF.
+    #[tokio::test]
+    async fn finish_chunk_without_trailing_separator_emits_terminal_stream_complete() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":3,"totalTokenCount":10}}}"#;
+        // No trailing separator on the finish line: it is parsed from the
+        // remaining buffer at EOF.
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(Bytes::from(format!("data: {}", finish_chunk))),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            3,
+            "Expected PartStart, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(7));
+                assert_eq!(complete.output_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }

--- a/serdes-ai-models/src/azure/mod.rs
+++ b/serdes-ai-models/src/azure/mod.rs
@@ -149,6 +149,7 @@ impl Model for AzureOpenAIModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serdes_ai_core::FinishReason;
 
     #[test]
     fn test_azure_model_creation() {
@@ -160,5 +161,68 @@ mod tests {
         );
         assert_eq!(model.name(), "gpt-4");
         assert_eq!(model.system(), "azure");
+    }
+
+    /// Azure streams by delegating to an inner OpenAI chat model, so a
+    /// streamed request over real HTTP inherits the terminal StreamComplete
+    /// emission at [DONE] with the buffered usage.
+    #[tokio::test]
+    async fn request_stream_inherits_terminal_stream_complete() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/openai/deployments/gpt-4/chat/completions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = AzureOpenAIModel::new("gpt-4", server.uri(), "2024-02-15-preview", "test-key");
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/chatgpt_oauth/model.rs
+++ b/serdes-ai-models/src/chatgpt_oauth/model.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 use base64::Engine;
 use reqwest::Client;
 use serdes_ai_core::messages::{
-    ImageContent, PartStartEvent, TextPart, ToolCallArgs, ToolCallPart, UserContent,
-    UserContentPart, UserPromptPart,
+    ImageContent, ModelResponseStreamEvent, PartStartEvent, StreamCompleteEvent, TextPart,
+    ToolCallArgs, ToolCallPart, UserContent, UserContentPart, UserPromptPart,
 };
 use serdes_ai_core::{
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
@@ -649,6 +649,7 @@ impl Model for ChatGptOAuthModel {
         self.parse_sse_response(response).await
     }
 
+    /// Stream a response through the non-streaming request fallback.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
@@ -659,10 +660,16 @@ impl Model for ChatGptOAuthModel {
         // TODO: Implement proper SSE streaming
         let response = self.request(messages, settings, params).await?;
 
-        use serdes_ai_core::messages::ModelResponseStreamEvent;
+        let ModelResponse {
+            parts,
+            finish_reason,
+            usage,
+            ..
+        } = response;
 
-        let events: Vec<Result<ModelResponseStreamEvent, ModelError>> = response
-            .parts
+        // Part events first, terminal event last; the request error above
+        // short-circuits failures before any event is emitted.
+        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> = parts
             .into_iter()
             .enumerate()
             .map(|(idx, part)| {
@@ -672,10 +679,164 @@ impl Model for ChatGptOAuthModel {
             })
             .collect();
 
+        events.push(Ok(stream_complete_event(finish_reason, usage.as_ref())));
+
         Ok(Box::pin(futures::stream::iter(events)))
     }
 
     fn profile(&self) -> &ModelProfile {
         &self.profile
+    }
+}
+
+/// Build the terminal event from the finish reason and usage mapped from
+/// the completed response.
+///
+/// Usage fields absent from the response stay `None`. A missing finish
+/// reason defaults to [`FinishReason::Stop`]; the terminal event requires a
+/// reason, and unknown strings already default to `Stop` in the
+/// non-streaming mapping.
+fn stream_complete_event(
+    finish_reason: Option<FinishReason>,
+    usage: Option<&RequestUsage>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason.unwrap_or(FinishReason::Stop));
+
+    if let Some(u) = usage {
+        if let Some(tokens) = u.request_tokens {
+            event = event.with_input_tokens(tokens);
+        }
+        if let Some(tokens) = u.response_tokens {
+            event = event.with_output_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_creation_tokens {
+            event = event.with_cache_creation_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_read_tokens {
+            event = event.with_cache_read_tokens(tokens);
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Streaming fallback over wiremock (real HTTP request path).
+
+    /// Serve a Codex SSE body from a wiremock server and collect the events
+    /// `request_stream` yields against it.
+    async fn stream_events_for(sse_body: &str) -> Vec<ModelResponseStreamEvent> {
+        use futures::StreamExt;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/responses"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let config = ChatGptConfig {
+            api_base_url: server.uri(),
+            ..Default::default()
+        };
+        let model = ChatGptOAuthModel::new("chatgpt-4o-codex", "test-token").with_config(config);
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A streamed request over real HTTP replays the buffered completed
+    /// response as part events and ends with exactly one terminal
+    /// StreamComplete carrying the mapped usage.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-4o-codex\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        // Part events precede the terminal event.
+        match events.first() {
+            Some(ModelResponseStreamEvent::PartStart(start)) => {
+                assert_eq!(start.index, 0);
+                assert!(
+                    matches!(&start.part, ModelResponsePart::Text(t) if t.content == "Hello"),
+                    "expected the buffered text part first, got {:?}",
+                    start.part
+                );
+            }
+            other => panic!("expected a leading part event, got {:?}", other),
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A completed response without usage still ends with exactly one
+    /// terminal event, and every token field stays `None`.
+    #[tokio::test]
+    async fn request_stream_without_usage_yields_none_token_fields() {
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hi\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"model\":\"gpt-4o-codex\"}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/claude_code_oauth/stream.rs
+++ b/serdes-ai-models/src/claude_code_oauth/stream.rs
@@ -67,3 +67,70 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use futures::StreamExt;
+    use serdes_ai_core::messages::FinishReason;
+
+    fn make_sse_bytes(event_type: &str, data: &str) -> Bytes {
+        Bytes::from(format!("event: {}\ndata: {}\n\n", event_type, data))
+    }
+
+    /// The wrapper passes the wrapped Anthropic parser's terminal
+    /// StreamComplete through unchanged: exactly one terminal event,
+    /// emitted last, with the usage fields the Anthropic stream reported.
+    #[tokio::test]
+    async fn passes_through_terminal_stream_complete() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":3,"cache_read_input_tokens":7}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_delta", msg_delta)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
+
+        let mut parser = ClaudeCodeStreamParser::new(stream::iter(bytes));
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, Some(3));
+                assert_eq!(complete.cache_read_tokens, Some(7));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+}

--- a/serdes-ai-models/src/cohere/model.rs
+++ b/serdes-ai-models/src/cohere/model.rs
@@ -13,14 +13,15 @@ use futures::Stream;
 use reqwest::Client;
 use serdes_ai_core::{
     messages::{
-        ModelResponseStreamEvent, TextPart, ToolCallArgs, ToolCallPart, UserContent,
-        UserContentPart,
+        ModelResponseStreamEvent, StreamCompleteEvent, TextPart, ToolCallArgs, ToolCallPart,
+        UserContent, UserContentPart,
     },
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
     RequestUsage,
 };
 use serdes_ai_tools::ToolDefinition;
 use std::{
+    collections::VecDeque,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -80,6 +81,13 @@ impl CohereModel {
     #[must_use]
     pub fn with_client(mut self, client: Client) -> Self {
         self.client = client;
+        self
+    }
+
+    /// Set a custom API base URL.
+    #[must_use]
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
         self
     }
 
@@ -359,11 +367,15 @@ impl Model for CohereModel {
     }
 }
 
-/// Stream parser for Cohere SSE responses.
+/// Stream parser for Cohere NDJSON responses.
 pub struct CohereStreamParser<S> {
     inner: S,
     buffer: String,
     started: bool,
+    // Events queued by a parsed line, drained before parsing more lines
+    pending: VecDeque<ModelResponseStreamEvent>,
+    // Finished: terminal event emitted or stream failed; no further events
+    done: bool,
 }
 
 impl<S> CohereStreamParser<S> {
@@ -373,6 +385,8 @@ impl<S> CohereStreamParser<S> {
             inner: stream,
             buffer: String::new(),
             started: false,
+            pending: VecDeque::new(),
+            done: false,
         }
     }
 }
@@ -385,6 +399,17 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
+            // Drain queued events first so the terminal event follows the
+            // part end that queued it.
+            if let Some(event) = self.pending.pop_front() {
+                return Poll::Ready(Some(Ok(event)));
+            }
+
+            // After the terminal event the stream is done.
+            if self.done {
+                return Poll::Ready(None);
+            }
+
             // Try to parse a complete event from buffer
             if let Some(event) = self.try_parse_event() {
                 return Poll::Ready(Some(Ok(event)));
@@ -432,6 +457,9 @@ impl<S> CohereStreamParser<S> {
                         }
                     }
                     "stream-end" => {
+                        // Mark done so no event follows the terminal one.
+                        self.done = true;
+                        self.pending.push_back(stream_complete_event(&event));
                         return Some(ModelResponseStreamEvent::part_end(0));
                     }
                     _ => {}
@@ -440,6 +468,43 @@ impl<S> CohereStreamParser<S> {
         }
         None
     }
+}
+
+/// Build the terminal event from a `stream-end` event's finish reason and
+/// the token counts in its wrapped response; usage fields absent from the
+/// wire stay `None`.
+fn stream_complete_event(event: &StreamEvent) -> ModelResponseStreamEvent {
+    let reason = event.finish_reason.as_deref().or_else(|| {
+        event
+            .response
+            .as_ref()
+            .and_then(|r| r.finish_reason.as_deref())
+    });
+    let finish_reason = match reason {
+        Some("MAX_TOKENS") => FinishReason::Length,
+        Some("TOOL_CALL") => FinishReason::ToolCall,
+        // COMPLETE and END_TURN map to Stop, matching the non-streaming
+        // response mapping; unknown and absent reasons also fall back to
+        // Stop because the terminal event requires a reason.
+        _ => FinishReason::Stop,
+    };
+
+    let mut complete = StreamCompleteEvent::new(finish_reason);
+    if let Some(tokens) = event
+        .response
+        .as_ref()
+        .and_then(|r| r.meta.as_ref())
+        .and_then(|meta| meta.tokens.as_ref())
+    {
+        if let Some(tokens) = tokens.input_tokens {
+            complete = complete.with_input_tokens(u64::from(tokens));
+        }
+        if let Some(tokens) = tokens.output_tokens {
+            complete = complete.with_output_tokens(u64::from(tokens));
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(complete)
 }
 
 #[cfg(test)]
@@ -467,5 +532,193 @@ mod tests {
         let profile = CohereModel::profile_for_model("command-r-plus");
         assert!(profile.supports_tools);
         assert_eq!(profile.context_window, Some(128_000));
+    }
+
+    /// A custom base URL overrides the default Cohere API endpoint.
+    #[test]
+    fn test_custom_base_url() {
+        let model = CohereModel::new("command-r-plus", "test-key")
+            .with_base_url("http://localhost:8080/v2");
+        assert_eq!(model.base_url, "http://localhost:8080/v2");
+    }
+
+    // Stream parser terminal-event contract.
+
+    /// Collect every event a parser yields for the given NDJSON lines.
+    async fn parse_ndjson(lines: &[&str]) -> Vec<ModelResponseStreamEvent> {
+        use futures::{stream, StreamExt};
+
+        let bytes = lines
+            .iter()
+            .map(|l| Ok(Bytes::from(format!("{}\n", l))))
+            .collect::<Vec<_>>();
+        let mut parser = CohereStreamParser::new(stream::iter(bytes));
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A stream-end event with token usage ends the stream with exactly one
+    /// terminal event, emitted last, mapping the finish reason and counts.
+    #[tokio::test]
+    async fn stream_end_emits_terminal_stream_complete_with_usage() {
+        let events = parse_ndjson(&[
+            r#"{"event_type":"text-generation","text":"Hel"}"#,
+            r#"{"event_type":"text-generation","text":"lo"}"#,
+            r#"{"event_type":"stream-end","finish_reason":"COMPLETE","response":{"text":"Hello","generation_id":"gen-1","finish_reason":"COMPLETE","meta":{"tokens":{"input_tokens":10,"output_tokens":5}}}}"#,
+        ])
+        .await;
+
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                // The wire format reports no cache counts.
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream-end event without usage still ends the stream with exactly
+    /// one terminal event; every token field stays `None`.
+    #[tokio::test]
+    async fn stream_end_without_usage_yields_none_token_fields() {
+        let events = parse_ndjson(&[
+            r#"{"event_type":"text-generation","text":"Hi"}"#,
+            r#"{"event_type":"stream-end","finish_reason":"MAX_TOKENS"}"#,
+        ])
+        .await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A TOOL_CALL stream-end maps to the ToolCall finish reason on the
+    /// terminal event, matching the non-streaming response mapping.
+    #[tokio::test]
+    async fn tool_call_stream_end_maps_to_tool_call_finish_reason() {
+        let events =
+            parse_ndjson(&[r#"{"event_type":"stream-end","finish_reason":"TOOL_CALL"}"#]).await;
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::ToolCall);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream that ends without stream-end emits no terminal event, so
+    /// consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn eof_without_stream_end_emits_no_terminal_event() {
+        let events = parse_ndjson(&[r#"{"event_type":"text-generation","text":"Hi"}"#]).await;
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
+        );
+    }
+
+    // Streaming over wiremock (real HTTP request path).
+
+    /// A streamed chat over real HTTP ends with exactly one terminal
+    /// StreamComplete carrying the stream-end response's token counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+
+        let ndjson_body = concat!(
+            "{\"event_type\":\"text-generation\",\"text\":\"Hel\"}\n",
+            "{\"event_type\":\"text-generation\",\"text\":\"lo\"}\n",
+            "{\"event_type\":\"stream-end\",\"finish_reason\":\"COMPLETE\",\"response\":{\"text\":\"Hello\",\"generation_id\":\"gen-1\",\"finish_reason\":\"COMPLETE\",\"meta\":{\"tokens\":{\"input_tokens\":10,\"output_tokens\":5}}}}\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/chat"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/x-ndjson")
+                    .set_body_string(ndjson_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = CohereModel::new("command-r-plus", "test-key").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/google/model.rs
+++ b/serdes-ai-models/src/google/model.rs
@@ -848,4 +848,73 @@ mod tests {
         assert!(matches!(&result.parts[0], ModelResponsePart::Text(t) if t.content == "Hello!"));
         assert!(matches!(result.finish_reason, Some(FinishReason::Stop)));
     }
+
+    // Streaming over wiremock (real HTTP request path).
+
+    /// A streamed generation over real HTTP ends with exactly one terminal
+    /// StreamComplete carrying the final chunk's mapped usageMetadata counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hello\"}]}}]}\n\n",
+            "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\" World\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15,\"cachedContentTokenCount\":3}}\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = GoogleModel::new("gemini-2.0-flash", "test-key").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }

--- a/serdes-ai-models/src/google/stream.rs
+++ b/serdes-ai-models/src/google/stream.rs
@@ -3,14 +3,14 @@
 //! Google uses a slightly different streaming format - each chunk is a complete
 //! JSON response object, not deltas.
 
-use super::types::{GenerateContentResponse, Part};
+use super::types::{GenerateContentResponse, Part, UsageMetadata};
 use crate::error::ModelError;
 use bytes::Bytes;
 use futures::Stream;
 use pin_project_lite::pin_project;
 use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent, TextPart, ThinkingPart,
-    ToolCallPart,
+    FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
+    StreamCompleteEvent, TextPart, ThinkingPart, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
 use std::collections::HashMap;
@@ -27,7 +27,13 @@ pin_project! {
         parts: HashMap<usize, PartState>,
         // Current part index
         next_part_index: usize,
-        // Finished
+        // Finish reason mapped from the last seen candidate finishReason
+        finish_reason: Option<FinishReason>,
+        // Usage metadata from the most recent chunk that reported it
+        usage: Option<UsageMetadata>,
+        // Open part indices awaiting a PartEnd before the terminal event
+        pending_part_ends: Vec<usize>,
+        // Finished: terminal event emitted, stream ended, or stream failed
         done: bool,
     }
 }
@@ -60,6 +66,9 @@ where
             buffer: String::new(),
             parts: HashMap::new(),
             next_part_index: 0,
+            finish_reason: None,
+            usage: None,
+            pending_part_ends: Vec::new(),
             done: false,
         }
     }
@@ -78,7 +87,32 @@ where
             return Poll::Ready(None);
         }
 
-        loop {
+        'outer: loop {
+            // Finish observed: close every open part, then emit the terminal
+            // event exactly once as the stream's last event.
+            if let Some(reason) = *this.finish_reason {
+                if let Some(idx) = this.pending_part_ends.pop() {
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: idx },
+                    ))));
+                }
+                if !this.parts.is_empty() {
+                    // Close parts in ascending index order: pop() takes from
+                    // the end, so queue the remaining indices descending.
+                    let mut indices: Vec<usize> = this.parts.drain().map(|(idx, _)| idx).collect();
+                    indices.sort_unstable();
+                    indices.reverse();
+                    let first = indices.pop().expect("parts checked non-empty");
+                    *this.pending_part_ends = indices;
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: first },
+                    ))));
+                }
+
+                *this.done = true;
+                return Poll::Ready(Some(Ok(stream_complete_event(reason, this.usage.as_ref()))));
+            }
+
             // Try to parse complete JSON objects from buffer
             // Google sends each chunk as a complete JSON object on its own line
             while let Some(line_end) = this.buffer.find('\n') {
@@ -94,6 +128,11 @@ where
 
                 // Handle [DONE] marker
                 if json_str == "[DONE]" {
+                    // Without an observed finishReason the stream is
+                    // truncated: end without the terminal event.
+                    if this.finish_reason.is_some() {
+                        continue 'outer;
+                    }
                     *this.done = true;
                     return Poll::Ready(None);
                 }
@@ -101,10 +140,18 @@ where
                 // Parse the JSON response
                 match serde_json::from_str::<GenerateContentResponse>(json_str) {
                     Ok(response) => {
+                        // Capture terminal metadata before part events so it
+                        // survives final chunks that also carry content.
+                        capture_terminal_metadata(&response, this.finish_reason, this.usage);
                         if let Some(event) =
-                            process_response(&response, this.parts, this.next_part_index, this.done)
+                            process_response(&response, this.parts, this.next_part_index)
                         {
                             return Poll::Ready(Some(event));
+                        }
+                        // The finishReason chunk is final: no later chunk
+                        // produces events.
+                        if this.finish_reason.is_some() {
+                            continue 'outer;
                         }
                     }
                     Err(e) => {
@@ -121,11 +168,13 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    // Mark done so no event (including the terminal event)
+                    // is emitted after an error.
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
-                    *this.done = true;
-                    // Process any remaining buffer
+                    // Process any remaining buffer without a trailing newline
                     if !this.buffer.is_empty() {
                         let remaining = std::mem::take(this.buffer);
                         let json_str = remaining.trim();
@@ -135,17 +184,25 @@ where
                             if let Ok(response) =
                                 serde_json::from_str::<GenerateContentResponse>(json_str)
                             {
-                                if let Some(event) = process_response(
+                                capture_terminal_metadata(
                                     &response,
-                                    this.parts,
-                                    this.next_part_index,
-                                    this.done,
-                                ) {
+                                    this.finish_reason,
+                                    this.usage,
+                                );
+                                if let Some(event) =
+                                    process_response(&response, this.parts, this.next_part_index)
+                                {
                                     return Poll::Ready(Some(event));
                                 }
                             }
                         }
                     }
+
+                    if this.finish_reason.is_some() {
+                        continue 'outer;
+                    }
+
+                    *this.done = true;
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -154,12 +211,31 @@ where
     }
 }
 
+/// Capture the terminal metadata a chunk carries: a candidate `finishReason`
+/// (the final chunk's completion signal) and the latest `usageMetadata`, so
+/// both survive final chunks that also carry content parts.
+fn capture_terminal_metadata(
+    response: &GenerateContentResponse,
+    finish_reason: &mut Option<FinishReason>,
+    usage: &mut Option<UsageMetadata>,
+) {
+    if let Some(reason) = response
+        .candidates
+        .first()
+        .and_then(|candidate| candidate.finish_reason.as_deref())
+    {
+        *finish_reason = Some(map_finish_reason(reason));
+    }
+    if let Some(metadata) = &response.usage_metadata {
+        *usage = Some(metadata.clone());
+    }
+}
+
 /// Process a response chunk into stream events.
 fn process_response(
     response: &GenerateContentResponse,
     parts: &mut HashMap<usize, PartState>,
     next_part_index: &mut usize,
-    done: &mut bool,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
     // Get the first candidate
     let candidate = response.candidates.first()?;
@@ -268,19 +344,42 @@ fn process_response(
         }
     }
 
-    // Check for finish
-    if candidate.finish_reason.is_some() {
-        *done = true;
+    None
+}
 
-        // Emit end events for all parts
-        if let Some((idx, _)) = parts.drain().next() {
-            return Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
-                index: idx,
-            })));
+/// Build the terminal event from the captured finish reason and usage
+/// metadata; the optional cached count maps to `cache_read_tokens` only when
+/// reported, and the wire format has no cache-creation count.
+fn stream_complete_event(
+    finish_reason: FinishReason,
+    usage: Option<&UsageMetadata>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason);
+
+    if let Some(u) = usage {
+        event = event
+            .with_input_tokens(u.prompt_token_count)
+            .with_output_tokens(u.candidates_token_count);
+        if let Some(cached) = u.cached_content_token_count {
+            event = event.with_cache_read_tokens(cached);
         }
     }
 
-    None
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+/// Map a Google finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::Stop`], matching the non-streaming
+/// response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "STOP" => FinishReason::Stop,
+        "MAX_TOKENS" => FinishReason::Length,
+        "SAFETY" | "RECITATION" => FinishReason::ContentFilter,
+        "TOOL_CALLS" | "FUNCTION_CALL" => FinishReason::ToolCall,
+        _ => FinishReason::Stop,
+    }
 }
 
 #[cfg(test)]
@@ -326,6 +425,8 @@ mod tests {
         }
     }
 
+    /// A final chunk with a finish reason but no usageMetadata still ends the
+    /// stream with exactly one terminal event; every token field stays None.
     #[tokio::test]
     async fn test_parse_with_finish() {
         let chunk1 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
@@ -339,10 +440,258 @@ mod tests {
             events.push(result.unwrap());
         }
 
-        assert!(
-            events.len() >= 2,
-            "Expected at least 2 events, got {:?}",
+        // Text delta and part end precede the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
             events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish chunk arriving without a trailing newline still ends the
+    /// stream with the terminal event after the remaining buffer is drained
+    /// at EOF.
+    #[tokio::test]
+    async fn finish_chunk_without_trailing_newline_emits_terminal_stream_complete() {
+        let chunk1 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let chunk2 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":" World"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#;
+        // No trailing newline on the finish chunk: it is parsed from the
+        // remaining buffer at EOF.
+        let bytes = vec![Ok(make_chunk(chunk1)), Ok(Bytes::from(chunk2))];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish-only final chunk without a trailing newline still routes
+    /// through the EOF remaining-buffer branch to the terminal event.
+    #[tokio::test]
+    async fn finish_only_chunk_without_trailing_newline_emits_terminal_stream_complete() {
+        let chunk = r#"{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":3,"totalTokenCount":10}}"#;
+        // No trailing newline and no content parts: the EOF branch must
+        // route the captured finish reason to the terminal event itself.
+        let stream = stream::iter(vec![Ok(Bytes::from(chunk))]);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the terminal event, got {:?}",
+            events
+        );
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(7));
+                assert_eq!(complete.output_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A final chunk carrying usageMetadata ends the stream with exactly one
+    /// terminal event last, mapping prompt, candidates, and cached counts.
+    #[tokio::test]
+    async fn final_chunk_with_usage_metadata_emits_terminal_stream_complete() {
+        let chunk1 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let chunk2 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":" World"}]},"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15,"cachedContentTokenCount":3}}"#;
+        let bytes = vec![
+            Ok(make_chunk(chunk1)),
+            Ok(make_chunk(chunk2)),
+            // A trailing [DONE] marker must not suppress the terminal event.
+            Ok(make_chunk("[DONE]")),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Content part events precede the part end and the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                // The wire format reports cached tokens but no cache-creation
+                // count.
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// The terminal event is sequenced after every open part's PartEnd, in
+    /// ascending index order.
+    #[tokio::test]
+    async fn terminal_event_follows_all_open_part_ends() {
+        let text_chunk =
+            r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let tool_chunk = r#"{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"search","args":{"q":"rust"}}}]}}]}"#;
+        let finish_chunk = r#"{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}"#;
+        let bytes = vec![
+            Ok(make_chunk(text_chunk)),
+            Ok(make_chunk(tool_chunk)),
+            Ok(make_chunk(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            5,
+            "Expected 2 PartStart, 2 PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match (&events[2], &events[3]) {
+            (
+                ModelResponseStreamEvent::PartEnd(first),
+                ModelResponseStreamEvent::PartEnd(second),
+            ) => {
+                assert_eq!(first.index, 0, "lowest open part closes first");
+                assert_eq!(second.index, 1);
+            }
+            other => panic!(
+                "expected PartEnd events before the terminal, got {:?}",
+                other
+            ),
+        }
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.input_tokens, Some(8));
+                assert_eq!(complete.output_tokens, Some(4));
+                // The optional cached count is absent on the wire: it stays
+                // None, never zero.
+                assert_eq!(complete.cache_read_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// Every Google finish reason string maps to the same core variant the
+    /// non-streaming path produces, with unknown strings defaulting to Stop.
+    #[tokio::test]
+    async fn finish_reason_strings_map_to_core_variants() {
+        for (wire, expected) in [
+            ("STOP", FinishReason::Stop),
+            ("MAX_TOKENS", FinishReason::Length),
+            ("SAFETY", FinishReason::ContentFilter),
+            ("RECITATION", FinishReason::ContentFilter),
+            ("TOOL_CALLS", FinishReason::ToolCall),
+            ("FUNCTION_CALL", FinishReason::ToolCall),
+            ("SOMETHING_NEW", FinishReason::Stop),
+        ] {
+            let chunk = format!(r#"{{"candidates":[{{"finishReason":"{wire}"}}]}}"#);
+            let stream = stream::iter(vec![Ok(make_chunk(&chunk))]);
+            let mut parser = GoogleStreamParser::new(stream);
+
+            let mut events = Vec::new();
+            while let Some(result) = parser.next().await {
+                events.push(result.unwrap());
+            }
+
+            match events.last() {
+                Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                    assert_eq!(complete.finish_reason, expected, "wire reason {wire}");
+                }
+                other => panic!("expected terminal event for {wire}, got {other:?}"),
+            }
+        }
+    }
+
+    /// A stream that ends without a finish reason emits no terminal event, so
+    /// consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn stream_end_without_finish_reason_emits_no_terminal_event() {
+        let chunk = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let bytes = vec![Ok(make_chunk(chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the part event, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
         );
     }
 }

--- a/serdes-ai-models/src/groq/mod.rs
+++ b/serdes-ai-models/src/groq/mod.rs
@@ -133,6 +133,7 @@ impl Model for GroqModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serdes_ai_core::FinishReason;
 
     #[test]
     fn test_groq_model_creation() {
@@ -151,5 +152,72 @@ mod tests {
 
         let model = GroqModel::gemma_9b("key");
         assert_eq!(model.name(), "gemma2-9b-it");
+    }
+
+    /// Groq streams by delegating to an inner OpenAI chat model, so a
+    /// streamed request over real HTTP inherits the terminal StreamComplete
+    /// emission at [DONE] with the buffered usage.
+    ///
+    /// The Groq base URL is fixed, so the test points the inner model at a
+    /// mock server and exercises the real `request_stream` delegation.
+    #[tokio::test]
+    async fn request_stream_inherits_terminal_stream_complete() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"llama-3.1-70b-versatile\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"llama-3.1-70b-versatile\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"llama-3.1-70b-versatile\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/chat/completions"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = GroqModel {
+            inner: OpenAIChatModel::new("llama-3.1-70b-versatile", "test-key")
+                .with_base_url(server.uri()),
+        };
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/huggingface/model.rs
+++ b/serdes-ai-models/src/huggingface/model.rs
@@ -10,8 +10,9 @@ use crate::error::ModelError;
 use crate::model::{Model, ModelRequestParameters, StreamedResponse};
 use crate::profile::ModelProfile;
 use serdes_ai_core::{
-    messages::ModelResponseStreamEvent, FinishReason, ModelRequest, ModelRequestPart,
-    ModelResponse, ModelResponsePart, ModelSettings, TextPart, UserContent, UserContentPart,
+    messages::{ModelResponseStreamEvent, StreamCompleteEvent},
+    FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
+    TextPart, UserContent, UserContentPart,
 };
 
 /// HuggingFace Inference API base URL.
@@ -196,21 +197,16 @@ impl HuggingFaceModel {
             .ok_or_else(|| ModelError::invalid_response("No generated text"))?;
 
         let finish_reason = match &resp {
-            GenerateResponse::Single(r) => r.details.as_ref().and_then(|d| {
-                d.finish_reason.as_ref().map(|r| match r.as_str() {
-                    "length" => FinishReason::Length,
-                    "eos_token" | "stop" => FinishReason::Stop,
-                    _ => FinishReason::Stop,
-                })
-            }),
+            GenerateResponse::Single(r) => r
+                .details
+                .as_ref()
+                .and_then(|d| d.finish_reason.as_deref())
+                .map(map_finish_reason),
             GenerateResponse::Batch(results) => results.first().and_then(|r| {
-                r.details.as_ref().and_then(|d| {
-                    d.finish_reason.as_ref().map(|r| match r.as_str() {
-                        "length" => FinishReason::Length,
-                        "eos_token" | "stop" => FinishReason::Stop,
-                        _ => FinishReason::Stop,
-                    })
-                })
+                r.details
+                    .as_ref()
+                    .and_then(|d| d.finish_reason.as_deref())
+                    .map(map_finish_reason)
             }),
         };
 
@@ -296,6 +292,7 @@ impl Model for HuggingFaceModel {
         self.parse_response(resp)
     }
 
+    /// Stream a generation from the TGI endpoint.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
@@ -328,15 +325,16 @@ impl Model for HuggingFaceModel {
         }
 
         let stream = response.bytes_stream();
-        let model_id = self.model_id.clone();
 
-        // Parse SSE stream
-        let mapped = stream.filter_map(move |chunk| {
-            let _model_id = model_id.clone();
-            async move {
+        // Parse SSE stream; a chunk can carry several data lines, so every
+        // event it produces is emitted, with the terminal event last.
+        let events = stream
+            .filter_map(|chunk| async {
                 match chunk {
                     Ok(bytes) => {
                         let text = String::from_utf8_lossy(&bytes);
+                        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> =
+                            Vec::new();
                         // Parse SSE data lines
                         for line in text.lines() {
                             if let Some(data) = line.strip_prefix("data:") {
@@ -347,25 +345,61 @@ impl Model for HuggingFaceModel {
                                 if let Ok(resp) = serde_json::from_str::<StreamResponse>(data) {
                                     if let Some(token) = resp.token {
                                         if !token.special {
-                                            return Some(Ok(ModelResponseStreamEvent::text_delta(
+                                            events.push(Ok(ModelResponseStreamEvent::text_delta(
                                                 0, token.text,
                                             )));
                                         }
                                     }
                                     if resp.generated_text.is_some() {
-                                        return Some(Ok(ModelResponseStreamEvent::part_end(0)));
+                                        events.push(Ok(ModelResponseStreamEvent::part_end(0)));
+                                        let finish_reason = resp
+                                            .details
+                                            .as_ref()
+                                            .and_then(|d| d.finish_reason.as_deref())
+                                            .map(map_finish_reason)
+                                            .unwrap_or(FinishReason::Stop);
+                                        events.push(Ok(ModelResponseStreamEvent::StreamComplete(
+                                            StreamCompleteEvent::new(finish_reason),
+                                        )));
                                     }
                                 }
                             }
                         }
-                        None
+                        if events.is_empty() {
+                            None
+                        } else {
+                            Some(events)
+                        }
                     }
-                    Err(e) => Some(Err(ModelError::network(e.to_string()))),
+                    Err(e) => Some(vec![Err(ModelError::network(e.to_string()))]),
                 }
+            })
+            .flat_map(futures::stream::iter);
+
+        // The terminal event ends the stream: nothing is yielded after the
+        // first StreamComplete, keeping it exactly once and last.
+        let mut terminal_seen = false;
+        let mapped = events.take_while(move |event| {
+            let stop = terminal_seen;
+            if matches!(event, Ok(ModelResponseStreamEvent::StreamComplete(_))) {
+                terminal_seen = true;
             }
+            std::future::ready(!stop)
         });
 
         Ok(Box::pin(mapped))
+    }
+}
+
+/// Map a TGI finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::Stop`], matching the non-streaming
+/// response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "length" => FinishReason::Length,
+        "eos_token" | "stop" => FinishReason::Stop,
+        _ => FinishReason::Stop,
     }
 }
 
@@ -406,5 +440,153 @@ mod tests {
         assert!(prompt.contains("<|user|>"));
         assert!(prompt.contains("Hello!"));
         assert!(prompt.ends_with("<|assistant|>\n"));
+    }
+
+    // Streaming over wiremock (real HTTP request path).
+
+    /// Collect the events a streamed request yields for the given SSE body.
+    async fn stream_events_for(sse_body: &str) -> Vec<ModelResponseStreamEvent> {
+        use futures::StreamExt;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = HuggingFaceModel::new("test-model", "test-token").with_endpoint(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A streamed generation over real HTTP ends with exactly one terminal
+    /// StreamComplete after the part end, mapping the final chunk's finish
+    /// reason and leaving every token field `None`.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete() {
+        let sse_body = concat!(
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
+            "data:{\"token\":{\"id\":2,\"text\":\" world\",\"logprob\":null,\"special\":false}}\n\n",
+            "data:{\"generated_text\":\"Hello world\",\"details\":{\"finish_reason\":\"length\",\"generated_tokens\":2,\"seed\":null}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        // Text deltas precede the part end and the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected 2 PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+        assert!(matches!(events[0], ModelResponseStreamEvent::PartDelta(_)));
+        assert!(matches!(events[1], ModelResponseStreamEvent::PartDelta(_)));
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                // TGI reports no token counts in this mode.
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream that ends without a generated_text chunk emits no terminal
+    /// event, so consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn request_stream_without_generated_text_emits_no_terminal_event() {
+        let sse_body = concat!(
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the text delta, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
+        );
+    }
+
+    /// A data line after the generated_text line yields no event after the
+    /// terminal one, keeping the terminal the stream's last event.
+    #[tokio::test]
+    async fn request_stream_ignores_lines_after_generated_text() {
+        let sse_body = concat!(
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
+            "data:{\"generated_text\":\"Hello\",\"details\":{\"finish_reason\":\"stop\",\"generated_tokens\":1,\"seed\":null}}\n\n",
+            "data:{\"token\":{\"id\":2,\"text\":\" trailing\",\"logprob\":null,\"special\":false}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+        assert!(
+            matches!(
+                events.last(),
+                Some(ModelResponseStreamEvent::StreamComplete(_))
+            ),
+            "terminal event must be emitted last, got {:?}",
+            events.last()
+        );
+    }
+
+    /// A duplicated generated_text line still yields exactly one terminal
+    /// event.
+    #[tokio::test]
+    async fn request_stream_with_duplicated_generated_text_emits_one_terminal_event() {
+        let sse_body = concat!(
+            "data:{\"generated_text\":\"Hello\",\"details\":{\"finish_reason\":\"stop\",\"generated_tokens\":1,\"seed\":null}}\n\n",
+            "data:{\"generated_text\":\"Hello again\",\"details\":{\"finish_reason\":\"stop\",\"generated_tokens\":2,\"seed\":null}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
     }
 }

--- a/serdes-ai-models/src/openai/chat.rs
+++ b/serdes-ai-models/src/openai/chat.rs
@@ -661,4 +661,72 @@ mod tests {
         assert_eq!(req.stream, Some(true));
         assert!(req.stream_options.is_some());
     }
+
+    /// A streaming chat completion over real HTTP ends with exactly one
+    /// terminal StreamComplete carrying the include_usage chunk's counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15,\"prompt_tokens_details\":{\"cached_tokens\":7}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/chat/completions"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = OpenAIChatModel::new("gpt-4o", "sk-test-key").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(7));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -18,8 +18,9 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use serdes_ai_core::messages::{
-    ImageContent, RetryPromptPart, TextPart, ThinkingPart, ToolCallArgs, ToolCallPart,
-    ToolReturnPart, UserContent, UserContentPart, UserPromptPart,
+    ImageContent, ModelResponseStreamEvent, PartStartEvent, RetryPromptPart, StreamCompleteEvent,
+    TextPart, ThinkingPart, ToolCallArgs, ToolCallPart, ToolReturnPart, UserContent,
+    UserContentPart, UserPromptPart,
 };
 use serdes_ai_core::{
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
@@ -1157,6 +1158,7 @@ impl Model for OpenAIResponsesModel {
         self.process_response(resp)
     }
 
+    /// Stream a response through the non-streaming request fallback.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
@@ -1167,23 +1169,59 @@ impl Model for OpenAIResponsesModel {
         // TODO: Implement proper streaming with ResponsesStreamParser
         let response = self.request(messages, settings, params).await?;
 
-        // Convert to a single-event stream
-        let events: Vec<Result<serdes_ai_core::messages::ModelResponseStreamEvent, ModelError>> =
-            response
-                .parts
-                .into_iter()
-                .enumerate()
-                .map(|(idx, part)| {
-                    Ok(
-                        serdes_ai_core::messages::ModelResponseStreamEvent::PartStart(
-                            serdes_ai_core::messages::PartStartEvent::new(idx, part),
-                        ),
-                    )
-                })
-                .collect();
+        let ModelResponse {
+            parts,
+            finish_reason,
+            usage,
+            ..
+        } = response;
+
+        // Part events first, terminal event last; the request error above
+        // short-circuits failures before any event is emitted.
+        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> = parts
+            .into_iter()
+            .enumerate()
+            .map(|(idx, part)| {
+                Ok(ModelResponseStreamEvent::PartStart(PartStartEvent::new(
+                    idx, part,
+                )))
+            })
+            .collect();
+
+        events.push(Ok(stream_complete_event(finish_reason, usage.as_ref())));
 
         Ok(Box::pin(futures::stream::iter(events)))
     }
+}
+
+/// Build the terminal event from the finish reason and usage the
+/// non-streaming path mapped from the completed response.
+///
+/// Usage fields absent from the response stay `None`; a status the
+/// non-streaming mapping leaves unmapped defaults to [`FinishReason::Stop`],
+/// matching the chat stream parser's terminal default.
+fn stream_complete_event(
+    finish_reason: Option<FinishReason>,
+    usage: Option<&RequestUsage>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason.unwrap_or(FinishReason::Stop));
+
+    if let Some(u) = usage {
+        if let Some(tokens) = u.request_tokens {
+            event = event.with_input_tokens(tokens);
+        }
+        if let Some(tokens) = u.response_tokens {
+            event = event.with_output_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_creation_tokens {
+            event = event.with_cache_creation_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_read_tokens {
+            event = event.with_cache_read_tokens(tokens);
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(event)
 }
 
 #[cfg(test)]
@@ -1283,5 +1321,134 @@ mod tests {
         let json = serde_json::to_string(&input).unwrap();
         assert!(json.contains("\"role\":\"tool\""));
         assert!(json.contains("\"tool_call_id\":\"call_123\""));
+    }
+
+    // Streaming fallback over wiremock (real HTTP request path).
+
+    /// Build a completed non-streaming Responses response body, with usage
+    /// attached only when the scenario provides it.
+    fn completed_response_body(usage: Option<serde_json::Value>) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 1234567890,
+            "model": "o3-mini",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{ "type": "output_text", "text": "Hello", "annotations": [] }]
+            }],
+            "error": null,
+            "metadata": null,
+            "service_tier": null
+        });
+        if let Some(usage) = usage {
+            body["usage"] = usage;
+        }
+        body
+    }
+
+    /// Serve the given response body from a wiremock server and collect the
+    /// events `request_stream` yields against it.
+    async fn stream_events_for(body: serde_json::Value) -> Vec<ModelResponseStreamEvent> {
+        use futures::StreamExt;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/responses"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let model = OpenAIResponsesModel::new("o3-mini", "sk-test").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A streamed request over real HTTP replays the buffered completed
+    /// response as part events and ends with exactly one terminal
+    /// StreamComplete carrying the mapped finish reason and usage.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        let usage = serde_json::json!({
+            "input_tokens": 12,
+            "output_tokens": 7,
+            "total_tokens": 19,
+            "input_tokens_details": {"cached_tokens": 4},
+            "output_tokens_details": {"reasoning_tokens": 3}
+        });
+        let events = stream_events_for(completed_response_body(Some(usage))).await;
+
+        // Part events precede the terminal event.
+        match events.first() {
+            Some(ModelResponseStreamEvent::PartStart(start)) => {
+                assert_eq!(start.index, 0);
+                assert!(
+                    matches!(&start.part, ModelResponsePart::Text(t) if t.content == "Hello"),
+                    "expected the buffered text part first, got {:?}",
+                    start.part
+                );
+            }
+            other => panic!("expected a leading part event, got {:?}", other),
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(12));
+                assert_eq!(complete.output_tokens, Some(7));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(4));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A completed response without usage still ends with exactly one
+    /// terminal event, and every token field stays `None`.
+    #[tokio::test]
+    async fn request_stream_without_usage_yields_none_token_fields() {
+        let events = stream_events_for(completed_response_body(None)).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/openai/stream.rs
+++ b/serdes-ai-models/src/openai/stream.rs
@@ -2,20 +2,6 @@
 //!
 //! This module provides streaming support for OpenAI chat completions.
 
-use super::types::ChatCompletionChunk;
-use crate::error::ModelError;
-use bytes::Bytes;
-use futures::Stream;
-use pin_project_lite::pin_project;
-use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent, TextPart, ThinkingPart,
-    ThinkingPartDelta, ToolCallArgs, ToolCallPart,
-};
-use serdes_ai_core::ModelResponsePart;
-use std::collections::HashMap;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 pin_project! {
     /// OpenAI SSE stream parser.
     pub struct OpenAIStreamParser<S> {
@@ -34,12 +20,32 @@ pin_project! {
         current_thinking_index: Option<usize>,
         // Next part index to use
         next_part_index: usize,
-        // Finished
+        // Finished: terminal event emitted or stream failed; no further events
         done: bool,
+        // data: [DONE] marker observed; terminal event still pending
+        done_seen: bool,
+        // Last seen non-None finish reason across chunks
+        last_finish_reason: Option<FinishReason>,
+        // Buffered usage from the include_usage chunk
+        usage: Option<Usage>,
         // Pending PartEnd events to emit (queued when multiple parts close at once)
         pending_part_ends: Vec<usize>,
     }
 }
+
+use super::types::{ChatCompletionChunk, Usage};
+use crate::error::ModelError;
+use bytes::Bytes;
+use futures::Stream;
+use pin_project_lite::pin_project;
+use serdes_ai_core::messages::{
+    FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
+    StreamCompleteEvent, TextPart, ThinkingPart, ThinkingPartDelta, ToolCallArgs, ToolCallPart,
+};
+use serdes_ai_core::ModelResponsePart;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// State for an in-progress tool call.
 #[derive(Debug, Clone, Default)]
@@ -67,6 +73,9 @@ where
             current_thinking_index: None,
             next_part_index: 0,
             done: false,
+            done_seen: false,
+            last_finish_reason: None,
+            usage: None,
             pending_part_ends: Vec::new(),
         }
     }
@@ -104,11 +113,23 @@ where
                     this.thinking_started,
                     this.current_thinking_index,
                     this.next_part_index,
-                    this.done,
+                    this.done_seen,
+                    this.last_finish_reason,
+                    this.usage,
                     this.pending_part_ends,
                 ) {
                     return Poll::Ready(Some(event));
                 }
+            }
+
+            // [DONE] observed and all buffered lines consumed: emit the
+            // terminal event. Queued part ends were already drained above.
+            if *this.done_seen {
+                *this.done = true;
+                return Poll::Ready(Some(Ok(stream_complete_event(
+                    *this.last_finish_reason,
+                    this.usage.as_ref(),
+                ))));
             }
 
             // Need more data
@@ -120,6 +141,9 @@ where
                     // Continue to process buffer
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    // Mark done so no event (including the terminal event) is
+                    // emitted after an error.
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
@@ -135,13 +159,26 @@ where
                                 this.thinking_started,
                                 this.current_thinking_index,
                                 this.next_part_index,
-                                this.done,
+                                this.done_seen,
+                                this.last_finish_reason,
+                                this.usage,
                                 this.pending_part_ends,
                             ) {
                                 return Poll::Ready(Some(event));
                             }
                         }
                     }
+
+                    // A [DONE] in the final (newline-less) line still emits
+                    // the terminal event before the stream ends.
+                    if *this.done_seen {
+                        *this.done = true;
+                        return Poll::Ready(Some(Ok(stream_complete_event(
+                            *this.last_finish_reason,
+                            this.usage.as_ref(),
+                        ))));
+                    }
+
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -160,7 +197,9 @@ fn parse_sse_line(
     thinking_started: &mut bool,
     current_thinking_index: &mut Option<usize>,
     next_part_index: &mut usize,
-    done: &mut bool,
+    done_seen: &mut bool,
+    last_finish_reason: &mut Option<FinishReason>,
+    usage: &mut Option<Usage>,
     pending_part_ends: &mut Vec<usize>,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
     let line = line.trim();
@@ -174,13 +213,19 @@ fn parse_sse_line(
     if let Some(data) = line.strip_prefix("data: ") {
         // Check for stream end
         if data == "[DONE]" {
-            *done = true;
+            *done_seen = true;
             return None;
         }
 
         // Parse the JSON chunk
         match serde_json::from_str::<ChatCompletionChunk>(data) {
             Ok(chunk) => {
+                // Buffer usage for the terminal event; the usage chunk has
+                // empty choices and produces no part events.
+                if let Some(chunk_usage) = chunk.usage {
+                    *usage = Some(chunk_usage);
+                }
+
                 // Process each choice
                 for choice in chunk.choices {
                     let delta = choice.delta;
@@ -288,8 +333,11 @@ fn parse_sse_line(
                         }
                     }
 
-                    // Handle finish reason - emit part end events
-                    if choice.finish_reason.is_some() {
+                    // Handle finish reason - remember it for the terminal
+                    // event and emit part end events
+                    if let Some(reason) = choice.finish_reason.as_deref() {
+                        *last_finish_reason = Some(map_finish_reason(reason));
+
                         // Collect all part indices that need to be closed
                         let mut parts_to_close = Vec::new();
 
@@ -327,6 +375,47 @@ fn parse_sse_line(
     }
 
     None
+}
+
+/// Build the terminal event from the last seen finish reason and the buffered
+/// usage chunk; fields absent from the wire stay `None`.
+fn stream_complete_event(
+    finish_reason: Option<FinishReason>,
+    usage: Option<&Usage>,
+) -> ModelResponseStreamEvent {
+    let reason = finish_reason.unwrap_or(FinishReason::Stop);
+    let mut event = StreamCompleteEvent::new(reason);
+
+    if let Some(u) = usage {
+        event = event
+            .with_input_tokens(u.prompt_tokens)
+            .with_output_tokens(u.completion_tokens);
+        // The OpenAI wire format reports cached prompt tokens but has no
+        // cache-creation count, so cache_creation_tokens stays None.
+        if let Some(cached) = u
+            .prompt_tokens_details
+            .as_ref()
+            .and_then(|d| d.cached_tokens)
+        {
+            event = event.with_cache_read_tokens(cached);
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+/// Map an OpenAI finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::Stop`], matching the non-streaming
+/// response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "stop" => FinishReason::Stop,
+        "length" => FinishReason::Length,
+        "content_filter" => FinishReason::ContentFilter,
+        "tool_calls" => FinishReason::ToolCall,
+        _ => FinishReason::Stop,
+    }
 }
 
 #[cfg(test)]
@@ -394,15 +483,88 @@ mod tests {
         }
     }
 
+    /// [DONE] without a usage chunk emits exactly one terminal event with the
+    /// default finish reason and all token fields None; nothing follows it.
     #[tokio::test]
     async fn test_parse_done() {
         let bytes = vec![Ok(Bytes::from("data: [DONE]\n\n"))];
         let stream = stream::iter(bytes);
         let mut parser = OpenAIStreamParser::new(stream);
 
-        // Should return None (stream ended)
-        let event = parser.next().await;
-        assert!(event.is_none());
+        let event = parser.next().await.unwrap().unwrap();
+        match event {
+            ModelResponseStreamEvent::StreamComplete(complete) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected StreamComplete, got {:?}", other),
+        }
+
+        // The terminal event is the final event of the stream.
+        assert!(parser.next().await.is_none());
+    }
+
+    /// EOF without [DONE] emits no terminal event (truncated streams stay
+    /// detectable by the agent loop).
+    #[tokio::test]
+    async fn test_eof_without_done_emits_no_terminal_event() {
+        let chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+        let bytes = vec![Ok(make_chunk_bytes(chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the part event: {:?}",
+            events
+        );
+        assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
+    }
+
+    /// A transport error mid-stream ends the stream with the error and never
+    /// emits the terminal event afterwards.
+    #[tokio::test]
+    async fn stream_error_suppresses_terminal_event() {
+        // reqwest::Error has no public constructor; a refused connection to a
+        // closed loopback port is the cheapest real one to obtain.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let err = client
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .err()
+            .expect("connection to closed loopback port must fail");
+
+        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+        let bytes = vec![Ok(make_chunk_bytes(text_chunk)), Err(err)];
+        let stream = stream::iter(bytes);
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result);
+        }
+
+        assert_eq!(
+            events.len(),
+            2,
+            "expected only the part event and the error: {:?}",
+            events
+        );
+        assert!(matches!(
+            events[0],
+            Ok(ModelResponseStreamEvent::PartStart(_))
+        ));
+        assert!(events[1].is_err());
     }
 
     #[tokio::test]
@@ -412,9 +574,99 @@ mod tests {
         let stream = stream::iter(bytes);
         let mut parser = OpenAIStreamParser::new(stream);
 
-        // Should return None since no parts are open
+        // Should return None since no parts are open and no [DONE] arrived
         let event = parser.next().await;
         assert!(event.is_none());
+    }
+
+    /// The include_usage chunk is buffered and produces no part events; its
+    /// counts are carried on the terminal event at [DONE].
+    #[tokio::test]
+    async fn usage_chunk_then_done_populates_terminal_event() {
+        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+        let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
+
+        let bytes = vec![
+            Ok(make_chunk_bytes(text_chunk)),
+            Ok(make_chunk_bytes(finish_chunk)),
+            Ok(make_chunk_bytes(usage_chunk)),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // The usage chunk is ignored for part events: only PartStart and
+        // PartEnd precede the terminal event.
+        assert_eq!(
+            events.len(),
+            3,
+            "expected PartStart, PartEnd, StreamComplete: {:?}",
+            events
+        );
+        assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
+        assert!(matches!(events[1], ModelResponseStreamEvent::PartEnd(_)));
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(7));
+            }
+            other => panic!("expected terminal StreamComplete, got {:?}", other),
+        }
+    }
+
+    /// Finish reason strings map onto the terminal event; unknown reasons
+    /// default to Stop.
+    #[tokio::test]
+    async fn finish_reason_maps_onto_terminal_event() {
+        let cases = [
+            ("stop", FinishReason::Stop),
+            ("length", FinishReason::Length),
+            ("content_filter", FinishReason::ContentFilter),
+            ("tool_calls", FinishReason::ToolCall),
+            ("function_call", FinishReason::Stop),
+            ("unknown_reason", FinishReason::Stop),
+        ];
+
+        for (wire_reason, expected) in cases {
+            let finish_chunk = format!(
+                r#"{{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{{"index":0,"delta":{{}},"finish_reason":"{wire_reason}"}}]}}"#
+            );
+            let bytes = vec![
+                Ok(make_chunk_bytes(&finish_chunk)),
+                Ok(Bytes::from("data: [DONE]\n\n")),
+            ];
+            let stream = stream::iter(bytes);
+            let mut parser = OpenAIStreamParser::new(stream);
+
+            let mut terminals = 0;
+            let mut finish_reason = None;
+            while let Some(result) = parser.next().await {
+                if let ModelResponseStreamEvent::StreamComplete(complete) = result.unwrap() {
+                    terminals += 1;
+                    finish_reason = Some(complete.finish_reason);
+                }
+            }
+
+            assert_eq!(
+                terminals, 1,
+                "expected one terminal event for {wire_reason}"
+            );
+            assert_eq!(
+                finish_reason,
+                Some(expected),
+                "finish reason mapping for {wire_reason}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -441,7 +693,9 @@ mod tests {
     }
 
     /// Regression test: when finish_reason is received with multiple open parts
-    /// (text + tool calls), ALL PartEnd events must be emitted, not just the first.
+    /// (text + tool calls), ALL PartEnd events must be emitted, not just the
+    /// first. The terminal event follows the queued part ends and is emitted
+    /// exactly once, last.
     #[tokio::test]
     async fn test_multiple_part_ends_on_finish() {
         // Scenario: text part starts, then 2 tool calls start, then finish_reason
@@ -450,12 +704,15 @@ mod tests {
         let tool1_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{\"q\":\"test\"}"}}]}}]}"#;
         let tool2_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"lookup","arguments":"{\"id\":1}"}}]}}]}"#;
         let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
+        let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
 
         let bytes = vec![
             Ok(make_chunk_bytes(text_chunk)),
             Ok(make_chunk_bytes(tool1_chunk)),
             Ok(make_chunk_bytes(tool2_chunk)),
             Ok(make_chunk_bytes(finish_chunk)),
+            Ok(make_chunk_bytes(usage_chunk)),
+            Ok(Bytes::from("data: [DONE]\n\n")),
         ];
         let stream = stream::iter(bytes);
         let mut parser = OpenAIStreamParser::new(stream);
@@ -471,6 +728,7 @@ mod tests {
         // - 1 PartStart for tool call 1 (index 1)
         // - 1 PartStart for tool call 2 (index 2)
         // - 3 PartEnd events (for indices 0, 1, 2)
+        // - 1 StreamComplete terminal event
         let part_starts: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, ModelResponseStreamEvent::PartStart(_)))
@@ -512,5 +770,28 @@ mod tests {
             vec![0, 1, 2],
             "All part indices should be closed"
         );
+
+        // Exactly one terminal event, carrying the buffered usage, emitted
+        // after every queued part end.
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+        assert!(
+            matches!(
+                events.last(),
+                Some(ModelResponseStreamEvent::StreamComplete(_))
+            ),
+            "terminal event must be emitted last, got {:?}",
+            events.last()
+        );
+        if let Some(ModelResponseStreamEvent::StreamComplete(complete)) = events.last() {
+            assert_eq!(complete.finish_reason, FinishReason::ToolCall);
+            assert_eq!(complete.input_tokens, Some(10));
+            assert_eq!(complete.output_tokens, Some(5));
+            assert_eq!(complete.cache_creation_tokens, None);
+            assert_eq!(complete.cache_read_tokens, Some(7));
+        }
     }
 }

--- a/serdes-ai-models/src/openrouter/model.rs
+++ b/serdes-ai-models/src/openrouter/model.rs
@@ -466,4 +466,50 @@ mod tests {
         );
         assert!(body.get("provider").is_some() && body.get("transforms").is_some());
     }
+
+    /// OpenRouter streams through `OpenAIStreamParser`, so its streams
+    /// inherit the terminal StreamComplete emission at [DONE] with the
+    /// buffered usage from its include_usage request.
+    #[tokio::test]
+    async fn openrouter_stream_inherits_terminal_stream_complete() {
+        use bytes::Bytes;
+        use futures::{stream, StreamExt};
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let content = r#"{"id":"gen-1","object":"chat.completion.chunk","created":1234567890,"model":"anthropic/claude-3-opus","choices":[{"index":0,"delta":{"content":"Hi"}}]}"#;
+        let finish = r#"{"id":"gen-1","object":"chat.completion.chunk","created":1234567890,"model":"anthropic/claude-3-opus","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let usage = r#"{"id":"gen-1","object":"chat.completion.chunk","created":1234567890,"model":"anthropic/claude-3-opus","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}"#;
+
+        // request_stream wraps response.bytes_stream() in OpenAIStreamParser;
+        // feed it the SSE bytes OpenRouter returns for include_usage streams.
+        let bytes = vec![
+            Ok(Bytes::from(format!("data: {}\n\n", content))),
+            Ok(Bytes::from(format!("data: {}\n\n", finish))),
+            Ok(Bytes::from(format!("data: {}\n\n", usage))),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let mut parser = OpenAIStreamParser::new(stream::iter(bytes));
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(3));
+                assert_eq!(complete.output_tokens, Some(2));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
Every provider streaming path now ends with exactly one terminal
`StreamComplete` event carrying the finish reason and token usage.
Callers read final token counts from the stream itself instead of
making a separate non-streaming request.

## Behaviour

- OpenAI chat streaming buffers the `include_usage` chunk and emits
  the terminal event at `data: [DONE]`. OpenRouter, Azure, and Groq
  inherit the parser.
- Google and Antigravity close open parts with `PartEnd`; the terminal
  event carries the final chunk's `finishReason` and `usageMetadata`.
  `cachedContentTokenCount` maps to `cache_read_tokens`; that wire
  reports no cache-creation count.
- Cohere maps `stream-end` token counts; HuggingFace and ChatGPT OAuth
  map `response.completed` usage.
- The Responses API fallback emits the terminal event after its
  buffered part events.
- `claude_code_oauth` passes the terminal event through unchanged.

Contract: exactly one terminal event, always last, never after a
transport error. Truncated streams emit none; usage fields absent
from the wire stay `None`. Request bodies and non-streaming paths
are unchanged.

## Usage

```rust
let mut stream = model
    .request_stream(&[req], &settings, &params)
    .await?;
while let Some(event) = stream.next().await {
    if let ModelResponseStreamEvent::StreamComplete(done) = event? {
        // done.finish_reason, done.input_tokens, done.output_tokens
    }
}
```

## Motivation

`StreamCompleteEvent` existed in core but provider streams never
emitted it. Per-request token accounting required non-streaming calls
or provider-specific parsing.

I wanted to get token counts from provider responses in streaming mode; but that was missing. It no longer is.

## Notes

- Streams now yield one extra event.
- Code treating every event as content must skip `StreamComplete`.
- Version bumped 0.2.6 to 0.3.0.
- Cohere gains `CohereModel::with_base_url` for endpoint overrides.