### PR TITLE
Add flexible reasoning effort configuration for OpenAI models

### DIFF
--- a/serdes-ai-models/src/lib.rs
+++ b/serdes-ai-models/src/lib.rs
@@ -537,12 +537,38 @@ mod tests {
         let result = build_model_with_config("unknown", "model", None, None, None);
         assert!(result.is_err());
     }
+
+    /// Setting a reasoning effort builds the Responses API model; gpt-5.1
+    /// reports reasoning support only on that path.
+    #[cfg(feature = "openai")]
+    #[test]
+    fn test_build_model_extended_reasoning_effort_selects_responses_model() {
+        let config = ExtendedModelConfig::new()
+            .with_api_key("test-key")
+            .with_reasoning_effort("xhigh");
+        let model = build_model_extended("openai", "gpt-5.1", config).unwrap();
+
+        assert_eq!(model.name(), "gpt-5.1");
+        assert!(model.profile().supports_reasoning);
+    }
+
+    /// Without a reasoning effort the openai branch keeps the chat
+    /// completions model, which does not report reasoning for gpt-5.1.
+    #[cfg(feature = "openai")]
+    #[test]
+    fn test_build_model_extended_without_reasoning_effort_keeps_chat_model() {
+        let config = ExtendedModelConfig::new().with_api_key("test-key");
+        let model = build_model_extended("openai", "gpt-5.1", config).unwrap();
+
+        assert_eq!(model.name(), "gpt-5.1");
+        assert!(!model.profile().supports_reasoning);
+    }
 }
 
 /// Extended configuration options for model building.
 ///
 /// This struct allows configuring advanced model features like extended thinking
-/// for Claude models, reasoning effort for OpenAI o1/o3, etc.
+/// for Claude models, reasoning effort for OpenAI reasoning models, etc.
 #[derive(Debug, Clone, Default)]
 pub struct ExtendedModelConfig {
     /// API key (overrides environment variable)
@@ -557,7 +583,8 @@ pub struct ExtendedModelConfig {
     pub enable_thinking: bool,
     /// Budget for thinking tokens (Anthropic Claude)
     pub thinking_budget: Option<u64>,
-    /// Reasoning effort (OpenAI o1/o3)
+    /// Reasoning effort for OpenAI reasoning models (e.g. "low", "high",
+    /// "xhigh", "max"); any string is sent verbatim
     pub reasoning_effort: Option<String>,
     /// Optional same-model retry policy. Retries are disabled when omitted.
     pub retry_policy: Option<RetryPolicy>,
@@ -600,7 +627,10 @@ impl ExtendedModelConfig {
         self
     }
 
-    /// Set reasoning effort for OpenAI o1/o3 models
+    /// Set reasoning effort for OpenAI reasoning models.
+    ///
+    /// Known efforts map to named variants case-insensitively; any other
+    /// string is sent to the API verbatim.
     pub fn with_reasoning_effort(mut self, effort: impl Into<String>) -> Self {
         self.reasoning_effort = Some(effort.into());
         self
@@ -622,7 +652,8 @@ impl ExtendedModelConfig {
 /// Build a model with extended configuration options.
 ///
 /// This function extends `build_model_with_config` to support advanced features
-/// like extended thinking for Claude models.
+/// like extended thinking for Claude models and reasoning effort for OpenAI
+/// reasoning models.
 ///
 /// # Arguments
 ///
@@ -640,6 +671,12 @@ impl ExtendedModelConfig {
 ///     .with_api_key("sk-...")
 ///     .with_thinking(Some(10000));
 /// let model = build_model_extended("anthropic", "claude-3-5-sonnet-20241022", config)?;
+///
+/// // Build OpenAI reasoning model with an effort level
+/// let config = ExtendedModelConfig::new()
+///     .with_api_key("sk-...")
+///     .with_reasoning_effort("max");
+/// let model = build_model_extended("openai", "gpt-5.1", config)?;
 /// ```
 pub fn build_model_extended(
     provider: &str,
@@ -653,33 +690,39 @@ pub fn build_model_extended(
         "openai" | "gpt" => {
             #[cfg(feature = "openai")]
             {
-                let model = if let Some(ref key) = config.api_key {
-                    OpenAIChatModel::new(model_name, key)
+                // Reasoning effort exists only on the Responses API, so an
+                // effort set here selects OpenAIResponsesModel over chat
+                // completions.
+                if config.reasoning_effort.is_some() {
+                    let model = openai_responses_model_from_config(model_name, &config)?;
+                    Ok(Arc::new(model) as Arc<dyn Model>)
                 } else {
-                    OpenAIChatModel::from_env(model_name)?
-                };
+                    let model = if let Some(ref key) = config.api_key {
+                        OpenAIChatModel::new(model_name, key)
+                    } else {
+                        OpenAIChatModel::from_env(model_name)?
+                    };
 
-                let model = if let Some(ref url) = config.base_url {
-                    model.with_base_url(url)
-                } else {
-                    model
-                };
+                    let model = if let Some(ref url) = config.base_url {
+                        model.with_base_url(url)
+                    } else {
+                        model
+                    };
 
-                let model = if let Some(t) = config.timeout {
-                    model.with_timeout(t)
-                } else {
-                    model
-                };
+                    let model = if let Some(t) = config.timeout {
+                        model.with_timeout(t)
+                    } else {
+                        model
+                    };
 
-                // TODO: Add reasoning_effort support when available in OpenAIChatModel
+                    let model = if let Some(ref client) = config.client {
+                        model.with_client(client.clone())
+                    } else {
+                        model
+                    };
 
-                let model = if let Some(ref client) = config.client {
-                    model.with_client(client.clone())
-                } else {
-                    model
-                };
-
-                Ok(Arc::new(model) as Arc<dyn Model>)
+                    Ok(Arc::new(model) as Arc<dyn Model>)
+                }
             }
             #[cfg(not(feature = "openai"))]
             {
@@ -833,4 +876,47 @@ pub fn build_model_extended(
         Some(policy) => Arc::new(RetryingModel::from_arc(model, policy)),
         None => model,
     })
+}
+
+/// Build the OpenAI Responses API model for the extended config, applying
+/// the configured reasoning effort and shared connection options.
+///
+/// Returns `ModelError::Configuration` when `config.reasoning_effort` is
+/// unset, because the effort is what selects the Responses API, or when
+/// `config.api_key` is unset and `OPENAI_API_KEY` is absent.
+#[cfg(feature = "openai")]
+pub(crate) fn openai_responses_model_from_config(
+    model_name: &str,
+    config: &ExtendedModelConfig,
+) -> ModelResult<OpenAIResponsesModel> {
+    let Some(effort) = config.reasoning_effort.as_deref() else {
+        return Err(ModelError::Configuration(
+            "Reasoning effort is required to build a Responses API model.".to_string(),
+        ));
+    };
+
+    let model = if let Some(ref key) = config.api_key {
+        OpenAIResponsesModel::new(model_name, key)
+    } else {
+        OpenAIResponsesModel::from_env(model_name)?
+    }
+    .with_reasoning_effort(effort);
+
+    let model = if let Some(ref url) = config.base_url {
+        model.with_base_url(url)
+    } else {
+        model
+    };
+
+    let model = if let Some(t) = config.timeout {
+        model.with_timeout(t)
+    } else {
+        model
+    };
+
+    if let Some(ref client) = config.client {
+        Ok(model.with_client(client.clone()))
+    } else {
+        Ok(model)
+    }
 }

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 /// OpenAI Responses API model settings.
 #[derive(Debug, Clone, Default)]
 pub struct OpenAIResponsesModelSettings {
-    /// Reasoning effort: "low", "medium", "high"
+    /// Reasoning effort (e.g. "low", "high", "xhigh", "max", or any custom string)
     pub reasoning_effort: Option<ReasoningEffort>,
 
     /// Reasoning summary: "concise", "detailed", "auto"
@@ -61,24 +61,74 @@ pub struct OpenAIResponsesModelSettings {
 }
 
 /// Reasoning effort level for reasoning models.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Known efforts are named variants; newer models may accept efforts this
+/// crate does not know about, which can be expressed with
+/// [`ReasoningEffort::Custom`]. The value is sent to the API verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ReasoningEffort {
-    /// Minimal reasoning - fastest responses
+    /// Minimal reasoning - fastest responses (gpt-5 family)
+    Minimal,
+    /// Low reasoning
     Low,
     /// Balanced reasoning - default
     #[default]
     Medium,
-    /// Deep reasoning - most thorough
+    /// Deep reasoning
     High,
+    /// Extra-deep reasoning (newer models, e.g. gpt-5.1)
+    XHigh,
+    /// Maximum reasoning (newer models, e.g. gpt-5.1-pro)
+    Max,
+    /// Any other effort string, passed through verbatim.
+    Custom(String),
 }
 
 impl ReasoningEffort {
-    fn as_str(&self) -> &'static str {
+    /// The effort string sent to the API.
+    fn as_str(&self) -> &str {
         match self {
+            Self::Minimal => "minimal",
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
+            Self::XHigh => "xhigh",
+            Self::Max => "max",
+            Self::Custom(s) => s,
         }
+    }
+
+    /// Parse an effort string. Known (case-insensitive) values map to named
+    /// variants; anything else becomes [`ReasoningEffort::Custom`] with the
+    /// original string preserved.
+    pub fn parse(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "minimal" => Self::Minimal,
+            "low" => Self::Low,
+            "medium" => Self::Medium,
+            "high" => Self::High,
+            "xhigh" => Self::XHigh,
+            "max" => Self::Max,
+            _ => Self::Custom(s.to_string()),
+        }
+    }
+}
+
+impl From<&str> for ReasoningEffort {
+    fn from(s: &str) -> Self {
+        Self::parse(s)
+    }
+}
+
+impl From<String> for ReasoningEffort {
+    fn from(s: String) -> Self {
+        Self::parse(&s)
+    }
+}
+
+impl std::fmt::Display for ReasoningEffort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -702,9 +752,12 @@ impl OpenAIResponsesModel {
     }
 
     /// Set the reasoning effort level.
+    ///
+    /// Accepts a [`ReasoningEffort`] or any string; known efforts map to
+    /// named variants and unknown strings pass through verbatim.
     #[must_use]
-    pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
-        self.default_settings.reasoning_effort = Some(effort);
+    pub fn with_reasoning_effort(mut self, effort: impl Into<ReasoningEffort>) -> Self {
+        self.default_settings.reasoning_effort = Some(effort.into());
         self
     }
 
@@ -939,7 +992,7 @@ impl OpenAIResponsesModel {
             || self.default_settings.reasoning_summary.is_some()
         {
             Some(ReasoningConfig {
-                effort: self.default_settings.reasoning_effort,
+                effort: self.default_settings.reasoning_effort.clone(),
                 summary: self.default_settings.reasoning_summary,
             })
         } else {
@@ -1190,6 +1243,8 @@ impl Model for OpenAIResponsesModel {
 mod tests {
     use super::*;
 
+    /// Every effort variant serializes as its API string; custom values
+    /// pass through verbatim.
     #[test]
     fn test_reasoning_effort_serialization() {
         assert_eq!(
@@ -1204,6 +1259,43 @@ mod tests {
             serde_json::to_string(&ReasoningEffort::High).unwrap(),
             "\"high\""
         );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::Minimal).unwrap(),
+            "\"minimal\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::XHigh).unwrap(),
+            "\"xhigh\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::Max).unwrap(),
+            "\"max\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::Custom("ultra".to_string())).unwrap(),
+            "\"ultra\""
+        );
+    }
+
+    /// Known efforts parse case-insensitively; unknown strings become
+    /// `Custom` with the original casing preserved.
+    #[test]
+    fn test_reasoning_effort_parse_maps_known_and_keeps_custom_verbatim() {
+        assert_eq!(ReasoningEffort::parse("xhigh"), ReasoningEffort::XHigh);
+        assert_eq!(ReasoningEffort::parse("MAX"), ReasoningEffort::Max);
+        assert_eq!(
+            ReasoningEffort::from("Minimal"),
+            ReasoningEffort::Minimal
+        );
+        assert_eq!(
+            ReasoningEffort::from(String::from("xhigh")),
+            ReasoningEffort::XHigh
+        );
+        assert_eq!(
+            ReasoningEffort::parse("UltraDeep"),
+            ReasoningEffort::Custom("UltraDeep".to_string())
+        );
+        assert_eq!(ReasoningEffort::XHigh.to_string(), "xhigh");
     }
 
     #[test]
@@ -1239,6 +1331,58 @@ mod tests {
             model.default_settings.reasoning_effort,
             Some(ReasoningEffort::High)
         );
+    }
+
+    /// The effort builder accepts strings, mapping known values to variants.
+    #[test]
+    fn test_model_builder_accepts_effort_strings() {
+        let model = OpenAIResponsesModel::new("gpt-5.1", "sk-test")
+            .with_reasoning_effort("xhigh")
+            .with_reasoning_effort("max");
+        assert_eq!(
+            model.default_settings.reasoning_effort,
+            Some(ReasoningEffort::Max)
+        );
+    }
+
+    /// A set effort reaches the request body as the reasoning config.
+    #[test]
+    fn test_build_request_serializes_reasoning_effort() {
+        let model =
+            OpenAIResponsesModel::new("gpt-5.1-pro", "sk-test").with_reasoning_effort("max");
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let request = model.build_request(
+            &[req],
+            &ModelSettings::new(),
+            &ModelRequestParameters::new(),
+            false,
+        );
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(
+            json.contains(r#""reasoning":{"effort":"max"}"#),
+            "expected max effort in request, got: {json}"
+        );
+    }
+
+    /// The extended-config path applies the configured effort and options
+    /// to the built Responses model, not just the model selection.
+    #[test]
+    fn test_extended_config_applies_effort_to_responses_model() {
+        let config = crate::ExtendedModelConfig::new()
+            .with_api_key("test-key")
+            .with_reasoning_effort("xhigh")
+            .with_base_url("https://custom.api.com/v1");
+
+        let model = crate::openai_responses_model_from_config("gpt-5.1", &config).unwrap();
+
+        assert_eq!(
+            model.default_settings.reasoning_effort,
+            Some(ReasoningEffort::XHigh)
+        );
+        assert_eq!(model.base_url, "https://custom.api.com/v1");
     }
 
     #[test]

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -1283,10 +1283,7 @@ mod tests {
     fn test_reasoning_effort_parse_maps_known_and_keeps_custom_verbatim() {
         assert_eq!(ReasoningEffort::parse("xhigh"), ReasoningEffort::XHigh);
         assert_eq!(ReasoningEffort::parse("MAX"), ReasoningEffort::Max);
-        assert_eq!(
-            ReasoningEffort::from("Minimal"),
-            ReasoningEffort::Minimal
-        );
+        assert_eq!(ReasoningEffort::from("Minimal"), ReasoningEffort::Minimal);
         assert_eq!(
             ReasoningEffort::from(String::from("xhigh")),
             ReasoningEffort::XHigh


### PR DESCRIPTION
## What changed

Setting a reasoning effort now works for OpenAI models. `build_model_extended`
sends the effort through the Responses API instead of ignoring it. The effort
type also accepts new and custom levels.

- `ReasoningEffort` adds `Minimal`, `XHigh`, `Max`, and `Custom(String)`.
- `ReasoningEffort::parse` maps known strings case-insensitively; unknown
  strings reach the API verbatim as `Custom`.
- `with_reasoning_effort` now takes any string, not just a known variant.
- A set `reasoning_effort` selects `OpenAIResponsesModel` over the chat model,
  because the effort exists only on the Responses API.
- The shared options (`api_key`, `base_url`, `timeout`, `client`) still apply
  on the Responses path.

## Usage

```rust
let config = ExtendedModelConfig::new()
    .with_api_key("sk-...")
    .with_reasoning_effort("max");
let model = build_model_extended("openai", "gpt-5.1", config)?;
```

## Motivation

Newer models accept efforts beyond low/medium/high: `xhigh` on gpt-5.1 and
`max` on gpt-5.1-pro. The old enum rejected them. The extended config also
ignored `reasoning_effort` entirely on the OpenAI branch.

## Notes

Before, callers that set `reasoning_effort` on the OpenAI branch got a chat
model with the value dropped. They now get a Responses model with reasoning
enabled.