### PR TITLE
Integrate PRs #51, #52, #53, #54, #55 — streaming usage, custom headers, reasoning effort (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,6 +290,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `with_header(name, value)` and `with_appended_header(name, value)` builder methods to `AnthropicModel` for attaching custom HTTP headers to every request:
+  - `with_header()` replaces any existing value of that header, including the library's own (`x-api-key`, `anthropic-version`, `Content-Type`, `anthropic-beta`) - no header is protected.
+  - `with_appended_header()` adds a value while keeping existing ones, for multi-valued headers such as `anthropic-beta`. It is the wrong choice for single-valued headers like `x-api-key`, where appending sends the header twice instead of overriding it.
+  - Header names and values are trusted caller configuration, not end-user input: since no header is protected, forwarding user-controlled data into these builders would let that user overwrite `x-api-key`.
+  - Header construction for the streaming and non-streaming paths is consolidated into a single `build_headers()`; an invalid header name or value now surfaces as `ModelError::Configuration` naming the header (never its value) instead of a late transport error.
+
 ### Planned
 - OpenAI Realtime API support
 - Cohere provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.7] - 2026-07-19
+## [0.3.0] - 2026-08-24
+
+Combined release integrating PRs #51, #52, #53, #54 and #55. Streaming is now a
+fully observable path: providers emit a terminal `StreamComplete` carrying token
+usage, and the agent surfaces that usage through `AgentStreamEvent`.
 
 ### Added
+- Every provider streaming path now ends with exactly one terminal `StreamComplete` event carrying the finish reason and token usage, so callers read final token counts from the stream itself instead of issuing a separate non-streaming request (#54):
+  - OpenAI chat streaming buffers the `include_usage` chunk and emits the terminal event at `data: [DONE]`; OpenRouter, Azure and Groq inherit the parser.
+  - Google and Antigravity close open parts with `PartEnd`; the terminal event carries the final chunk's `finishReason` and `usageMetadata`, mapping `cachedContentTokenCount` to `cache_read_tokens` (that wire reports no cache-creation count).
+  - Cohere maps `stream-end` token counts; HuggingFace and ChatGPT OAuth map `response.completed` usage; the Responses API fallback emits the terminal event after its buffered part events; `claude_code_oauth` passes it through unchanged.
+  - Contract: exactly one terminal event, always last, never after a transport error. Truncated streams emit none; usage fields absent from the wire stay `None`. Request bodies and non-streaming paths are unchanged.
+- Added `CohereModel::with_base_url` for endpoint overrides (#54).
+- Added `with_header(name, value)` and `with_appended_header(name, value)` builder methods to `AnthropicModel` for attaching custom HTTP headers to every request (#52):
+  - `with_header()` replaces any existing value of that header, including the library's own (`x-api-key`, `anthropic-version`, `Content-Type`, `anthropic-beta`) - no header is protected.
+  - `with_appended_header()` adds a value while keeping existing ones, for multi-valued headers such as `anthropic-beta`. It is the wrong choice for single-valued headers like `x-api-key`, where appending sends the header twice instead of overriding it.
+  - Header names and values are trusted caller configuration, not end-user input: since no header is protected, forwarding user-controlled data into these builders would let that user overwrite `x-api-key`.
+  - Header construction for the streaming and non-streaming paths is consolidated into a single `build_headers()`; an invalid header name or value now surfaces as `ModelError::Configuration` naming the header (never its value) instead of a late transport error.
+- `ReasoningEffort` gains `Minimal`, `XHigh`, `Max` and `Custom(String)` variants, and `with_reasoning_effort` now accepts any string (#55):
+  - `ReasoningEffort::parse` maps known strings case-insensitively; unknown strings reach the API verbatim as `Custom`, supporting newer efforts such as `xhigh` on gpt-5.1 and `max` on gpt-5.1-pro.
+  - `build_model_extended` now honours `reasoning_effort` on the OpenAI branch, selecting `OpenAIResponsesModel` (the effort exists only on the Responses API) while still applying the shared `api_key`, `base_url`, `timeout` and `client` options.
 - Token usage is now surfaced through the streaming `AgentStreamEvent` path (`run_stream`), matching the non-streaming `run()` path:
   - `AgentStreamEvent::ResponseComplete` now carries `usage: Option<RequestUsage>` (per-model-response token usage; `None` when the provider reports none).
   - `AgentStreamEvent::RunComplete` now carries `usage: RunUsage` (run-aggregate token usage, the field-wise sum of per-step usage).
@@ -20,8 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Streaming runs (`run_stream`) against an Anthropic model no longer re-issue the same request 3-4 times for a single, tool-less completion. The agent loop ended a run only on `FinishReason::Stop`, but the Anthropic streaming parser maps normal completions to `EndTurn` (the non-streaming parser maps `end_turn` to `Stop`, so only streaming was affected). The loop now ends on the existing completeness predicate `FinishReason::is_complete()` (`Stop | EndTurn | StopSequence`), so a normal streamed completion terminates in exactly one round - eliminating the redundant model calls, latency, and token cost. Tool-call rounds are unaffected (they continue before the completion check).
   - Note: a `max_tokens`-truncated (`Length`) streamed completion is still not treated as terminal and can re-issue the request; this pre-existing behavior is now logged (via `warn!`) and tracked as a follow-up.
 
-### Note
-- Adding fields to these public `AgentStreamEvent` struct-variants is source-breaking for downstream code that matches them exhaustively without `..`.
+### Changed
+- Version bump to `0.3.0` across workspace crates.
+- Nix devshell exports `OPENSSL_LIB_DIR`, `OPENSSL_INCLUDE_DIR`, `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` so `native-tls` builds work; nixpkgs and rust-overlay locks updated, moving the locked Rust stable toolchain (#53).
+
+### Breaking
+- Streams now yield one extra event: code that treats every event as content must skip `StreamComplete` (#54).
+- Adding `usage` fields to the public `AgentStreamEvent` struct-variants is source-breaking for downstream code that matches them exhaustively without `..` (#51).
+- Callers that previously set `reasoning_effort` on the OpenAI branch of `build_model_extended` received a chat model with the value silently dropped; they now receive a Responses model with reasoning enabled (#55).
 
 ## [0.2.6] - 2025-07-11
 
@@ -307,13 +331,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 
 ## [Unreleased]
-
-### Added
-- Added `with_header(name, value)` and `with_appended_header(name, value)` builder methods to `AnthropicModel` for attaching custom HTTP headers to every request:
-  - `with_header()` replaces any existing value of that header, including the library's own (`x-api-key`, `anthropic-version`, `Content-Type`, `anthropic-beta`) - no header is protected.
-  - `with_appended_header()` adds a value while keeping existing ones, for multi-valued headers such as `anthropic-beta`. It is the wrong choice for single-valued headers like `x-api-key`, where appending sends the header twice instead of overriding it.
-  - Header names and values are trusted caller configuration, not end-user input: since no header is protected, forwarding user-controlled data into these builders would let that user overwrite `x-api-key`.
-  - Header construction for the streaming and non-streaming paths is consolidated into a single `build_headers()`; an invalid header name or value now surfaces as `ModelError::Configuration` naming the header (never its value) instead of a late transport error.
 
 ### Planned
 - OpenAI Realtime API support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-07-19
+
+### Added
+- Token usage is now surfaced through the streaming `AgentStreamEvent` path (`run_stream`), matching the non-streaming `run()` path:
+  - `AgentStreamEvent::ResponseComplete` now carries `usage: Option<RequestUsage>` (per-model-response token usage; `None` when the provider reports none).
+  - `AgentStreamEvent::RunComplete` now carries `usage: RunUsage` (run-aggregate token usage, the field-wise sum of per-step usage).
+  - `AgentStreamEvent::Cancelled` now carries `usage: RunUsage` (partial run-aggregate accumulated up to cancellation).
+- Both the standard and cancellable streaming loops now accumulate per-response usage run-wide, mirroring `run()`.
+
+### Fixed
+- Streaming runs (`run_stream`) over models whose parser does not emit a terminal `StreamComplete` event no longer collapse to an empty/errored result. A change in the streaming-resilience work (#39) made the agent run-loop treat the absence of a terminal `StreamComplete` as a premature EOF, which incorrectly broke every non-Anthropic provider (OpenAI/Google/Groq/etc., whose parsers never emit `StreamComplete`) as well as in-memory test models - collapsing otherwise-valid runs to "no response". The run-loop now treats a clean stream end (content produced, no explicit error) as a successful completion (`FinishReason::Stop`). Anthropic's explicit truncation detection (`IncompleteStream` on a missing `message_stop`/partial frame) is unchanged, and the empty-stream guard still errors on a stream that produced no content.
+  - Note: for non-Anthropic providers, whose parsers do not signal truncation, a genuinely truncated stream is now accepted as a normal completion (the pre-#39 behavior). Adding real termination detection for those parsers is tracked as a follow-up.
+- Streaming runs (`run_stream`) against an Anthropic model no longer re-issue the same request 3-4 times for a single, tool-less completion. The agent loop ended a run only on `FinishReason::Stop`, but the Anthropic streaming parser maps normal completions to `EndTurn` (the non-streaming parser maps `end_turn` to `Stop`, so only streaming was affected). The loop now ends on the existing completeness predicate `FinishReason::is_complete()` (`Stop | EndTurn | StopSequence`), so a normal streamed completion terminates in exactly one round - eliminating the redundant model calls, latency, and token cost. Tool-call rounds are unaffected (they continue before the completion check).
+  - Note: a `max_tokens`-truncated (`Length`) streamed completion is still not treated as terminal and can re-issue the request; this pre-existing behavior is now logged (via `warn!`) and tracked as a follow-up.
+
+### Note
+- Adding fields to these public `AgentStreamEvent` struct-variants is source-breaking for downstream code that matches them exhaustively without `..`.
+
 ## [0.2.6] - 2025-07-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "futures",
  "pretty_assertions",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-a2a"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-agent"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-core"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-embeddings"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-evals"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-graph"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-macros"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-mcp"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-models"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-output"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-providers"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-retries"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-streaming"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-tools"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-toolsets"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-ui"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "futures",
  "pretty_assertions",
@@ -2949,7 +2949,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-a2a"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "axum",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-agent"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "base64",
@@ -3023,7 +3023,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-embeddings"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-evals"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-graph"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3076,7 +3076,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-macros"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-mcp"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-models"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-output"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-providers"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "base64",
@@ -3188,7 +3188,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-retries"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-streaming"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-tools"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-toolsets"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "indexmap",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "serdes-ai-ui"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["serdes-ai contributors"]
@@ -93,21 +93,21 @@ pretty_assertions = "1.4"
 regex = "1.12"
 
 # Internal crates
-serdes-ai-core = { path = "serdes-ai-core", version = "0.2.6" }
-serdes-ai-agent = { path = "serdes-ai-agent", version = "0.2.6" }
-serdes-ai-models = { path = "serdes-ai-models", version = "0.2.6" }
-serdes-ai-providers = { path = "serdes-ai-providers", version = "0.2.6" }
-serdes-ai-tools = { path = "serdes-ai-tools", version = "0.2.6" }
-serdes-ai-toolsets = { path = "serdes-ai-toolsets", version = "0.2.6" }
-serdes-ai-output = { path = "serdes-ai-output", version = "0.2.6" }
-serdes-ai-streaming = { path = "serdes-ai-streaming", version = "0.2.6" }
-serdes-ai-mcp = { path = "serdes-ai-mcp", version = "0.2.6" }
-serdes-ai-embeddings = { path = "serdes-ai-embeddings", version = "0.2.6" }
-serdes-ai-retries = { path = "serdes-ai-retries", version = "0.2.6" }
-serdes-ai-graph = { path = "serdes-ai-graph", version = "0.2.6" }
-serdes-ai-evals = { path = "serdes-ai-evals", version = "0.2.6" }
-serdes-ai-macros = { path = "serdes-ai-macros", version = "0.2.6" }
-serdes-ai-a2a = { path = "serdes-ai-a2a", version = "0.2.6" }
+serdes-ai-core = { path = "serdes-ai-core", version = "0.3.0" }
+serdes-ai-agent = { path = "serdes-ai-agent", version = "0.3.0" }
+serdes-ai-models = { path = "serdes-ai-models", version = "0.3.0" }
+serdes-ai-providers = { path = "serdes-ai-providers", version = "0.3.0" }
+serdes-ai-tools = { path = "serdes-ai-tools", version = "0.3.0" }
+serdes-ai-toolsets = { path = "serdes-ai-toolsets", version = "0.3.0" }
+serdes-ai-output = { path = "serdes-ai-output", version = "0.3.0" }
+serdes-ai-streaming = { path = "serdes-ai-streaming", version = "0.3.0" }
+serdes-ai-mcp = { path = "serdes-ai-mcp", version = "0.3.0" }
+serdes-ai-embeddings = { path = "serdes-ai-embeddings", version = "0.3.0" }
+serdes-ai-retries = { path = "serdes-ai-retries", version = "0.3.0" }
+serdes-ai-graph = { path = "serdes-ai-graph", version = "0.3.0" }
+serdes-ai-evals = { path = "serdes-ai-evals", version = "0.3.0" }
+serdes-ai-macros = { path = "serdes-ai-macros", version = "0.3.0" }
+serdes-ai-a2a = { path = "serdes-ai-a2a", version = "0.3.0" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "MIT"
 authors = ["serdes-ai contributors"]
@@ -93,21 +93,21 @@ pretty_assertions = "1.4"
 regex = "1.12"
 
 # Internal crates
-serdes-ai-core = { path = "serdes-ai-core", version = "0.2.6" }
-serdes-ai-agent = { path = "serdes-ai-agent", version = "0.2.6" }
-serdes-ai-models = { path = "serdes-ai-models", version = "0.2.6" }
-serdes-ai-providers = { path = "serdes-ai-providers", version = "0.2.6" }
-serdes-ai-tools = { path = "serdes-ai-tools", version = "0.2.6" }
-serdes-ai-toolsets = { path = "serdes-ai-toolsets", version = "0.2.6" }
-serdes-ai-output = { path = "serdes-ai-output", version = "0.2.6" }
-serdes-ai-streaming = { path = "serdes-ai-streaming", version = "0.2.6" }
-serdes-ai-mcp = { path = "serdes-ai-mcp", version = "0.2.6" }
-serdes-ai-embeddings = { path = "serdes-ai-embeddings", version = "0.2.6" }
-serdes-ai-retries = { path = "serdes-ai-retries", version = "0.2.6" }
-serdes-ai-graph = { path = "serdes-ai-graph", version = "0.2.6" }
-serdes-ai-evals = { path = "serdes-ai-evals", version = "0.2.6" }
-serdes-ai-macros = { path = "serdes-ai-macros", version = "0.2.6" }
-serdes-ai-a2a = { path = "serdes-ai-a2a", version = "0.2.6" }
+serdes-ai-core = { path = "serdes-ai-core", version = "0.2.7" }
+serdes-ai-agent = { path = "serdes-ai-agent", version = "0.2.7" }
+serdes-ai-models = { path = "serdes-ai-models", version = "0.2.7" }
+serdes-ai-providers = { path = "serdes-ai-providers", version = "0.2.7" }
+serdes-ai-tools = { path = "serdes-ai-tools", version = "0.2.7" }
+serdes-ai-toolsets = { path = "serdes-ai-toolsets", version = "0.2.7" }
+serdes-ai-output = { path = "serdes-ai-output", version = "0.2.7" }
+serdes-ai-streaming = { path = "serdes-ai-streaming", version = "0.2.7" }
+serdes-ai-mcp = { path = "serdes-ai-mcp", version = "0.2.7" }
+serdes-ai-embeddings = { path = "serdes-ai-embeddings", version = "0.2.7" }
+serdes-ai-retries = { path = "serdes-ai-retries", version = "0.2.7" }
+serdes-ai-graph = { path = "serdes-ai-graph", version = "0.2.7" }
+serdes-ai-evals = { path = "serdes-ai-evals", version = "0.2.7" }
+serdes-ai-macros = { path = "serdes-ai-macros", version = "0.2.7" }
+serdes-ai-a2a = { path = "serdes-ai-a2a", version = "0.2.7" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773476965,
-        "narHash": "sha256-Laaj25PvGeoP5SPhMfMGxvWqM6ZjZ6LdUeEhP6b3czY=",
+        "lastModified": 1787209939,
+        "narHash": "sha256-WvvHR4kSQLAbtouMC/ruZ5UpLwlUcY3K4FAllMN+yGk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f82ce7af0b79ac154b12e27ed800aeb97413723c",
+        "rev": "391b592eb44808b3bd0cb80bb71b63a5a118b8bb",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773457417,
-        "narHash": "sha256-waABTSxPdbxml4BhcabHhyQF02Qnj27qRU4ard0mTQo=",
+        "lastModified": 1787281715,
+        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "055977c30249484010750e03074c744dcdaa0d23",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,12 @@
       in {
         devShells.default = pkgs.mkShell {
           packages = [ rust pkgs.openssl pkgs.pkg-config pkgs.clang pkgs.lld ];
+          # openssl-sys discovery: explicit lib/include dirs; pkg-config as fallback.
+          OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+          OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+          # Runtime resolution of libssl.so.3 for binaries built in the shell.
+          LD_LIBRARY_PATH = "${pkgs.openssl.out}/lib";
         };
       }
     );

--- a/serdes-ai-agent/src/stream.rs
+++ b/serdes-ai-agent/src/stream.rs
@@ -99,7 +99,14 @@ pub enum AgentStreamEvent {
     /// Thinking delta (for reasoning models).
     ThinkingDelta { text: String },
     /// Model response completed.
-    ResponseComplete { step: u32 },
+    ResponseComplete {
+        /// 1-based index of the model response within the run.
+        step: u32,
+        /// Token usage the provider reported for THIS model response.
+        ///
+        /// `None` means the provider did not report usage for this step.
+        usage: Option<RequestUsage>,
+    },
     /// Output ready.
     OutputReady,
     /// Run completed.
@@ -108,6 +115,11 @@ pub enum AgentStreamEvent {
         /// Complete message history from this run (system prompt, user prompts,
         /// assistant responses, tool calls and returns).
         messages: Vec<ModelRequest>,
+        /// Field-wise aggregate of the per-step `RequestUsage` values across
+        /// every model response in this run; `total_tokens` is derived from
+        /// request+response when a provider omits it. Equivalent to the
+        /// `AgentRunResult.usage` returned by the non-streaming `run()` path.
+        usage: RunUsage,
     },
     /// Error occurred.
     Error { message: String },
@@ -119,6 +131,11 @@ pub enum AgentStreamEvent {
         partial_thinking: Option<String>,
         /// Tool calls that were in progress when cancelled.
         pending_tools: Vec<String>,
+        /// Run-aggregate token usage accumulated up to the point of cancellation.
+        ///
+        /// A cancelled run still reports what it spent so far; may be all-zero
+        /// (`RunUsage::default()`) if cancelled before any usage-bearing response.
+        usage: RunUsage,
     },
 }
 
@@ -671,28 +688,19 @@ impl AgentStream {
                     "AgentStream: finished processing model stream"
                 );
 
-                // If the stream did not produce a terminal StreamComplete event,
-                // this is a premature EOF — emit an error and abort.
-                let stream_finish_reason = match stream_finish_reason {
-                    Some(reason) => reason,
-                    None => {
-                        let _ = tx
-                            .send(Ok(AgentStreamEvent::Error {
-                                message:
-                                    "model stream ended without a terminal StreamComplete event"
-                                        .to_string(),
-                            }))
-                            .await;
-                        let _ = tx
-                            .send(Err(AgentRunError::Model(
-                                serdes_ai_models::ModelError::incomplete_stream(
-                                    "model stream ended without a terminal StreamComplete event",
-                                ),
-                            )))
-                            .await;
-                        return;
-                    }
-                };
+                // A stream may legitimately end without an explicit terminal StreamComplete
+                // (in-memory/mock streams, and OpenAI/Google/etc. parsers which never emit one).
+                // Anthropic's parser surfaces REAL truncation separately as an explicit Err
+                // (handled above), so a clean end here with content is a successful completion.
+                // Default the finish reason to Stop. (The `response_parts.is_empty()` guard in
+                // the next block still catches a stream that produced nothing.)
+                if stream_finish_reason.is_none() {
+                    debug!(
+                        parts = response_parts.len(),
+                        "stream ended without terminal StreamComplete; defaulting finish_reason=Stop"
+                    );
+                }
+                let stream_finish_reason = stream_finish_reason.unwrap_or(FinishReason::Stop);
 
                 // If the stream produced no parts at all, treat it as an error
                 if response_parts.is_empty() {
@@ -727,9 +735,18 @@ impl AgentStream {
                 finish_reason = response.finish_reason;
                 responses.push(response.clone());
 
+                // Accumulate run-wide usage, mirroring the non-streaming run()
+                // path (run.rs:398-399) so streaming and non-streaming agree.
+                if let Some(u) = &response.usage {
+                    usage.add_request(u.clone());
+                }
+
                 // Emit ResponseComplete
                 let _ = tx
-                    .send(Ok(AgentStreamEvent::ResponseComplete { step }))
+                    .send(Ok(AgentStreamEvent::ResponseComplete {
+                        step,
+                        usage: response.usage.clone(),
+                    }))
                     .await;
 
                 // Check for tool calls that need execution
@@ -854,7 +871,7 @@ impl AgentStream {
                 }
 
                 // No tool calls - check finish condition
-                if finish_reason == Some(FinishReason::Stop) {
+                if finish_reason.is_some_and(|r| r.is_complete()) {
                     // Add final response to messages for complete history
                     let mut response_req = ModelRequest::new();
                     response_req
@@ -864,6 +881,19 @@ impl AgentStream {
 
                     finished = true;
                     let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
+                } else if let Some(r) = finish_reason {
+                    // finish_reason is Some but NOT complete, and there were no
+                    // tool calls (the tool-call path `continue`d before reaching
+                    // here). The loop is about to silently re-issue the same
+                    // request - make that observable. NOT a behavior change:
+                    // termination is unchanged; termination-on-Length/etc. is a
+                    // separate P2 follow-up. `let _ = &r` keeps `r` "used" so the
+                    // no-op `warn!` build (tracing-integration off) stays clean.
+                    let _ = &r;
+                    warn!(
+                        finish_reason = ?r,
+                        "stream completed with a non-terminal finish reason and no tool calls; re-issuing request (this can loop - see follow-up for Length/ContentFilter/Error handling)"
+                    );
                 }
             }
 
@@ -872,6 +902,7 @@ impl AgentStream {
                 .send(Ok(AgentStreamEvent::RunComplete {
                     run_id: run_id_clone,
                     messages,
+                    usage,
                 }))
                 .await;
         });
@@ -1001,6 +1032,7 @@ impl AgentStream {
                                 Some(accumulated_thinking)
                             },
                             pending_tools: pending_tool_names,
+                            usage: usage.clone(),
                         }))
                         .await;
                     let _ = tx.send(Err(AgentRunError::Cancelled)).await;
@@ -1112,6 +1144,7 @@ impl AgentStream {
                                         Some(accumulated_thinking)
                                     },
                                     pending_tools: pending_tool_names,
+                                    usage: usage.clone(),
                                 }))
                                 .await;
                             let _ = tx.send(Err(AgentRunError::Cancelled)).await;
@@ -1247,28 +1280,19 @@ impl AgentStream {
                     }
                 }
 
-                // If the stream did not produce a terminal StreamComplete event,
-                // this is a premature EOF — emit an error and abort.
-                let stream_finish_reason = match stream_finish_reason {
-                    Some(reason) => reason,
-                    None => {
-                        let _ = tx
-                            .send(Ok(AgentStreamEvent::Error {
-                                message:
-                                    "model stream ended without a terminal StreamComplete event"
-                                        .to_string(),
-                            }))
-                            .await;
-                        let _ = tx
-                            .send(Err(AgentRunError::Model(
-                                serdes_ai_models::ModelError::incomplete_stream(
-                                    "model stream ended without a terminal StreamComplete event",
-                                ),
-                            )))
-                            .await;
-                        return;
-                    }
-                };
+                // A stream may legitimately end without an explicit terminal StreamComplete
+                // (in-memory/mock streams, and OpenAI/Google/etc. parsers which never emit one).
+                // Anthropic's parser surfaces REAL truncation separately as an explicit Err
+                // (handled above), so a clean end here with content is a successful completion.
+                // Default the finish reason to Stop. (The `response_parts.is_empty()` guard in
+                // the next block still catches a stream that produced nothing.)
+                if stream_finish_reason.is_none() {
+                    debug!(
+                        parts = response_parts.len(),
+                        "stream ended without terminal StreamComplete; defaulting finish_reason=Stop"
+                    );
+                }
+                let stream_finish_reason = stream_finish_reason.unwrap_or(FinishReason::Stop);
 
                 // If the stream produced no parts at all, treat it as an error
                 if response_parts.is_empty() {
@@ -1303,8 +1327,17 @@ impl AgentStream {
                 finish_reason = response.finish_reason;
                 responses.push(response.clone());
 
+                // Accumulate run-wide usage, mirroring the non-streaming run()
+                // path (run.rs:398-399) so streaming and non-streaming agree.
+                if let Some(u) = &response.usage {
+                    usage.add_request(u.clone());
+                }
+
                 let _ = tx
-                    .send(Ok(AgentStreamEvent::ResponseComplete { step }))
+                    .send(Ok(AgentStreamEvent::ResponseComplete {
+                        step,
+                        usage: response.usage.clone(),
+                    }))
                     .await;
 
                 // Check for tool calls
@@ -1346,6 +1379,7 @@ impl AgentStream {
                                         Some(accumulated_thinking)
                                     },
                                     pending_tools: pending_tool_names,
+                                    usage: usage.clone(),
                                 }))
                                 .await;
                             let _ = tx.send(Err(AgentRunError::Cancelled)).await;
@@ -1444,7 +1478,7 @@ impl AgentStream {
                     continue;
                 }
 
-                if finish_reason == Some(FinishReason::Stop) {
+                if finish_reason.is_some_and(|r| r.is_complete()) {
                     // Add final response to messages for complete history
                     let mut response_req = ModelRequest::new();
                     response_req
@@ -1454,6 +1488,19 @@ impl AgentStream {
 
                     finished = true;
                     let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
+                } else if let Some(r) = finish_reason {
+                    // finish_reason is Some but NOT complete, and there were no
+                    // tool calls (the tool-call path `continue`d before reaching
+                    // here). The loop is about to silently re-issue the same
+                    // request - make that observable. NOT a behavior change:
+                    // termination is unchanged; termination-on-Length/etc. is a
+                    // separate P2 follow-up. `let _ = &r` keeps `r` "used" so the
+                    // no-op `warn!` build (tracing-integration off) stays clean.
+                    let _ = &r;
+                    warn!(
+                        finish_reason = ?r,
+                        "stream completed with a non-terminal finish reason and no tool calls; re-issuing request (this can loop - see follow-up for Length/ContentFilter/Error handling)"
+                    );
                 }
             }
 
@@ -1461,6 +1508,7 @@ impl AgentStream {
                 .send(Ok(AgentStreamEvent::RunComplete {
                     run_id: run_id_clone,
                     messages,
+                    usage,
                 }))
                 .await;
         });
@@ -1554,11 +1602,13 @@ mod tests {
             AgentStreamEvent::RunComplete {
                 run_id: "123".to_string(),
                 messages: vec![],
+                usage: RunUsage::default(),
             },
             AgentStreamEvent::Cancelled {
                 partial_text: Some("partial".to_string()),
                 partial_thinking: None,
                 pending_tools: vec!["tool1".to_string()],
+                usage: RunUsage::default(),
             },
         ];
 
@@ -1571,6 +1621,7 @@ mod tests {
             partial_text: Some("Hello, I was saying...".to_string()),
             partial_thinking: Some("Let me think about this...".to_string()),
             pending_tools: vec!["search".to_string(), "fetch".to_string()],
+            usage: RunUsage::default(),
         };
 
         let debug = format!("{:?}", event);
@@ -1585,17 +1636,24 @@ mod tests {
             partial_text: None,
             partial_thinking: None,
             pending_tools: vec![],
+            usage: RunUsage::default(),
         };
 
         if let AgentStreamEvent::Cancelled {
             partial_text,
             partial_thinking,
             pending_tools,
+            usage,
         } = event
         {
             assert!(partial_text.is_none());
             assert!(partial_thinking.is_none());
             assert!(pending_tools.is_empty());
+            // No usage-bearing response occurred, so the partial aggregate is empty.
+            assert_eq!(usage.request_count, 0);
+            assert_eq!(usage.request_tokens, 0);
+            assert_eq!(usage.response_tokens, 0);
+            assert_eq!(usage.total_tokens, 0);
         } else {
             panic!("Expected Cancelled event");
         }
@@ -1614,6 +1672,464 @@ mod tests {
         assert_eq!(usage.request_tokens, Some(10));
         assert_eq!(usage.response_tokens, Some(5));
         assert_eq!(usage.total_tokens, Some(15));
+        assert_eq!(usage.cache_creation_tokens, Some(3));
+        assert_eq!(usage.cache_read_tokens, Some(7));
+    }
+
+    // ========================================================================
+    // Usage-surfacing tests (T1-T4): token usage flows through the streaming
+    // `AgentStreamEvent` path, mirroring the non-streaming `run()` path.
+    // ========================================================================
+
+    /// T1 (R1): `ResponseComplete` carries the per-step provider usage.
+    #[tokio::test]
+    async fn test_response_complete_reports_per_step_usage() {
+        let model = FunctionModel::with_stream(move |_messages, _settings| {
+            let events = vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("done")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+                Ok(ModelResponseStreamEvent::StreamComplete(
+                    StreamCompleteEvent::new(FinishReason::Stop)
+                        .with_input_tokens(10)
+                        .with_output_tokens(5),
+                )),
+            ];
+            Box::pin(stream::iter(events))
+        });
+
+        let agent = agent(model).build();
+        let mut stream = agent
+            .run_stream("hello", ())
+            .await
+            .expect("stream should start");
+
+        let mut response_completes = Vec::new();
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event should be ok");
+            if let AgentStreamEvent::ResponseComplete { step, usage } = event {
+                response_completes.push((step, usage));
+            }
+        }
+
+        assert_eq!(
+            response_completes.len(),
+            1,
+            "expected exactly one ResponseComplete"
+        );
+        let (step, usage) = &response_completes[0];
+        assert_eq!(*step, 1);
+        let usage = usage.as_ref().expect("per-step usage should be present");
+        assert_eq!(usage.request_tokens, Some(10));
+        assert_eq!(usage.response_tokens, Some(5));
+        assert_eq!(usage.total_tokens, Some(15));
+    }
+
+    /// T2 (R1 / AC1.2): `ResponseComplete.usage` is `None` when the provider
+    /// reports no token fields.
+    #[tokio::test]
+    async fn test_response_complete_usage_none_when_provider_reports_nothing() {
+        let model = FunctionModel::with_stream(move |_messages, _settings| {
+            let events = vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("done")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+                Ok(ModelResponseStreamEvent::StreamComplete(
+                    StreamCompleteEvent::new(FinishReason::Stop),
+                )),
+            ];
+            Box::pin(stream::iter(events))
+        });
+
+        let agent = agent(model).build();
+        let mut stream = agent
+            .run_stream("hello", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_response_complete = false;
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event should be ok");
+            if let AgentStreamEvent::ResponseComplete { usage, .. } = event {
+                saw_response_complete = true;
+                assert!(
+                    usage.is_none(),
+                    "usage should be None when provider reports no tokens"
+                );
+            }
+        }
+        assert!(saw_response_complete, "expected a ResponseComplete event");
+    }
+
+    /// T3 (R2 + R3): `RunComplete.usage` is the field-wise aggregate of every
+    /// step's usage across a real 2-request tool loop, and equals the sum of
+    /// the per-step `ResponseComplete.usage` values observed in the same stream.
+    #[tokio::test]
+    async fn test_run_complete_reports_aggregate_usage() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let events = if step == 0 {
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::ToolCall(
+                                ToolCallPart::new("demo_tool", ToolCallArgs::string("{}"))
+                                    .with_tool_call_id("call_1"),
+                            ),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::ToolCall)
+                                .with_input_tokens(10)
+                                .with_output_tokens(5),
+                        )),
+                    ]
+                } else {
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("done")),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::Stop)
+                                .with_input_tokens(4)
+                                .with_output_tokens(6),
+                        )),
+                    ]
+                };
+                Box::pin(stream::iter(events))
+            })
+        };
+
+        let agent = agent(model)
+            .tool_fn(
+                "demo_tool",
+                "Demo tool",
+                |_ctx, _args: serde_json::Value| Ok(serdes_ai_tools::ToolReturn::text("ok")),
+            )
+            .build();
+
+        let mut stream = agent
+            .run_stream("trigger tool then finish", ())
+            .await
+            .expect("stream should start");
+
+        let mut per_step_request = 0u64;
+        let mut per_step_response = 0u64;
+        let mut per_step_total = 0u64;
+        let mut run_complete_usage = None;
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event should be ok");
+            match event {
+                AgentStreamEvent::ResponseComplete { usage: Some(u), .. } => {
+                    per_step_request += u.request_tokens.unwrap_or(0);
+                    per_step_response += u.response_tokens.unwrap_or(0);
+                    per_step_total += u.total_tokens.unwrap_or(0);
+                }
+                AgentStreamEvent::RunComplete { usage, .. } => {
+                    run_complete_usage = Some(usage);
+                }
+                _ => {}
+            }
+        }
+
+        let usage = run_complete_usage.expect("expected a RunComplete event");
+        // Field-wise sum of both steps: input 10+4, output 5+6, total 15+10.
+        assert_eq!(usage.request_tokens, 14);
+        assert_eq!(usage.response_tokens, 11);
+        assert_eq!(usage.total_tokens, 25);
+        // Ties R2 accumulation to the R1 per-step values seen in this stream.
+        assert_eq!(usage.request_tokens, per_step_request);
+        assert_eq!(usage.response_tokens, per_step_response);
+        assert_eq!(usage.total_tokens, per_step_total);
+    }
+
+    /// T4 (R4): `Cancelled` carries the partial run-aggregate usage.
+    ///
+    /// Deterministic mid-run cancellation is racy against a synchronous mock
+    /// stream (the whole model stream drains before the token flips at the
+    /// intended point), so this uses the TEST_PLAN-documented fallback: a
+    /// construction+match round-trip asserting the partial aggregate survives
+    /// on the `Cancelled` variant. The three production emit sites are covered
+    /// by code review (they all pass `usage.clone()`), and the existing
+    /// cancel-path tests remain green with the new field.
+    #[test]
+    fn test_cancelled_reports_partial_usage() {
+        let mut partial = RunUsage::new();
+        partial.add_request(RequestUsage::new().request_tokens(10).response_tokens(5));
+
+        let event = AgentStreamEvent::Cancelled {
+            partial_text: Some("partial".to_string()),
+            partial_thinking: None,
+            pending_tools: vec!["demo_tool".to_string()],
+            usage: partial,
+        };
+
+        if let AgentStreamEvent::Cancelled { usage, .. } = event {
+            // A run cancelled after >=1 usage-bearing response reports the
+            // partial sum, not an all-zero aggregate.
+            assert_eq!(usage.request_count, 1);
+            assert_eq!(usage.request_tokens, 10);
+            assert_eq!(usage.response_tokens, 5);
+            assert_eq!(usage.total_tokens, 15);
+        } else {
+            panic!("expected Cancelled event");
+        }
+    }
+
+    /// T4b (R2 Loop 2 / AC2.2): prove Loop 2's usage accumulation by EXECUTION.
+    ///
+    /// Cancel-path option chosen: **full non-cancelled run THROUGH Loop 2**.
+    /// Deterministic mid-run cancellation is racy against a synchronous mock
+    /// stream — the whole model stream drains before the token flip can land at
+    /// the intended point — so instead of the unreliable mid-run-cancel path we
+    /// drive the *cancellable* code path (`new_with_cancel`) with a token that is
+    /// never triggered, all the way through a real 2-request tool loop to
+    /// completion. This exercises the accumulator at stream.rs:748-749 that lives
+    /// inside the `new_with_cancel` task (a physically different loop body from
+    /// the `new`/`run_stream` path proven by T3), so Loop 2's `add_request` is
+    /// validated by running it, not only by code review.
+    #[tokio::test]
+    async fn test_run_complete_aggregate_usage_through_cancellable_loop() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let events = if step == 0 {
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::ToolCall(
+                                ToolCallPart::new("demo_tool", ToolCallArgs::string("{}"))
+                                    .with_tool_call_id("call_1"),
+                            ),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::ToolCall)
+                                .with_input_tokens(10)
+                                .with_output_tokens(5),
+                        )),
+                    ]
+                } else {
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("done")),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::Stop)
+                                .with_input_tokens(4)
+                                .with_output_tokens(6),
+                        )),
+                    ]
+                };
+                Box::pin(stream::iter(events))
+            })
+        };
+
+        let agentic = agent(model)
+            .tool_fn(
+                "demo_tool",
+                "Demo tool",
+                |_ctx, _args: serde_json::Value| Ok(serdes_ai_tools::ToolReturn::text("ok")),
+            )
+            .build();
+
+        // Untriggered token -> the run completes normally through Loop 2.
+        let token = CancellationToken::new();
+        let mut stream = AgentStream::new_with_cancel(
+            &agentic,
+            "trigger tool then finish".into(),
+            (),
+            RunOptions::default(),
+            token,
+        )
+        .await
+        .expect("stream should start");
+
+        let mut per_step_request = 0u64;
+        let mut per_step_response = 0u64;
+        let mut run_complete_usage = None;
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event should be ok");
+            match event {
+                AgentStreamEvent::ResponseComplete { usage: Some(u), .. } => {
+                    per_step_request += u.request_tokens.unwrap_or(0);
+                    per_step_response += u.response_tokens.unwrap_or(0);
+                }
+                AgentStreamEvent::RunComplete { usage, .. } => {
+                    run_complete_usage = Some(usage);
+                }
+                _ => {}
+            }
+        }
+
+        let usage = run_complete_usage.expect("expected a RunComplete event");
+        // Field-wise aggregate of both steps accumulated inside Loop 2.
+        assert_eq!(usage.request_tokens, 14);
+        assert_eq!(usage.response_tokens, 11);
+        assert_eq!(usage.total_tokens, 25);
+        assert_eq!(usage.request_count, 2);
+        // Loop 2's aggregate matches the per-step values it emitted.
+        assert_eq!(usage.request_tokens, per_step_request);
+        assert_eq!(usage.response_tokens, per_step_response);
+    }
+
+    /// T7 (R2 / AC1.2 + AC3.2): a mid-run step with NO provider usage must not
+    /// corrupt or double-count the run aggregate. Step 0 reports usage (10/5)
+    /// and triggers a tool; step 1 reports no token fields. Step 1's
+    /// `ResponseComplete.usage` is `None`, and the terminal aggregate reflects
+    /// only the one usage-bearing step (`request_count == 1`).
+    #[tokio::test]
+    async fn test_run_complete_aggregate_ignores_usage_none_step() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let events = if step == 0 {
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::ToolCall(
+                                ToolCallPart::new("demo_tool", ToolCallArgs::string("{}"))
+                                    .with_tool_call_id("call_1"),
+                            ),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::ToolCall)
+                                .with_input_tokens(10)
+                                .with_output_tokens(5),
+                        )),
+                    ]
+                } else {
+                    // Step 1 reports NO token fields.
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("done")),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(FinishReason::Stop),
+                        )),
+                    ]
+                };
+                Box::pin(stream::iter(events))
+            })
+        };
+
+        let agent = agent(model)
+            .tool_fn(
+                "demo_tool",
+                "Demo tool",
+                |_ctx, _args: serde_json::Value| Ok(serdes_ai_tools::ToolReturn::text("ok")),
+            )
+            .build();
+
+        let mut stream = agent
+            .run_stream("trigger tool then finish", ())
+            .await
+            .expect("stream should start");
+
+        let mut step_usages: Vec<(u32, Option<RequestUsage>)> = Vec::new();
+        let mut run_complete_usage = None;
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event should be ok");
+            match event {
+                AgentStreamEvent::ResponseComplete { step, usage } => {
+                    step_usages.push((step, usage));
+                }
+                AgentStreamEvent::RunComplete { usage, .. } => {
+                    run_complete_usage = Some(usage);
+                }
+                _ => {}
+            }
+        }
+
+        assert_eq!(step_usages.len(), 2, "expected two ResponseComplete events");
+        // Step 0 carried usage; step 1 reported nothing.
+        let step0 = step_usages[0].1.as_ref().expect("step 0 has usage");
+        assert_eq!(step0.request_tokens, Some(10));
+        assert!(
+            step_usages[1].1.is_none(),
+            "the usage-None step must ship None, not a zeroed usage"
+        );
+
+        let usage = run_complete_usage.expect("expected a RunComplete event");
+        // Only the one usage-bearing step contributes; the None step is skipped,
+        // so the aggregate is neither corrupted nor double-counted.
+        assert_eq!(usage.request_tokens, 10);
+        assert_eq!(usage.response_tokens, 5);
+        assert_eq!(usage.total_tokens, 15);
+        assert_eq!(usage.request_count, 1);
+    }
+
+    /// T8 (R1 + R3, billing): cache-creation and cache-read tokens survive from
+    /// the provider's `StreamComplete` all the way onto the event path — both
+    /// the per-step `ResponseComplete.usage` and the terminal `RunComplete.usage`
+    /// aggregate — proving cache-token accumulation is exercised end-to-end, not
+    /// just inside the private `usage_from_stream_complete` helper.
+    #[tokio::test]
+    async fn test_cache_tokens_surface_on_event_path() {
+        let model = FunctionModel::with_stream(move |_messages, _settings| {
+            let events = vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("done")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+                Ok(ModelResponseStreamEvent::StreamComplete(
+                    StreamCompleteEvent::new(FinishReason::Stop)
+                        .with_input_tokens(10)
+                        .with_output_tokens(5)
+                        .with_cache_creation_tokens(3)
+                        .with_cache_read_tokens(7),
+                )),
+            ];
+            Box::pin(stream::iter(events))
+        });
+
+        let agent = agent(model).build();
+        let mut stream = agent
+            .run_stream("hello", ())
+            .await
+            .expect("stream should start");
+
+        let mut step_usage = None;
+        let mut run_complete_usage = None;
+        while let Some(event) = stream.next().await {
+            let event = event.expect("stream event should be ok");
+            match event {
+                AgentStreamEvent::ResponseComplete { usage, .. } => {
+                    step_usage = usage;
+                }
+                AgentStreamEvent::RunComplete { usage, .. } => {
+                    run_complete_usage = Some(usage);
+                }
+                _ => {}
+            }
+        }
+
+        // Per-step cache tokens survive onto ResponseComplete.usage.
+        let step = step_usage.expect("per-step usage should be present");
+        assert_eq!(step.cache_creation_tokens, Some(3));
+        assert_eq!(step.cache_read_tokens, Some(7));
+
+        // And they accumulate into the terminal RunComplete aggregate.
+        let usage = run_complete_usage.expect("expected a RunComplete event");
         assert_eq!(usage.cache_creation_tokens, Some(3));
         assert_eq!(usage.cache_read_tokens, Some(7));
     }
@@ -1971,6 +2487,724 @@ mod tests {
         assert!(
             !saw_tool_executed,
             "must NOT execute tool on premature EOF (cancellable)"
+        );
+    }
+
+    // ========================================================================
+    // Regression tests for the #39/PR#50 over-broad inferred-EOF gate:
+    // a stream that produces content and ends WITHOUT a terminal
+    // StreamComplete (in-memory/mock streams AND real OpenAI/Google/etc.
+    // parsers, which never emit one) must complete SUCCESSFULLY. Real
+    // truncation is still surfaced as an explicit Err by the provider parser
+    // (Anthropic), which is covered by serdes-ai-models tests.
+    // ========================================================================
+
+    /// RT1: a mock stream emits text + part_end but NO StreamComplete.
+    /// It must complete successfully (TextDelta + RunComplete, no Error).
+    /// This FAILED before the fix (inferred-EOF gate emitted Error + returned).
+    #[tokio::test]
+    async fn test_run_stream_completes_without_terminal_streamcomplete() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("hello world")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+            ]))
+        });
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("Hi", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_text = false;
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::TextDelta { .. }) => saw_text = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("stream without StreamComplete must not error: {:?}", e),
+            }
+        }
+
+        assert!(saw_text, "expected at least one TextDelta");
+        assert!(saw_run_complete, "expected a terminal RunComplete");
+        assert!(!saw_error, "must NOT emit an Error event");
+    }
+
+    /// RT2: a genuinely empty stream (no parts, no StreamComplete) must still
+    /// error - the empty-content guard is preserved.
+    #[tokio::test]
+    async fn test_empty_stream_still_errors() {
+        let model =
+            FunctionModel::with_stream(|_messages, _settings| Box::pin(stream::iter(vec![])));
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("Hi", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(_) => saw_error = true,
+            }
+        }
+
+        assert!(!saw_run_complete, "empty stream must NOT emit RunComplete");
+        assert!(saw_error, "empty stream must still produce an error");
+    }
+
+    /// RT4: the OpenAI-parser terminal shape (part_start + text_delta + part_end,
+    /// closed on finish, NO StreamComplete) - the real non-Anthropic-provider
+    /// stream shape. Must complete successfully (TextDelta + RunComplete, no Error).
+    #[tokio::test]
+    async fn test_run_stream_openai_shape_no_streamcomplete() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("")),
+                )),
+                Ok(ModelResponseStreamEvent::text_delta(0, "hello ")),
+                Ok(ModelResponseStreamEvent::text_delta(0, "world")),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+            ]))
+        });
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("Hi", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_text = false;
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::TextDelta { .. }) => saw_text = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("OpenAI-shape stream must not error: {:?}", e),
+            }
+        }
+
+        assert!(saw_text, "expected at least one TextDelta");
+        assert!(saw_run_complete, "expected a terminal RunComplete");
+        assert!(!saw_error, "must NOT emit an Error event");
+    }
+
+    /// RT1-cancellable (Loop 2 success path): the RT1 mock — text + part_end,
+    /// NO terminal StreamComplete — driven through the *cancellable* code path
+    /// (`new_with_cancel` with an UNTRIGGERED token). This proves Loop 2's
+    /// `unwrap_or(FinishReason::Stop)` at stream.rs:1270+ by EXECUTION: Loop 2 is
+    /// a physically distinct loop body from `run_stream`'s Loop 1 (proven by RT1),
+    /// so it needs its own regression guard. Must complete successfully
+    /// (TextDelta + RunComplete, no Error).
+    #[tokio::test]
+    async fn test_run_stream_completes_without_terminal_streamcomplete_cancellable() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("hello world")),
+                )),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+            ]))
+        });
+
+        let agentic = agent(model).build();
+
+        // Untriggered token -> the run completes normally through Loop 2.
+        let token = CancellationToken::new();
+        let mut stream =
+            AgentStream::new_with_cancel(&agentic, "Hi".into(), (), RunOptions::default(), token)
+                .await
+                .expect("stream should start");
+
+        let mut saw_text = false;
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::TextDelta { .. }) => saw_text = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => {
+                    panic!(
+                        "cancellable stream without StreamComplete must not error: {:?}",
+                        e
+                    )
+                }
+            }
+        }
+
+        assert!(saw_text, "expected at least one TextDelta");
+        assert!(saw_run_complete, "expected a terminal RunComplete");
+        assert!(!saw_error, "must NOT emit an Error event");
+    }
+
+    /// RT2-cancellable (Loop 2 empty-content guard): a genuinely empty stream
+    /// (no parts, no StreamComplete) driven through the *cancellable* path must
+    /// still error. This proves the `response_parts.is_empty()` guard is intact
+    /// on Loop 2 as well as Loop 1 (RT2) — defaulting the finish reason to Stop
+    /// does NOT paper over a stream that produced nothing.
+    #[tokio::test]
+    async fn test_empty_stream_still_errors_cancellable() {
+        let model =
+            FunctionModel::with_stream(|_messages, _settings| Box::pin(stream::iter(vec![])));
+
+        let agentic = agent(model).build();
+
+        let token = CancellationToken::new();
+        let mut stream =
+            AgentStream::new_with_cancel(&agentic, "Hi".into(), (), RunOptions::default(), token)
+                .await
+                .expect("stream should start");
+
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(_) => saw_error = true,
+            }
+        }
+
+        assert!(
+            !saw_run_complete,
+            "empty cancellable stream must NOT emit RunComplete"
+        );
+        assert!(
+            saw_error,
+            "empty cancellable stream must still produce an error"
+        );
+    }
+
+    /// Multi-step tool loop where NO step emits a terminal StreamComplete
+    /// (each defaults to FinishReason::Stop). Step 0 emits a ToolCall; step 1
+    /// emits text. This proves loop continuation keys on TOOL-CALL PRESENCE,
+    /// not on the finish reason: even though step 0 defaults to Stop, the
+    /// pending tool call forces a 2nd request. Asserts the tool executed, two
+    /// model requests were made, and exactly ONE terminal RunComplete fired.
+    #[tokio::test]
+    async fn test_tool_loop_without_streamcomplete_continues() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let events = if step == 0 {
+                    // ToolCall part, NO StreamComplete -> finish_reason defaults to Stop.
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::ToolCall(
+                                ToolCallPart::new("demo_tool", ToolCallArgs::string("{}"))
+                                    .with_tool_call_id("call_1"),
+                            ),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                    ]
+                } else {
+                    // Text, NO StreamComplete -> finish_reason defaults to Stop.
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("done")),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                    ]
+                };
+                Box::pin(stream::iter(events))
+            })
+        };
+
+        let agentic = {
+            let tool_calls = Arc::clone(&tool_calls);
+            agent(model)
+                .tool_fn(
+                    "demo_tool",
+                    "Demo tool",
+                    move |_ctx, _args: serde_json::Value| {
+                        tool_calls.fetch_add(1, Ordering::SeqCst);
+                        Ok(serdes_ai_tools::ToolReturn::text("ok"))
+                    },
+                )
+                .build()
+        };
+
+        let mut stream = agentic
+            .run_stream("trigger tool then finish", ())
+            .await
+            .expect("stream should start");
+
+        let mut run_complete_count = 0usize;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { .. }) => run_complete_count += 1,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("tool loop without StreamComplete must not error: {:?}", e),
+            }
+        }
+
+        assert!(!saw_error, "must NOT emit an Error event");
+        assert_eq!(
+            tool_calls.load(Ordering::SeqCst),
+            1,
+            "the registered tool must have executed exactly once"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "loop must make a 2nd model request after the tool call (2 steps)"
+        );
+        assert_eq!(
+            run_complete_count, 1,
+            "exactly one terminal RunComplete must fire"
+        );
+    }
+
+    /// AC3.2 ACCEPTED-TRADE-OFF GUARD: a stream that emits partial content
+    /// (a couple of TextDeltas + part_end) but NO terminal StreamComplete and
+    /// NO Err is accepted as a SUCCESSFUL completion (finish_reason defaults to
+    /// Stop). This is a DELIBERATE trade-off: for non-Anthropic providers a
+    /// genuinely truncated stream is currently indistinguishable from success,
+    /// because their parsers never emit StreamComplete. Anthropic still surfaces
+    /// real truncation as an explicit Err and is unaffected.
+    ///
+    /// This test PINS the current behavior so any future re-tightening (see the
+    /// AC3.3 follow-up: real OpenAI/Google termination detection) is a conscious,
+    /// reviewed change rather than a silent regression.
+    #[tokio::test]
+    async fn test_partial_content_without_terminal_accepted_as_stop() {
+        let model = FunctionModel::with_stream(|_messages, _settings| {
+            Box::pin(stream::iter(vec![
+                Ok(ModelResponseStreamEvent::part_start(
+                    0,
+                    ModelResponsePart::Text(TextPart::new("")),
+                )),
+                Ok(ModelResponseStreamEvent::text_delta(0, "partial ")),
+                Ok(ModelResponseStreamEvent::text_delta(0, "answer")),
+                Ok(ModelResponseStreamEvent::part_end(0)),
+            ]))
+        });
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("Hi", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("accepted-trade-off stream must not error: {:?}", e),
+            }
+        }
+
+        // AC3.2: partial-but-unterminated content is accepted as SUCCESS today.
+        assert!(
+            saw_run_complete,
+            "partial content without StreamComplete must complete as success"
+        );
+        assert!(
+            !saw_error,
+            "must NOT emit an Error event (accepted trade-off)"
+        );
+    }
+
+    // ========================================================================
+    // EndTurn-loop regression (fix: run_stream exited only on Stop, but
+    // Anthropic streaming maps normal completions to EndTurn). The loop now
+    // keys on FinishReason::is_complete() = {Stop, EndTurn, StopSequence} at
+    // BOTH exit sites (Loop 1 = run_stream, Loop 2 = new_with_cancel).
+    // ========================================================================
+
+    /// RT1 (R1/R5, Loop 1): a tool-less stream whose terminal StreamComplete
+    /// carries `FinishReason::EndTurn` (exactly what Anthropic streaming emits
+    /// for a normal completion) must finish in EXACTLY ONE model round.
+    ///
+    /// The closure counts calls via an `AtomicUsize` and has a SAFETY CAP: once
+    /// it has been invoked 3 times it switches to `Stop`, so a still-broken loop
+    /// cannot hang the test suite - it just fails the `== 1` assertion instead.
+    /// Pre-fix (`== Some(Stop)`) this loops (EndTurn never matched); post-fix it
+    /// is exactly 1. Drives Loop 1 (`run_stream`).
+    #[tokio::test]
+    async fn test_run_stream_completes_on_endturn() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                // Safety cap: after 3 rounds fall back to Stop so a still-broken
+                // loop terminates (and fails `== 1`) instead of hanging.
+                let reason = if step >= 3 {
+                    FinishReason::Stop
+                } else {
+                    FinishReason::EndTurn
+                };
+                Box::pin(stream::iter(vec![
+                    Ok(ModelResponseStreamEvent::part_start(
+                        0,
+                        ModelResponsePart::Text(TextPart::new("done")),
+                    )),
+                    Ok(ModelResponseStreamEvent::part_end(0)),
+                    Ok(ModelResponseStreamEvent::StreamComplete(
+                        StreamCompleteEvent::new(reason),
+                    )),
+                ]))
+            })
+        };
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("hello", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_output_ready = false;
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::OutputReady) => saw_output_ready = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("EndTurn stream must not error: {:?}", e),
+            }
+        }
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "EndTurn must complete the loop in exactly one round"
+        );
+        assert!(saw_output_ready, "expected an OutputReady event");
+        assert!(saw_run_complete, "expected a terminal RunComplete");
+        assert!(!saw_error, "must NOT emit an Error event");
+    }
+
+    /// RT1-cancellable (R1/AC1.2, Loop 2): identical to RT1 but driven through
+    /// the *cancellable* path (`new_with_cancel` with an UNTRIGGERED token).
+    /// Loop 2 is a physically distinct loop body from `run_stream`'s Loop 1, so
+    /// it needs its own execution guard - this proves the fix landed on Loop 2
+    /// too. Mirrors `test_run_stream_completes_without_terminal_streamcomplete_cancellable`.
+    #[tokio::test]
+    async fn test_run_stream_completes_on_endturn_cancellable() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let reason = if step >= 3 {
+                    FinishReason::Stop
+                } else {
+                    FinishReason::EndTurn
+                };
+                Box::pin(stream::iter(vec![
+                    Ok(ModelResponseStreamEvent::part_start(
+                        0,
+                        ModelResponsePart::Text(TextPart::new("done")),
+                    )),
+                    Ok(ModelResponseStreamEvent::part_end(0)),
+                    Ok(ModelResponseStreamEvent::StreamComplete(
+                        StreamCompleteEvent::new(reason),
+                    )),
+                ]))
+            })
+        };
+
+        let agentic = agent(model).build();
+        let token = CancellationToken::new();
+        let mut stream = AgentStream::new_with_cancel(
+            &agentic,
+            "hello".into(),
+            (),
+            RunOptions::default(),
+            token,
+        )
+        .await
+        .expect("stream should start");
+
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("EndTurn cancellable stream must not error: {:?}", e),
+            }
+        }
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "EndTurn must complete Loop 2 in exactly one round"
+        );
+        assert!(saw_run_complete, "expected a terminal RunComplete");
+        assert!(!saw_error, "must NOT emit an Error event");
+    }
+
+    /// RT2 (R1/AC5.1b, Loop 1): same shape as RT1 but with
+    /// `FinishReason::StopSequence`. Proves the loop keys on the full
+    /// `is_complete()` set - {Stop, EndTurn, StopSequence} - and did not merely
+    /// add an EndTurn special-case.
+    #[tokio::test]
+    async fn test_run_stream_completes_on_stop_sequence() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let reason = if step >= 3 {
+                    FinishReason::Stop
+                } else {
+                    FinishReason::StopSequence
+                };
+                Box::pin(stream::iter(vec![
+                    Ok(ModelResponseStreamEvent::part_start(
+                        0,
+                        ModelResponsePart::Text(TextPart::new("done")),
+                    )),
+                    Ok(ModelResponseStreamEvent::part_end(0)),
+                    Ok(ModelResponseStreamEvent::StreamComplete(
+                        StreamCompleteEvent::new(reason),
+                    )),
+                ]))
+            })
+        };
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("hello", ())
+            .await
+            .expect("stream should start");
+
+        let mut saw_run_complete = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { .. }) => saw_run_complete = true,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("StopSequence stream must not error: {:?}", e),
+            }
+        }
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "StopSequence must complete the loop in exactly one round"
+        );
+        assert!(saw_run_complete, "expected a terminal RunComplete");
+        assert!(!saw_error, "must NOT emit an Error event");
+    }
+
+    /// RT5 (R4/AC4.1): the usage feature stays intact on the EndTurn completion
+    /// path. A single-round EndTurn completion (input 10 / output 5) must emit
+    /// EXACTLY ONE terminal RunComplete whose aggregate usage is 10/5/15 - i.e.
+    /// usage fires once, not once-per-erroneous-loop.
+    #[tokio::test]
+    async fn test_run_stream_endturn_usage_fires_once() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                let reason = if step >= 3 {
+                    FinishReason::Stop
+                } else {
+                    FinishReason::EndTurn
+                };
+                Box::pin(stream::iter(vec![
+                    Ok(ModelResponseStreamEvent::part_start(
+                        0,
+                        ModelResponsePart::Text(TextPart::new("done")),
+                    )),
+                    Ok(ModelResponseStreamEvent::part_end(0)),
+                    Ok(ModelResponseStreamEvent::StreamComplete(
+                        StreamCompleteEvent::new(reason)
+                            .with_input_tokens(10)
+                            .with_output_tokens(5),
+                    )),
+                ]))
+            })
+        };
+
+        let agentic = agent(model).build();
+        let mut stream = agentic
+            .run_stream("hello", ())
+            .await
+            .expect("stream should start");
+
+        let mut run_completes = Vec::new();
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::RunComplete { usage, .. }) => run_completes.push(usage),
+                Ok(_) => {}
+                Err(e) => panic!("EndTurn usage stream must not error: {:?}", e),
+            }
+        }
+
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            1,
+            "EndTurn must complete in exactly one round"
+        );
+        assert_eq!(
+            run_completes.len(),
+            1,
+            "expected exactly one terminal RunComplete"
+        );
+        let usage = &run_completes[0];
+        assert_eq!(usage.request_tokens, 10);
+        assert_eq!(usage.response_tokens, 5);
+        assert_eq!(usage.total_tokens, 15);
+    }
+
+    /// RT6 (ordering guard, Loop 1): a tool-bearing step whose terminal
+    /// StreamComplete ALSO carries `FinishReason::EndTurn` - which is now
+    /// `is_complete()` - must NOT terminate the loop early. The tool-call
+    /// `continue` (which fires on `!tool_calls.is_empty()`) MUST run BEFORE the
+    /// widened completion check, so the loop issues a 2nd request to let the
+    /// model respond to the tool result.
+    ///
+    /// STEP 0: ToolCall part_start/part_end + StreamComplete(EndTurn)
+    ///         (a tool-bearing response that also carries a now-complete reason).
+    /// STEP 1: text + StreamComplete(EndTurn) -> the genuine terminal round.
+    ///
+    /// If the widened finish check were reached BEFORE the tool `continue`,
+    /// STEP 0's EndTurn would terminate the run after ONE round and the tool
+    /// result would never be sent back - the `call_count == 2` assertion catches
+    /// that regression. An `AtomicUsize` call counter with a SAFETY CAP (>= 4 ->
+    /// Stop) guarantees a genuinely broken loop FAILS an assertion rather than
+    /// hanging the suite.
+    #[tokio::test]
+    async fn test_tool_loop_with_endturn_continues() {
+        let call_count = Arc::new(AtomicUsize::new(0));
+        let tool_calls = Arc::new(AtomicUsize::new(0));
+        let model = {
+            let call_count = Arc::clone(&call_count);
+            FunctionModel::with_stream(move |_messages, _settings| {
+                let step = call_count.fetch_add(1, Ordering::SeqCst);
+                // Safety cap: after 4 rounds fall back to Stop so a genuinely
+                // broken loop terminates (and fails `== 2`) instead of hanging.
+                let reason = if step >= 4 {
+                    FinishReason::Stop
+                } else {
+                    FinishReason::EndTurn
+                };
+                let events = if step == 0 {
+                    // Tool-bearing step whose terminal reason is ALSO complete
+                    // (EndTurn). The tool-call `continue` must win over the
+                    // widened finish check.
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::ToolCall(
+                                ToolCallPart::new("demo_tool", ToolCallArgs::string("{}"))
+                                    .with_tool_call_id("call_1"),
+                            ),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(reason),
+                        )),
+                    ]
+                } else {
+                    // Genuine terminal round: text + EndTurn completion.
+                    vec![
+                        Ok(ModelResponseStreamEvent::part_start(
+                            0,
+                            ModelResponsePart::Text(TextPart::new("done")),
+                        )),
+                        Ok(ModelResponseStreamEvent::part_end(0)),
+                        Ok(ModelResponseStreamEvent::StreamComplete(
+                            StreamCompleteEvent::new(reason),
+                        )),
+                    ]
+                };
+                Box::pin(stream::iter(events))
+            })
+        };
+
+        let agentic = {
+            let tool_calls = Arc::clone(&tool_calls);
+            agent(model)
+                .tool_fn(
+                    "demo_tool",
+                    "Demo tool",
+                    move |_ctx, _args: serde_json::Value| {
+                        tool_calls.fetch_add(1, Ordering::SeqCst);
+                        Ok(serdes_ai_tools::ToolReturn::text("ok"))
+                    },
+                )
+                .build()
+        };
+
+        let mut stream = agentic
+            .run_stream("call the tool then finish", ())
+            .await
+            .expect("stream should start");
+
+        let mut run_complete_count = 0usize;
+        let mut saw_output_ready = false;
+        let mut saw_error = false;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(AgentStreamEvent::OutputReady) => saw_output_ready = true,
+                Ok(AgentStreamEvent::RunComplete { .. }) => run_complete_count += 1,
+                Ok(AgentStreamEvent::Error { .. }) => saw_error = true,
+                Ok(_) => {}
+                Err(e) => panic!("tool+EndTurn loop must not error: {:?}", e),
+            }
+        }
+
+        assert!(!saw_error, "must NOT emit an Error event");
+        assert_eq!(
+            tool_calls.load(Ordering::SeqCst),
+            1,
+            "the registered tool must have executed exactly once"
+        );
+        assert_eq!(
+            call_count.load(Ordering::SeqCst),
+            2,
+            "tool-bearing EndTurn step must NOT terminate early: the loop must \
+             make a 2nd round to respond to the tool result"
+        );
+        assert!(
+            saw_output_ready,
+            "the genuine terminal (2nd) round must emit OutputReady"
+        );
+        assert_eq!(
+            run_complete_count, 1,
+            "exactly one terminal RunComplete must fire (no premature termination)"
         );
     }
 }

--- a/serdes-ai-models/src/anthropic/model.rs
+++ b/serdes-ai-models/src/anthropic/model.rs
@@ -8,7 +8,7 @@ use crate::model::{Model, ModelRequestParameters, StreamedResponse, ToolChoice};
 use crate::profile::{anthropic_claude_profile, ModelProfile};
 use async_trait::async_trait;
 use base64::Engine;
-use reqwest::header::HeaderMap;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, CONTENT_TYPE};
 use reqwest::Client;
 use serdes_ai_core::messages::{
     DocumentContent, ImageContent, RetryPromptPart, TextPart, ThinkingPart, ToolCallArgs,
@@ -19,10 +19,56 @@ use serdes_ai_core::{
     RequestUsage,
 };
 use serdes_ai_tools::ToolDefinition;
+use std::fmt;
 use std::time::Duration;
 
-/// Anthropic Claude model.
+/// The `anthropic-beta` feature-flag header. Multi-valued by design.
+const ANTHROPIC_BETA: HeaderName = HeaderName::from_static("anthropic-beta");
+
+/// Placeholder rendered by `Debug` in place of a secret.
+const REDACTED: &str = "<redacted>";
+
+/// Convert a runtime string into a [`HeaderValue`].
+///
+/// The error names the header but never its value - the value may be a secret.
+/// Embedding `e` is safe: `InvalidHeaderValue`'s `Display` is a constant string
+/// that does not echo the input.
+fn parse_header_value(name: &str, value: &str) -> Result<HeaderValue, ModelError> {
+    HeaderValue::from_str(value)
+        .map_err(|e| ModelError::configuration(format!("Invalid value for header '{name}': {e}")))
+}
+
+/// How a caller-supplied header is merged into the request headers.
 #[derive(Debug, Clone)]
+enum HeaderMergeMode {
+    /// Replace every existing value of that header name.
+    Set,
+    /// Add a value, keeping any existing ones.
+    Append,
+}
+
+/// One caller-supplied header. Named fields rather than a tuple: two `String`
+/// slots side by side make a name/value transposition invisible to the compiler.
+#[derive(Clone)]
+struct ExtraHeader {
+    name: String,
+    value: String,
+    mode: HeaderMergeMode,
+}
+
+/// Renders the NAME (diagnostic) but redacts the VALUE, which may be a secret.
+impl fmt::Debug for ExtraHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtraHeader")
+            .field("name", &self.name)
+            .field("value", &REDACTED)
+            .field("mode", &self.mode)
+            .finish()
+    }
+}
+
+/// Anthropic Claude model.
+#[derive(Clone)]
 pub struct AnthropicModel {
     model_name: String,
     client: Client,
@@ -38,6 +84,29 @@ pub struct AnthropicModel {
     enable_caching: bool,
     /// Anthropic API version.
     api_version: String,
+    /// Caller-supplied headers, in call order.
+    extra_headers: Vec<ExtraHeader>,
+}
+
+/// Hand-written so that secrets never reach a log or a panic message: the API
+/// key and every caller header VALUE are redacted. Header NAMES stay visible -
+/// they are diagnostic, not secret. Same discipline the error paths follow.
+impl fmt::Debug for AnthropicModel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AnthropicModel")
+            .field("model_name", &self.model_name)
+            .field("client", &self.client)
+            .field("api_key", &REDACTED)
+            .field("base_url", &self.base_url)
+            .field("profile", &self.profile)
+            .field("default_timeout", &self.default_timeout)
+            .field("enable_thinking", &self.enable_thinking)
+            .field("thinking_budget", &self.thinking_budget)
+            .field("enable_caching", &self.enable_caching)
+            .field("api_version", &self.api_version)
+            .field("extra_headers", &self.extra_headers)
+            .finish()
+    }
 }
 
 impl AnthropicModel {
@@ -57,6 +126,7 @@ impl AnthropicModel {
             thinking_budget: None,
             enable_caching: false,
             api_version: "2023-06-01".to_string(),
+            extra_headers: Vec::new(),
         }
     }
 
@@ -118,6 +188,141 @@ impl AnthropicModel {
     pub fn with_api_version(mut self, version: impl Into<String>) -> Self {
         self.api_version = version.into();
         self
+    }
+
+    /// Set a custom HTTP header on every request made by this model.
+    ///
+    /// Setting a header that the library also sets (`x-api-key`,
+    /// `anthropic-version`, `Content-Type`, `anthropic-beta`) REPLACES the
+    /// library's value. There is no protected header: the caller owns the
+    /// request. Calling this twice with the same name keeps the LAST value.
+    ///
+    /// Use [`with_appended_header`](Self::with_appended_header) instead for
+    /// multi-valued headers you want to ADD to rather than replace.
+    ///
+    /// An invalid header name or value is reported as a
+    /// [`ModelError::Configuration`] when the request is built, since this
+    /// builder cannot fail.
+    ///
+    /// # Security
+    ///
+    /// The name and the value are treated as TRUSTED caller configuration, not
+    /// as end-user input. No header is protected, so forwarding user-controlled
+    /// data into this method would let that user overwrite `x-api-key` and send
+    /// requests under a credential of their choosing. Validate or allow-list
+    /// anything that did not originate in your own configuration.
+    #[must_use]
+    pub fn with_header(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.extra_headers.push(ExtraHeader {
+            name: name.into(),
+            value: value.into(),
+            mode: HeaderMergeMode::Set,
+        });
+        self
+    }
+
+    /// Append a custom HTTP header value, keeping any existing values of the
+    /// same name (including the library's own).
+    ///
+    /// This is for multi-valued headers - most notably `anthropic-beta`, which
+    /// carries a list of feature flags. Appending `anthropic-beta` therefore
+    /// ADDS a flag while leaving the library's own flags (extended thinking,
+    /// prompt caching) in place.
+    ///
+    /// An invalid header name or value is reported as a
+    /// [`ModelError::Configuration`] when the request is built, since this
+    /// builder cannot fail.
+    ///
+    /// # Wrong for single-valued headers
+    ///
+    /// Appending a header that may carry only one value - `x-api-key` above
+    /// all, but equally `anthropic-version` or `Content-Type` - does NOT
+    /// override it. It sends the header TWICE, and which of the two values the
+    /// server honors is server-dependent: a caller who appended `x-api-key`
+    /// intending to swap credentials may silently keep authenticating with the
+    /// old key. Use [`with_header`](Self::with_header) to override.
+    ///
+    /// # Security
+    ///
+    /// The name and the value are treated as TRUSTED caller configuration, not
+    /// as end-user input. No header is protected, so forwarding user-controlled
+    /// data into this method would let that user attach a second `x-api-key` to
+    /// every request. Validate or allow-list anything that did not originate in
+    /// your own configuration.
+    #[must_use]
+    pub fn with_appended_header(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.extra_headers.push(ExtraHeader {
+            name: name.into(),
+            value: value.into(),
+            mode: HeaderMergeMode::Append,
+        });
+        self
+    }
+
+    /// Build the headers for a request - the single construction site shared by
+    /// the streaming and non-streaming paths.
+    ///
+    /// Error messages name the offending header but NEVER its value: a header
+    /// value may be a secret, and for `x-api-key` it always is. The underlying
+    /// `http` errors are safe to embed - their `Display` never echoes the input.
+    fn build_headers(&self) -> Result<HeaderMap, ModelError> {
+        let mut headers = HeaderMap::new();
+
+        let mut api_key = parse_header_value("x-api-key", &self.api_key)?;
+        // Keeps the credential out of the HPACK dynamic table on HTTP/2.
+        // Purely a transport hint: the value sent on the wire is unchanged.
+        api_key.set_sensitive(true);
+        headers.insert(HeaderName::from_static("x-api-key"), api_key);
+        headers.insert(
+            HeaderName::from_static("anthropic-version"),
+            parse_header_value("anthropic-version", &self.api_version)?,
+        );
+        // `CONTENT_TYPE`, not `HeaderName::from_static("Content-Type")`, which
+        // would panic on the uppercase bytes.
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        // Beta flags are multi-valued: the second one appends so that enabling
+        // both thinking and caching still sends both.
+        if self.enable_thinking {
+            headers.append(
+                ANTHROPIC_BETA,
+                HeaderValue::from_static("interleaved-thinking-2025-05-14"),
+            );
+        }
+        if self.enable_caching {
+            headers.append(
+                ANTHROPIC_BETA,
+                HeaderValue::from_static("prompt-caching-2024-07-31"),
+            );
+        }
+
+        for ExtraHeader { name, value, mode } in &self.extra_headers {
+            // `escape_debug` on the NAME: this message reaches `error!()` and
+            // `AgentStreamEvent::Error`, so a name carrying control characters
+            // must not be able to forge a log line. The VALUE is never
+            // interpolated at all - it may be a secret.
+            let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|e| {
+                ModelError::configuration(format!(
+                    "Invalid header name '{}': {e}",
+                    name.escape_debug()
+                ))
+            })?;
+            let header_value = parse_header_value(name, value)?;
+            match mode {
+                HeaderMergeMode::Set => {
+                    headers.insert(header_name, header_value);
+                }
+                HeaderMergeMode::Append => {
+                    headers.append(header_name, header_value);
+                }
+            }
+        }
+
+        Ok(headers)
     }
 
     /// Get the appropriate profile for a model name.
@@ -595,23 +800,11 @@ impl Model for AnthropicModel {
 
         let timeout = settings.timeout.unwrap_or(self.default_timeout);
 
-        let mut request = self
+        let request = self
             .client
             .post(format!("{}/v1/messages", self.base_url))
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", &self.api_version)
-            .header("Content-Type", "application/json")
+            .headers(self.build_headers()?)
             .timeout(timeout);
-
-        // Add beta header for extended thinking
-        if self.enable_thinking {
-            request = request.header("anthropic-beta", "interleaved-thinking-2025-05-14");
-        }
-
-        // Add beta header for prompt caching
-        if self.enable_caching {
-            request = request.header("anthropic-beta", "prompt-caching-2024-07-31");
-        }
 
         let response = request.json(&body).send().await?;
 
@@ -640,21 +833,11 @@ impl Model for AnthropicModel {
 
         let timeout = settings.timeout.unwrap_or(self.default_timeout);
 
-        let mut request = self
+        let request = self
             .client
             .post(format!("{}/v1/messages", self.base_url))
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", &self.api_version)
-            .header("Content-Type", "application/json")
+            .headers(self.build_headers()?)
             .timeout(timeout);
-
-        if self.enable_thinking {
-            request = request.header("anthropic-beta", "interleaved-thinking-2025-05-14");
-        }
-
-        if self.enable_caching {
-            request = request.header("anthropic-beta", "prompt-caching-2024-07-31");
-        }
 
         let response = request.json(&body).send().await?;
 
@@ -727,10 +910,8 @@ mod tests {
                             "application/json",
                         )
                 } else {
-                    ResponseTemplate::new(200).set_body_raw(
-                        r#"{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-test","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}"#,
-                        "application/json",
-                    )
+                    ResponseTemplate::new(200)
+                        .set_body_raw(MESSAGES_SUCCESS_BODY, "application/json")
                 }
             }
         }
@@ -946,5 +1127,429 @@ mod tests {
         assert!(matches!(&result.parts[0], ModelResponsePart::Text(_)));
         assert!(matches!(&result.parts[1], ModelResponsePart::ToolCall(_)));
         assert!(matches!(result.finish_reason, Some(FinishReason::ToolCall)));
+    }
+
+    // -----------------------------------------------------------------
+    // Custom headers - AC1..AC10 of
+    // specs/20260803_feat_anthropic_with_header/TEST_PLAN.md
+    // -----------------------------------------------------------------
+
+    const MESSAGES_SUCCESS_BODY: &str = r#"{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-test","stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}"#;
+
+    /// Mock server answering `POST /v1/messages` with a minimal success body.
+    async fn messages_mock_server() -> wiremock::MockServer {
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/v1/messages"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_raw(MESSAGES_SUCCESS_BODY, "application/json"),
+            )
+            .mount(&server)
+            .await;
+        server
+    }
+
+    /// Headers of the single request the mock server received.
+    async fn only_received_headers(server: &wiremock::MockServer) -> HeaderMap {
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server records requests");
+        assert_eq!(requests.len(), 1, "expected exactly one captured request");
+        requests[0].headers.clone()
+    }
+
+    /// All values sent for `name`, in order. Empty when the header is absent.
+    ///
+    /// A non-UTF-8 value renders as a placeholder rather than panicking, so a
+    /// future test with a latin-1 value fails on its own assertion instead of
+    /// dying inside this helper.
+    fn header_values(headers: &HeaderMap, name: &str) -> Vec<String> {
+        headers
+            .get_all(name)
+            .iter()
+            .map(|value| value.to_str().unwrap_or("<non-utf8>").to_owned())
+            .collect()
+    }
+
+    /// Drive one non-streaming request and return the headers actually sent.
+    async fn headers_of_non_streaming_request(model: AnthropicModel) -> HeaderMap {
+        let server = messages_mock_server().await;
+        model
+            .with_base_url(server.uri())
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .expect("mocked request succeeds");
+        only_received_headers(&server).await
+    }
+
+    /// Drive one streaming request and return the headers actually sent.
+    ///
+    /// `request_stream` only checks the status before handing back the parser,
+    /// so the body is never polled here - the request is already captured.
+    async fn headers_of_streaming_request(model: AnthropicModel) -> HeaderMap {
+        let server = messages_mock_server().await;
+        let _stream = model
+            .with_base_url(server.uri())
+            .request_stream(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .expect("mocked stream request succeeds");
+        only_received_headers(&server).await
+    }
+
+    /// AC6 - default behavior: the three fixed headers, and no `anthropic-beta`.
+    /// Transport headers added by reqwest (host, accept, content-length) are
+    /// deliberately not asserted on.
+    #[tokio::test]
+    async fn no_custom_headers_leaves_request_unchanged() {
+        let headers =
+            headers_of_non_streaming_request(AnthropicModel::new("claude-test", "sk-test")).await;
+
+        assert_eq!(header_values(&headers, "x-api-key"), vec!["sk-test"]);
+        assert_eq!(
+            header_values(&headers, "anthropic-version"),
+            vec!["2023-06-01"]
+        );
+        assert_eq!(
+            header_values(&headers, "content-type"),
+            vec!["application/json"]
+        );
+        assert!(
+            header_values(&headers, "anthropic-beta").is_empty(),
+            "no beta flag must be sent by default"
+        );
+    }
+
+    /// AC9 - regression guard for the `build_headers()` consolidation: thinking
+    /// and caching must BOTH still emit their `anthropic-beta` flag.
+    #[tokio::test]
+    async fn thinking_and_caching_still_send_both_beta_flags() {
+        let model = AnthropicModel::new("claude-test", "sk-test")
+            .with_thinking(Some(1024))
+            .with_caching();
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(
+            header_values(&headers, "anthropic-beta"),
+            vec![
+                "interleaved-thinking-2025-05-14",
+                "prompt-caching-2024-07-31"
+            ]
+        );
+    }
+
+    /// AC1 - a custom header reaches the non-streaming request.
+    #[tokio::test]
+    async fn with_header_appears_in_non_streaming_request() {
+        let model = AnthropicModel::new("claude-test", "sk-test").with_header("x-client", "silix");
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(header_values(&headers, "x-client"), vec!["silix"]);
+    }
+
+    /// AC2 - and the streaming request, which is the consumer's normal case.
+    #[tokio::test]
+    async fn with_header_appears_in_streaming_request() {
+        let model = AnthropicModel::new("claude-test", "sk-test").with_header("x-client", "silix");
+
+        let headers = headers_of_streaming_request(model).await;
+
+        assert_eq!(header_values(&headers, "x-client"), vec!["silix"]);
+    }
+
+    /// AC3 - no header is protected: `x-api-key` is replaced, and sent EXACTLY
+    /// once. The count matters - appending would send it twice and only the
+    /// count catches that.
+    #[tokio::test]
+    async fn with_header_overwrites_api_key_exactly_once() {
+        let model =
+            AnthropicModel::new("claude-test", "sk-original").with_header("x-api-key", "override");
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(header_values(&headers, "x-api-key"), vec!["override"]);
+    }
+
+    /// AC4 - `with_header` means SET: it replaces the library's own
+    /// `anthropic-beta` flags. No special case, no inferred intent.
+    #[tokio::test]
+    async fn with_header_replaces_anthropic_beta() {
+        let model = AnthropicModel::new("claude-test", "sk-test")
+            .with_caching()
+            .with_header("anthropic-beta", "only-mine");
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(header_values(&headers, "anthropic-beta"), vec!["only-mine"]);
+    }
+
+    /// AC5 - `with_appended_header` means ADD: the library's flags survive.
+    #[tokio::test]
+    async fn with_appended_header_adds_to_anthropic_beta() {
+        let model = AnthropicModel::new("claude-test", "sk-test")
+            .with_caching()
+            .with_appended_header("anthropic-beta", "my-flag");
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(
+            header_values(&headers, "anthropic-beta"),
+            vec!["prompt-caching-2024-07-31", "my-flag"]
+        );
+    }
+
+    /// AC7 - setting the same header twice keeps the last value only.
+    #[tokio::test]
+    async fn with_header_last_value_wins() {
+        let model = AnthropicModel::new("claude-test", "sk-test")
+            .with_header("a", "1")
+            .with_header("a", "2");
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(header_values(&headers, "a"), vec!["2"]);
+    }
+
+    /// AC10 - the ORDER of set/append calls is honored, in both directions.
+    #[tokio::test]
+    async fn set_and_append_order_is_honored() {
+        let append_then_set = AnthropicModel::new("claude-test", "sk-test")
+            .with_appended_header("x-m", "1")
+            .with_header("x-m", "2");
+        let headers = headers_of_non_streaming_request(append_then_set).await;
+        assert_eq!(
+            header_values(&headers, "x-m"),
+            vec!["2"],
+            "a later set must replace the earlier appended value"
+        );
+
+        let set_then_append = AnthropicModel::new("claude-test", "sk-test")
+            .with_header("x-m", "2")
+            .with_appended_header("x-m", "1");
+        let headers = headers_of_non_streaming_request(set_then_append).await;
+        assert_eq!(
+            header_values(&headers, "x-m"),
+            vec!["2", "1"],
+            "a later append must keep the earlier set value"
+        );
+    }
+
+    /// AC8 - an invalid header NAME is a real configuration error naming the
+    /// offending header, not a silent skip.
+    #[test]
+    fn invalid_header_name_is_configuration_error() {
+        let model = AnthropicModel::new("claude-test", "sk-test").with_header("bad name", "v");
+
+        let error = model.build_headers().expect_err("invalid name must error");
+
+        assert!(
+            matches!(error, ModelError::Configuration(_)),
+            "expected a Configuration error, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("bad name"),
+            "message must name the offending header, got {error}"
+        );
+    }
+
+    /// AC8b - an invalid header VALUE errors, names the header, and must NOT
+    /// echo the value: a custom header may carry a secret.
+    #[test]
+    fn invalid_header_value_error_does_not_leak_value() {
+        let model =
+            AnthropicModel::new("claude-test", "sk-test").with_header("x-tenant", "secret\nvalue");
+
+        let error = model.build_headers().expect_err("invalid value must error");
+
+        assert!(
+            matches!(error, ModelError::Configuration(_)),
+            "expected a Configuration error, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("x-tenant"),
+            "message must name the offending header, got {message}"
+        );
+        assert!(
+            !message.contains("secret"),
+            "message must never echo the header value, got {message}"
+        );
+    }
+
+    /// AC8b (append path) - the same guarantees hold for appended headers.
+    #[test]
+    fn invalid_appended_header_value_does_not_leak_value() {
+        let model = AnthropicModel::new("claude-test", "sk-test")
+            .with_appended_header("x-tenant", "secret\nvalue");
+
+        let error = model.build_headers().expect_err("invalid value must error");
+
+        assert!(matches!(error, ModelError::Configuration(_)));
+        let message = error.to_string();
+        assert!(message.contains("x-tenant"));
+        assert!(!message.contains("secret"));
+    }
+
+    /// AC8c - the fixed headers are fallible too: an API key with a trailing
+    /// newline (the realistic env/file case) errors WITHOUT leaking the key.
+    #[test]
+    fn invalid_api_key_is_configuration_error_without_leaking_key() {
+        let model = AnthropicModel::new("claude-test", "sk-leakcanary-\n");
+
+        let error = model
+            .build_headers()
+            .expect_err("invalid api key must error");
+
+        assert!(
+            matches!(error, ModelError::Configuration(_)),
+            "expected a Configuration error, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("x-api-key"),
+            "message must name the offending header, got {message}"
+        );
+        assert!(
+            !message.contains("leakcanary"),
+            "message must never echo the API key, got {message}"
+        );
+    }
+
+    /// AC8c (version path) - same discipline for `anthropic-version`.
+    #[test]
+    fn invalid_api_version_is_configuration_error() {
+        let model = AnthropicModel::new("claude-test", "sk-test").with_api_version("2023-06-01\n");
+
+        let error = model
+            .build_headers()
+            .expect_err("invalid api version must error");
+
+        assert!(matches!(error, ModelError::Configuration(_)));
+        assert!(error.to_string().contains("anthropic-version"));
+    }
+
+    /// AC8d - `build_headers()` must not panic for a default model. Guards the
+    /// `HeaderName::from_static` uppercase hazard: `from_static("Content-Type")`
+    /// would panic on every single request.
+    #[test]
+    fn build_headers_does_not_panic_for_default_model() {
+        let headers = AnthropicModel::new("claude-test", "sk-test")
+            .build_headers()
+            .expect("default model builds headers");
+
+        assert_eq!(
+            header_values(&headers, "content-type"),
+            vec!["application/json"]
+        );
+    }
+
+    /// A caller header name is NORMALIZED to lowercase, as `HeaderName::from_bytes`
+    /// guarantees. Pins the guarantee against a future refactor to `from_static`,
+    /// which would panic on the uppercase bytes instead.
+    #[tokio::test]
+    async fn caller_header_name_is_normalized_to_lowercase() {
+        let model = AnthropicModel::new("claude-test", "sk-test").with_header("X-Client", "silix");
+
+        let headers = headers_of_non_streaming_request(model).await;
+
+        assert_eq!(header_values(&headers, "x-client"), vec!["silix"]);
+    }
+
+    /// Fail-closed: when `build_headers()` fails, NO request goes out. Without
+    /// this the caller's intended auth/tenant header could be silently dropped
+    /// while the request still reaches the API.
+    #[tokio::test]
+    async fn invalid_header_prevents_the_request_from_being_sent() {
+        let server = messages_mock_server().await;
+        let model = AnthropicModel::new("claude-test", "sk-test")
+            .with_base_url(server.uri())
+            .with_header("bad name", "v");
+
+        let error = model
+            .request(
+                &[ModelRequest::new()],
+                &ModelSettings::default(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .expect_err("an invalid header must fail the request");
+
+        assert!(
+            matches!(error, ModelError::Configuration(_)),
+            "expected a Configuration error, got {error:?}"
+        );
+        let requests = server
+            .received_requests()
+            .await
+            .expect("mock server records requests");
+        assert_eq!(
+            requests.len(),
+            0,
+            "no request may reach the API when header construction fails"
+        );
+    }
+
+    /// The `Debug` rendering must not leak secrets: neither the API key nor any
+    /// caller header VALUE. Header NAMES stay visible - they are diagnostic.
+    #[test]
+    fn debug_redacts_api_key_and_extra_header_values() {
+        let model = AnthropicModel::new("claude-test", "sk-leakcanary")
+            .with_header("x-tenant", "tenantcanary")
+            .with_appended_header("x-trace", "tracecanary");
+
+        let rendered = format!("{model:?}");
+
+        assert!(
+            !rendered.contains("sk-leakcanary"),
+            "Debug must not echo the api key, got {rendered}"
+        );
+        assert!(
+            !rendered.contains("tenantcanary"),
+            "Debug must not echo a set header value, got {rendered}"
+        );
+        assert!(
+            !rendered.contains("tracecanary"),
+            "Debug must not echo an appended header value, got {rendered}"
+        );
+        assert!(
+            rendered.contains("x-tenant") && rendered.contains("x-trace"),
+            "header names must stay visible for diagnostics, got {rendered}"
+        );
+        assert!(
+            rendered.contains("claude-test") && rendered.contains("2023-06-01"),
+            "non-secret fields must still be rendered, got {rendered}"
+        );
+    }
+
+    /// The invalid header NAME is escaped before it reaches an error message:
+    /// the message flows into `error!()` and `AgentStreamEvent::Error`, so a
+    /// name with control characters must not be able to forge a log line.
+    #[test]
+    fn invalid_header_name_is_escaped_in_the_error_message() {
+        let model =
+            AnthropicModel::new("claude-test", "sk-test").with_header("bad\nname: injected", "v");
+
+        let error = model.build_headers().expect_err("invalid name must error");
+
+        let message = error.to_string();
+        assert!(
+            !message.contains('\n'),
+            "the error message must stay single-line, got {message:?}"
+        );
+        assert!(
+            message.contains("bad\\nname"),
+            "the name must appear escaped, got {message:?}"
+        );
     }
 }

--- a/serdes-ai-models/src/antigravity/model.rs
+++ b/serdes-ai-models/src/antigravity/model.rs
@@ -643,3 +643,81 @@ impl Model for AntigravityModel {
         &self.profile
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A streamed generation over real HTTP ends with exactly one terminal
+    /// StreamComplete carrying the final chunk's mapped finishReason and
+    /// usageMetadata counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"response\":{\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hello\"}]}}]}}\n\n",
+            "data: {\"response\":{\"candidates\":[{\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15,\"cachedContentTokenCount\":3}}}\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/v1internal:streamGenerateContent",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let config = AntigravityConfig {
+            endpoint: server.uri(),
+            ..Default::default()
+        };
+        let model = AntigravityModel::new("gemini-3-flash", "test-token", "test-project")
+            .with_config(config);
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+}

--- a/serdes-ai-models/src/antigravity/stream.rs
+++ b/serdes-ai-models/src/antigravity/stream.rs
@@ -8,8 +8,8 @@ use bytes::Bytes;
 use futures::Stream;
 use pin_project_lite::pin_project;
 use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent, TextPart, ThinkingPart,
-    ToolCallPart,
+    FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
+    StreamCompleteEvent, TextPart, ThinkingPart, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
 use std::collections::HashMap;
@@ -27,7 +27,13 @@ pin_project! {
         parts: HashMap<usize, PartState>,
         // Current part index
         next_part_index: usize,
-        // Finished
+        // Finish reason mapped from the final chunk's candidate finishReason
+        finish_reason: Option<FinishReason>,
+        // Usage metadata from the wrapped response when present
+        usage: Option<UsageMetadata>,
+        // Open part indices awaiting a PartEnd before the terminal event
+        pending_part_ends: Vec<usize>,
+        // Finished: terminal event emitted, stream ended, or stream failed
         done: bool,
     }
 }
@@ -52,6 +58,9 @@ where
             buffer: String::new(),
             parts: HashMap::new(),
             next_part_index: 0,
+            finish_reason: None,
+            usage: None,
+            pending_part_ends: Vec::new(),
             done: false,
         }
     }
@@ -70,7 +79,32 @@ where
             return Poll::Ready(None);
         }
 
-        loop {
+        'outer: loop {
+            // Finish observed: close every open part, then emit the terminal
+            // event exactly once as the stream's last event.
+            if let Some(reason) = *this.finish_reason {
+                if let Some(idx) = this.pending_part_ends.pop() {
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: idx },
+                    ))));
+                }
+                if !this.parts.is_empty() {
+                    // Close parts in ascending index order: pop() takes from
+                    // the end, so queue the remaining indices descending.
+                    let mut indices: Vec<usize> = this.parts.drain().map(|(idx, _)| idx).collect();
+                    indices.sort_unstable();
+                    indices.reverse();
+                    let first = indices.pop().expect("parts checked non-empty");
+                    *this.pending_part_ends = indices;
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: first },
+                    ))));
+                }
+
+                *this.done = true;
+                return Poll::Ready(Some(Ok(stream_complete_event(reason, this.usage.as_ref()))));
+            }
+
             // Try both \r\n\r\n (Windows) and \n\n (Unix) line endings
             let separator = if this.buffer.contains("\r\n\r\n") {
                 "\r\n\r\n"
@@ -90,6 +124,11 @@ where
                     if let Some(data) = line.strip_prefix("data: ") {
                         // Handle [DONE] marker
                         if data == "[DONE]" {
+                            // Without an observed finishReason the stream is
+                            // truncated: end without the terminal event.
+                            if this.finish_reason.is_some() {
+                                continue 'outer;
+                            }
                             *this.done = true;
                             return Poll::Ready(None);
                         }
@@ -97,13 +136,23 @@ where
                         // Parse the JSON response
                         match serde_json::from_str::<AntigravityResponse>(data) {
                             Ok(response) => {
-                                if let Some(event) = process_response(
+                                // Capture terminal metadata before part events
+                                // so it survives final chunks that also carry
+                                // content.
+                                capture_terminal_metadata(
                                     &response,
-                                    this.parts,
-                                    this.next_part_index,
-                                    this.done,
-                                ) {
+                                    this.finish_reason,
+                                    this.usage,
+                                );
+                                if let Some(event) =
+                                    process_response(&response, this.parts, this.next_part_index)
+                                {
                                     return Poll::Ready(Some(event));
+                                }
+                                // The finishReason chunk is final: no later
+                                // chunk produces events.
+                                if this.finish_reason.is_some() {
+                                    continue 'outer;
                                 }
                             }
                             Err(e) => {
@@ -123,11 +172,13 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    // Mark done so no event (including the terminal event)
+                    // is emitted after an error.
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
-                    *this.done = true;
-                    // Process any remaining buffer
+                    // Process any remaining buffer without a trailing separator
                     if !this.buffer.is_empty() {
                         let remaining = std::mem::take(this.buffer);
                         for line in remaining.lines() {
@@ -136,11 +187,15 @@ where
                                     if let Ok(response) =
                                         serde_json::from_str::<AntigravityResponse>(data)
                                     {
+                                        capture_terminal_metadata(
+                                            &response,
+                                            this.finish_reason,
+                                            this.usage,
+                                        );
                                         if let Some(event) = process_response(
                                             &response,
                                             this.parts,
                                             this.next_part_index,
-                                            this.done,
                                         ) {
                                             return Poll::Ready(Some(event));
                                         }
@@ -149,6 +204,12 @@ where
                             }
                         }
                     }
+
+                    if this.finish_reason.is_some() {
+                        continue 'outer;
+                    }
+
+                    *this.done = true;
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -157,12 +218,32 @@ where
     }
 }
 
+/// Capture the terminal metadata a chunk carries: a candidate `finishReason`
+/// (the final chunk's completion signal) and the wrapped response's
+/// `usageMetadata`, so both survive final chunks that also carry content.
+fn capture_terminal_metadata(
+    response: &AntigravityResponse,
+    finish_reason: &mut Option<FinishReason>,
+    usage: &mut Option<UsageMetadata>,
+) {
+    if let Some(reason) = response
+        .response
+        .candidates
+        .first()
+        .and_then(|candidate| candidate.finish_reason.as_deref())
+    {
+        *finish_reason = Some(map_finish_reason(reason));
+    }
+    if let Some(metadata) = &response.response.usage_metadata {
+        *usage = Some(metadata.clone());
+    }
+}
+
 /// Process a response chunk into stream events.
 fn process_response(
     response: &AntigravityResponse,
     parts: &mut HashMap<usize, PartState>,
     next_part_index: &mut usize,
-    done: &mut bool,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
     // Get the first candidate from the wrapped response
     let candidate = response.response.candidates.first()?;
@@ -293,17 +374,320 @@ fn process_response(
         }
     }
 
-    // Check for finish
-    if candidate.finish_reason.is_some() {
-        *done = true;
+    None
+}
 
-        // Emit end events for all parts
-        if let Some((idx, _)) = parts.drain().next() {
-            return Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
-                index: idx,
-            })));
+/// Build the terminal event from the captured finish reason and usage
+/// metadata; the optional cached count maps to `cache_read_tokens` only when
+/// reported, and the wire format has no cache-creation count.
+fn stream_complete_event(
+    finish_reason: FinishReason,
+    usage: Option<&UsageMetadata>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason);
+
+    if let Some(u) = usage {
+        if let Some(tokens) = u.prompt_token_count {
+            event = event.with_input_tokens(tokens as u64);
+        }
+        if let Some(tokens) = u.candidates_token_count {
+            event = event.with_output_tokens(tokens as u64);
+        }
+        if let Some(cached) = u.cached_content_token_count {
+            event = event.with_cache_read_tokens(cached as u64);
         }
     }
 
-    None
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+/// Map an Antigravity finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::EndTurn`], matching the
+/// non-streaming response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "STOP" => FinishReason::EndTurn,
+        "MAX_TOKENS" => FinishReason::Length,
+        "SAFETY" => FinishReason::ContentFilter,
+        _ => FinishReason::EndTurn,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use futures::StreamExt;
+
+    fn make_sse_bytes(data: &str) -> Bytes {
+        Bytes::from(format!("data: {}\n\n", data))
+    }
+
+    /// A final chunk carrying finishReason and usageMetadata ends the stream
+    /// with exactly one terminal event, emitted last, mapping the finish
+    /// reason and the prompt, candidates, and cached counts.
+    #[tokio::test]
+    async fn final_chunk_with_finish_and_usage_emits_terminal_stream_complete() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":" World"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15,"cachedContentTokenCount":3}}}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(make_sse_bytes(finish_chunk)),
+            // A trailing [DONE] marker must not suppress the terminal event.
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Content part events precede the part end and the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                // The wire format reports cached tokens but no cache-creation
+                // count.
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish chunk without usageMetadata still ends the stream with
+    /// exactly one terminal event; every token field stays `None`.
+    #[tokio::test]
+    async fn finish_without_usage_metadata_yields_none_token_fields() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"MAX_TOKENS"}]}}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(make_sse_bytes(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// The terminal event follows every open part's PartEnd when the finish
+    /// chunk arrives with multiple parts open.
+    #[tokio::test]
+    async fn terminal_event_follows_all_open_part_ends() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let tool_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"search","args":{"q":"rust"}}}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(make_sse_bytes(tool_chunk)),
+            Ok(make_sse_bytes(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            5,
+            "Expected 2 PartStart, 2 PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match (&events[2], &events[3]) {
+            (
+                ModelResponseStreamEvent::PartEnd(first),
+                ModelResponseStreamEvent::PartEnd(second),
+            ) => {
+                assert_eq!(first.index, 0, "lowest open part closes first");
+                assert_eq!(second.index, 1);
+            }
+            other => panic!(
+                "expected PartEnd events before the terminal, got {:?}",
+                other
+            ),
+        }
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(8));
+                assert_eq!(complete.output_tokens, Some(4));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream that ends without a finish reason emits no terminal event, so
+    /// consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn stream_end_without_finish_reason_emits_no_terminal_event() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let bytes = vec![Ok(make_sse_bytes(text_chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the part event, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
+        );
+    }
+
+    /// A transport error ends the stream with the error; a finish chunk that
+    /// arrives after it produces no terminal event.
+    #[tokio::test]
+    async fn stream_error_suppresses_terminal_event() {
+        // reqwest::Error has no public constructor; a refused connection to a
+        // closed loopback port is the cheapest real one to obtain.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let err = client
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .err()
+            .expect("connection to closed loopback port must fail");
+
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}}"#;
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Err(err),
+            Ok(make_sse_bytes(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result);
+        }
+
+        assert!(
+            events.last().is_some_and(|e| e.is_err()),
+            "expected the stream to end with the error, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Ok(ModelResponseStreamEvent::StreamComplete(_)))),
+            "no terminal event may be emitted after an error"
+        );
+    }
+
+    /// A SAFETY finish reason maps to ContentFilter on the terminal event,
+    /// matching the non-streaming response mapping.
+    #[tokio::test]
+    async fn safety_finish_reason_maps_to_content_filter() {
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"SAFETY"}]}}"#;
+        let bytes = vec![Ok(make_sse_bytes(finish_chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::ContentFilter);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish chunk arriving without a trailing separator still ends the
+    /// stream with the terminal event after the remaining buffer is drained
+    /// at EOF.
+    #[tokio::test]
+    async fn finish_chunk_without_trailing_separator_emits_terminal_stream_complete() {
+        let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
+        let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":3,"totalTokenCount":10}}}"#;
+        // No trailing separator on the finish line: it is parsed from the
+        // remaining buffer at EOF.
+        let bytes = vec![
+            Ok(make_sse_bytes(text_chunk)),
+            Ok(Bytes::from(format!("data: {}", finish_chunk))),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = AntigravityStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            3,
+            "Expected PartStart, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(7));
+                assert_eq!(complete.output_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }

--- a/serdes-ai-models/src/antigravity/stream.rs
+++ b/serdes-ai-models/src/antigravity/stream.rs
@@ -600,8 +600,7 @@ mod tests {
             .get("http://127.0.0.1:1")
             .send()
             .await
-            .err()
-            .expect("connection to closed loopback port must fail");
+            .expect_err("connection to closed loopback port must fail");
 
         let text_chunk = r#"{"response":{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}}"#;
         let finish_chunk = r#"{"response":{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}}"#;

--- a/serdes-ai-models/src/azure/mod.rs
+++ b/serdes-ai-models/src/azure/mod.rs
@@ -149,6 +149,7 @@ impl Model for AzureOpenAIModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serdes_ai_core::FinishReason;
 
     #[test]
     fn test_azure_model_creation() {
@@ -160,5 +161,68 @@ mod tests {
         );
         assert_eq!(model.name(), "gpt-4");
         assert_eq!(model.system(), "azure");
+    }
+
+    /// Azure streams by delegating to an inner OpenAI chat model, so a
+    /// streamed request over real HTTP inherits the terminal StreamComplete
+    /// emission at [DONE] with the buffered usage.
+    #[tokio::test]
+    async fn request_stream_inherits_terminal_stream_complete() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/openai/deployments/gpt-4/chat/completions",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = AzureOpenAIModel::new("gpt-4", server.uri(), "2024-02-15-preview", "test-key");
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/chatgpt_oauth/model.rs
+++ b/serdes-ai-models/src/chatgpt_oauth/model.rs
@@ -8,8 +8,8 @@ use async_trait::async_trait;
 use base64::Engine;
 use reqwest::Client;
 use serdes_ai_core::messages::{
-    ImageContent, PartStartEvent, TextPart, ToolCallArgs, ToolCallPart, UserContent,
-    UserContentPart, UserPromptPart,
+    ImageContent, ModelResponseStreamEvent, PartStartEvent, StreamCompleteEvent, TextPart,
+    ToolCallArgs, ToolCallPart, UserContent, UserContentPart, UserPromptPart,
 };
 use serdes_ai_core::{
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
@@ -649,6 +649,7 @@ impl Model for ChatGptOAuthModel {
         self.parse_sse_response(response).await
     }
 
+    /// Stream a response through the non-streaming request fallback.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
@@ -659,10 +660,16 @@ impl Model for ChatGptOAuthModel {
         // TODO: Implement proper SSE streaming
         let response = self.request(messages, settings, params).await?;
 
-        use serdes_ai_core::messages::ModelResponseStreamEvent;
+        let ModelResponse {
+            parts,
+            finish_reason,
+            usage,
+            ..
+        } = response;
 
-        let events: Vec<Result<ModelResponseStreamEvent, ModelError>> = response
-            .parts
+        // Part events first, terminal event last; the request error above
+        // short-circuits failures before any event is emitted.
+        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> = parts
             .into_iter()
             .enumerate()
             .map(|(idx, part)| {
@@ -672,10 +679,164 @@ impl Model for ChatGptOAuthModel {
             })
             .collect();
 
+        events.push(Ok(stream_complete_event(finish_reason, usage.as_ref())));
+
         Ok(Box::pin(futures::stream::iter(events)))
     }
 
     fn profile(&self) -> &ModelProfile {
         &self.profile
+    }
+}
+
+/// Build the terminal event from the finish reason and usage mapped from
+/// the completed response.
+///
+/// Usage fields absent from the response stay `None`. A missing finish
+/// reason defaults to [`FinishReason::Stop`]; the terminal event requires a
+/// reason, and unknown strings already default to `Stop` in the
+/// non-streaming mapping.
+fn stream_complete_event(
+    finish_reason: Option<FinishReason>,
+    usage: Option<&RequestUsage>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason.unwrap_or(FinishReason::Stop));
+
+    if let Some(u) = usage {
+        if let Some(tokens) = u.request_tokens {
+            event = event.with_input_tokens(tokens);
+        }
+        if let Some(tokens) = u.response_tokens {
+            event = event.with_output_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_creation_tokens {
+            event = event.with_cache_creation_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_read_tokens {
+            event = event.with_cache_read_tokens(tokens);
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Streaming fallback over wiremock (real HTTP request path).
+
+    /// Serve a Codex SSE body from a wiremock server and collect the events
+    /// `request_stream` yields against it.
+    async fn stream_events_for(sse_body: &str) -> Vec<ModelResponseStreamEvent> {
+        use futures::StreamExt;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/responses"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let config = ChatGptConfig {
+            api_base_url: server.uri(),
+            ..Default::default()
+        };
+        let model = ChatGptOAuthModel::new("chatgpt-4o-codex", "test-token").with_config(config);
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A streamed request over real HTTP replays the buffered completed
+    /// response as part events and ends with exactly one terminal
+    /// StreamComplete carrying the mapped usage.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"gpt-4o-codex\",\"usage\":{\"input_tokens\":10,\"output_tokens\":5}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        // Part events precede the terminal event.
+        match events.first() {
+            Some(ModelResponseStreamEvent::PartStart(start)) => {
+                assert_eq!(start.index, 0);
+                assert!(
+                    matches!(&start.part, ModelResponsePart::Text(t) if t.content == "Hello"),
+                    "expected the buffered text part first, got {:?}",
+                    start.part
+                );
+            }
+            other => panic!("expected a leading part event, got {:?}", other),
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A completed response without usage still ends with exactly one
+    /// terminal event, and every token field stays `None`.
+    #[tokio::test]
+    async fn request_stream_without_usage_yields_none_token_fields() {
+        let sse_body = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hi\"}\n\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_2\",\"model\":\"gpt-4o-codex\"}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/claude_code_oauth/stream.rs
+++ b/serdes-ai-models/src/claude_code_oauth/stream.rs
@@ -67,3 +67,70 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::stream;
+    use futures::StreamExt;
+    use serdes_ai_core::messages::FinishReason;
+
+    fn make_sse_bytes(event_type: &str, data: &str) -> Bytes {
+        Bytes::from(format!("event: {}\ndata: {}\n\n", event_type, data))
+    }
+
+    /// The wrapper passes the wrapped Anthropic parser's terminal
+    /// StreamComplete through unchanged: exactly one terminal event,
+    /// emitted last, with the usage fields the Anthropic stream reported.
+    #[tokio::test]
+    async fn passes_through_terminal_stream_complete() {
+        let msg_start = r#"{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":0,"cache_creation_input_tokens":3,"cache_read_input_tokens":7}}}"#;
+        let block_start =
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}"#;
+        let delta = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#;
+        let block_stop = r#"{"type":"content_block_stop","index":0}"#;
+        let msg_delta = r#"{"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":5}}"#;
+        let msg_stop = r#"{"type":"message_stop"}"#;
+
+        let bytes = vec![
+            Ok(make_sse_bytes("message_start", msg_start)),
+            Ok(make_sse_bytes("content_block_start", block_start)),
+            Ok(make_sse_bytes("content_block_delta", delta)),
+            Ok(make_sse_bytes("content_block_stop", block_stop)),
+            Ok(make_sse_bytes("message_delta", msg_delta)),
+            Ok(make_sse_bytes("message_stop", msg_stop)),
+        ];
+
+        let mut parser = ClaudeCodeStreamParser::new(stream::iter(bytes));
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::EndTurn);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, Some(3));
+                assert_eq!(complete.cache_read_tokens, Some(7));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+}

--- a/serdes-ai-models/src/cohere/model.rs
+++ b/serdes-ai-models/src/cohere/model.rs
@@ -13,14 +13,15 @@ use futures::Stream;
 use reqwest::Client;
 use serdes_ai_core::{
     messages::{
-        ModelResponseStreamEvent, TextPart, ToolCallArgs, ToolCallPart, UserContent,
-        UserContentPart,
+        ModelResponseStreamEvent, StreamCompleteEvent, TextPart, ToolCallArgs, ToolCallPart,
+        UserContent, UserContentPart,
     },
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
     RequestUsage,
 };
 use serdes_ai_tools::ToolDefinition;
 use std::{
+    collections::VecDeque,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -80,6 +81,13 @@ impl CohereModel {
     #[must_use]
     pub fn with_client(mut self, client: Client) -> Self {
         self.client = client;
+        self
+    }
+
+    /// Set a custom API base URL.
+    #[must_use]
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
         self
     }
 
@@ -359,11 +367,15 @@ impl Model for CohereModel {
     }
 }
 
-/// Stream parser for Cohere SSE responses.
+/// Stream parser for Cohere NDJSON responses.
 pub struct CohereStreamParser<S> {
     inner: S,
     buffer: String,
     started: bool,
+    // Events queued by a parsed line, drained before parsing more lines
+    pending: VecDeque<ModelResponseStreamEvent>,
+    // Finished: terminal event emitted or stream failed; no further events
+    done: bool,
 }
 
 impl<S> CohereStreamParser<S> {
@@ -373,6 +385,8 @@ impl<S> CohereStreamParser<S> {
             inner: stream,
             buffer: String::new(),
             started: false,
+            pending: VecDeque::new(),
+            done: false,
         }
     }
 }
@@ -385,6 +399,17 @@ where
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
+            // Drain queued events first so the terminal event follows the
+            // part end that queued it.
+            if let Some(event) = self.pending.pop_front() {
+                return Poll::Ready(Some(Ok(event)));
+            }
+
+            // After the terminal event the stream is done.
+            if self.done {
+                return Poll::Ready(None);
+            }
+
             // Try to parse a complete event from buffer
             if let Some(event) = self.try_parse_event() {
                 return Poll::Ready(Some(Ok(event)));
@@ -432,6 +457,9 @@ impl<S> CohereStreamParser<S> {
                         }
                     }
                     "stream-end" => {
+                        // Mark done so no event follows the terminal one.
+                        self.done = true;
+                        self.pending.push_back(stream_complete_event(&event));
                         return Some(ModelResponseStreamEvent::part_end(0));
                     }
                     _ => {}
@@ -440,6 +468,43 @@ impl<S> CohereStreamParser<S> {
         }
         None
     }
+}
+
+/// Build the terminal event from a `stream-end` event's finish reason and
+/// the token counts in its wrapped response; usage fields absent from the
+/// wire stay `None`.
+fn stream_complete_event(event: &StreamEvent) -> ModelResponseStreamEvent {
+    let reason = event.finish_reason.as_deref().or_else(|| {
+        event
+            .response
+            .as_ref()
+            .and_then(|r| r.finish_reason.as_deref())
+    });
+    let finish_reason = match reason {
+        Some("MAX_TOKENS") => FinishReason::Length,
+        Some("TOOL_CALL") => FinishReason::ToolCall,
+        // COMPLETE and END_TURN map to Stop, matching the non-streaming
+        // response mapping; unknown and absent reasons also fall back to
+        // Stop because the terminal event requires a reason.
+        _ => FinishReason::Stop,
+    };
+
+    let mut complete = StreamCompleteEvent::new(finish_reason);
+    if let Some(tokens) = event
+        .response
+        .as_ref()
+        .and_then(|r| r.meta.as_ref())
+        .and_then(|meta| meta.tokens.as_ref())
+    {
+        if let Some(tokens) = tokens.input_tokens {
+            complete = complete.with_input_tokens(u64::from(tokens));
+        }
+        if let Some(tokens) = tokens.output_tokens {
+            complete = complete.with_output_tokens(u64::from(tokens));
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(complete)
 }
 
 #[cfg(test)]
@@ -467,5 +532,193 @@ mod tests {
         let profile = CohereModel::profile_for_model("command-r-plus");
         assert!(profile.supports_tools);
         assert_eq!(profile.context_window, Some(128_000));
+    }
+
+    /// A custom base URL overrides the default Cohere API endpoint.
+    #[test]
+    fn test_custom_base_url() {
+        let model = CohereModel::new("command-r-plus", "test-key")
+            .with_base_url("http://localhost:8080/v2");
+        assert_eq!(model.base_url, "http://localhost:8080/v2");
+    }
+
+    // Stream parser terminal-event contract.
+
+    /// Collect every event a parser yields for the given NDJSON lines.
+    async fn parse_ndjson(lines: &[&str]) -> Vec<ModelResponseStreamEvent> {
+        use futures::{stream, StreamExt};
+
+        let bytes = lines
+            .iter()
+            .map(|l| Ok(Bytes::from(format!("{}\n", l))))
+            .collect::<Vec<_>>();
+        let mut parser = CohereStreamParser::new(stream::iter(bytes));
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A stream-end event with token usage ends the stream with exactly one
+    /// terminal event, emitted last, mapping the finish reason and counts.
+    #[tokio::test]
+    async fn stream_end_emits_terminal_stream_complete_with_usage() {
+        let events = parse_ndjson(&[
+            r#"{"event_type":"text-generation","text":"Hel"}"#,
+            r#"{"event_type":"text-generation","text":"lo"}"#,
+            r#"{"event_type":"stream-end","finish_reason":"COMPLETE","response":{"text":"Hello","generation_id":"gen-1","finish_reason":"COMPLETE","meta":{"tokens":{"input_tokens":10,"output_tokens":5}}}}"#,
+        ])
+        .await;
+
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                // The wire format reports no cache counts.
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream-end event without usage still ends the stream with exactly
+    /// one terminal event; every token field stays `None`.
+    #[tokio::test]
+    async fn stream_end_without_usage_yields_none_token_fields() {
+        let events = parse_ndjson(&[
+            r#"{"event_type":"text-generation","text":"Hi"}"#,
+            r#"{"event_type":"stream-end","finish_reason":"MAX_TOKENS"}"#,
+        ])
+        .await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A TOOL_CALL stream-end maps to the ToolCall finish reason on the
+    /// terminal event, matching the non-streaming response mapping.
+    #[tokio::test]
+    async fn tool_call_stream_end_maps_to_tool_call_finish_reason() {
+        let events =
+            parse_ndjson(&[r#"{"event_type":"stream-end","finish_reason":"TOOL_CALL"}"#]).await;
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::ToolCall);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream that ends without stream-end emits no terminal event, so
+    /// consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn eof_without_stream_end_emits_no_terminal_event() {
+        let events = parse_ndjson(&[r#"{"event_type":"text-generation","text":"Hi"}"#]).await;
+
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
+        );
+    }
+
+    // Streaming over wiremock (real HTTP request path).
+
+    /// A streamed chat over real HTTP ends with exactly one terminal
+    /// StreamComplete carrying the stream-end response's token counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+
+        let ndjson_body = concat!(
+            "{\"event_type\":\"text-generation\",\"text\":\"Hel\"}\n",
+            "{\"event_type\":\"text-generation\",\"text\":\"lo\"}\n",
+            "{\"event_type\":\"stream-end\",\"finish_reason\":\"COMPLETE\",\"response\":{\"text\":\"Hello\",\"generation_id\":\"gen-1\",\"finish_reason\":\"COMPLETE\",\"meta\":{\"tokens\":{\"input_tokens\":10,\"output_tokens\":5}}}}\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/chat"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/x-ndjson")
+                    .set_body_string(ndjson_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = CohereModel::new("command-r-plus", "test-key").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/google/model.rs
+++ b/serdes-ai-models/src/google/model.rs
@@ -848,4 +848,73 @@ mod tests {
         assert!(matches!(&result.parts[0], ModelResponsePart::Text(t) if t.content == "Hello!"));
         assert!(matches!(result.finish_reason, Some(FinishReason::Stop)));
     }
+
+    // Streaming over wiremock (real HTTP request path).
+
+    /// A streamed generation over real HTTP ends with exactly one terminal
+    /// StreamComplete carrying the final chunk's mapped usageMetadata counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\"Hello\"}]}}]}\n\n",
+            "data: {\"candidates\":[{\"content\":{\"role\":\"model\",\"parts\":[{\"text\":\" World\"}]},\"finishReason\":\"STOP\"}],\"usageMetadata\":{\"promptTokenCount\":10,\"candidatesTokenCount\":5,\"totalTokenCount\":15,\"cachedContentTokenCount\":3}}\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path(
+                "/v1beta/models/gemini-2.0-flash:streamGenerateContent",
+            ))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = GoogleModel::new("gemini-2.0-flash", "test-key").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }

--- a/serdes-ai-models/src/google/stream.rs
+++ b/serdes-ai-models/src/google/stream.rs
@@ -3,14 +3,14 @@
 //! Google uses a slightly different streaming format - each chunk is a complete
 //! JSON response object, not deltas.
 
-use super::types::{GenerateContentResponse, Part};
+use super::types::{GenerateContentResponse, Part, UsageMetadata};
 use crate::error::ModelError;
 use bytes::Bytes;
 use futures::Stream;
 use pin_project_lite::pin_project;
 use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent, TextPart, ThinkingPart,
-    ToolCallPart,
+    FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
+    StreamCompleteEvent, TextPart, ThinkingPart, ToolCallPart,
 };
 use serdes_ai_core::ModelResponsePart;
 use std::collections::HashMap;
@@ -27,7 +27,13 @@ pin_project! {
         parts: HashMap<usize, PartState>,
         // Current part index
         next_part_index: usize,
-        // Finished
+        // Finish reason mapped from the last seen candidate finishReason
+        finish_reason: Option<FinishReason>,
+        // Usage metadata from the most recent chunk that reported it
+        usage: Option<UsageMetadata>,
+        // Open part indices awaiting a PartEnd before the terminal event
+        pending_part_ends: Vec<usize>,
+        // Finished: terminal event emitted, stream ended, or stream failed
         done: bool,
     }
 }
@@ -60,6 +66,9 @@ where
             buffer: String::new(),
             parts: HashMap::new(),
             next_part_index: 0,
+            finish_reason: None,
+            usage: None,
+            pending_part_ends: Vec::new(),
             done: false,
         }
     }
@@ -78,7 +87,32 @@ where
             return Poll::Ready(None);
         }
 
-        loop {
+        'outer: loop {
+            // Finish observed: close every open part, then emit the terminal
+            // event exactly once as the stream's last event.
+            if let Some(reason) = *this.finish_reason {
+                if let Some(idx) = this.pending_part_ends.pop() {
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: idx },
+                    ))));
+                }
+                if !this.parts.is_empty() {
+                    // Close parts in ascending index order: pop() takes from
+                    // the end, so queue the remaining indices descending.
+                    let mut indices: Vec<usize> = this.parts.drain().map(|(idx, _)| idx).collect();
+                    indices.sort_unstable();
+                    indices.reverse();
+                    let first = indices.pop().expect("parts checked non-empty");
+                    *this.pending_part_ends = indices;
+                    return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(
+                        PartEndEvent { index: first },
+                    ))));
+                }
+
+                *this.done = true;
+                return Poll::Ready(Some(Ok(stream_complete_event(reason, this.usage.as_ref()))));
+            }
+
             // Try to parse complete JSON objects from buffer
             // Google sends each chunk as a complete JSON object on its own line
             while let Some(line_end) = this.buffer.find('\n') {
@@ -94,6 +128,11 @@ where
 
                 // Handle [DONE] marker
                 if json_str == "[DONE]" {
+                    // Without an observed finishReason the stream is
+                    // truncated: end without the terminal event.
+                    if this.finish_reason.is_some() {
+                        continue 'outer;
+                    }
                     *this.done = true;
                     return Poll::Ready(None);
                 }
@@ -101,10 +140,18 @@ where
                 // Parse the JSON response
                 match serde_json::from_str::<GenerateContentResponse>(json_str) {
                     Ok(response) => {
+                        // Capture terminal metadata before part events so it
+                        // survives final chunks that also carry content.
+                        capture_terminal_metadata(&response, this.finish_reason, this.usage);
                         if let Some(event) =
-                            process_response(&response, this.parts, this.next_part_index, this.done)
+                            process_response(&response, this.parts, this.next_part_index)
                         {
                             return Poll::Ready(Some(event));
+                        }
+                        // The finishReason chunk is final: no later chunk
+                        // produces events.
+                        if this.finish_reason.is_some() {
+                            continue 'outer;
                         }
                     }
                     Err(e) => {
@@ -121,11 +168,13 @@ where
                     }
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    // Mark done so no event (including the terminal event)
+                    // is emitted after an error.
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
-                    *this.done = true;
-                    // Process any remaining buffer
+                    // Process any remaining buffer without a trailing newline
                     if !this.buffer.is_empty() {
                         let remaining = std::mem::take(this.buffer);
                         let json_str = remaining.trim();
@@ -135,17 +184,25 @@ where
                             if let Ok(response) =
                                 serde_json::from_str::<GenerateContentResponse>(json_str)
                             {
-                                if let Some(event) = process_response(
+                                capture_terminal_metadata(
                                     &response,
-                                    this.parts,
-                                    this.next_part_index,
-                                    this.done,
-                                ) {
+                                    this.finish_reason,
+                                    this.usage,
+                                );
+                                if let Some(event) =
+                                    process_response(&response, this.parts, this.next_part_index)
+                                {
                                     return Poll::Ready(Some(event));
                                 }
                             }
                         }
                     }
+
+                    if this.finish_reason.is_some() {
+                        continue 'outer;
+                    }
+
+                    *this.done = true;
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -154,12 +211,31 @@ where
     }
 }
 
+/// Capture the terminal metadata a chunk carries: a candidate `finishReason`
+/// (the final chunk's completion signal) and the latest `usageMetadata`, so
+/// both survive final chunks that also carry content parts.
+fn capture_terminal_metadata(
+    response: &GenerateContentResponse,
+    finish_reason: &mut Option<FinishReason>,
+    usage: &mut Option<UsageMetadata>,
+) {
+    if let Some(reason) = response
+        .candidates
+        .first()
+        .and_then(|candidate| candidate.finish_reason.as_deref())
+    {
+        *finish_reason = Some(map_finish_reason(reason));
+    }
+    if let Some(metadata) = &response.usage_metadata {
+        *usage = Some(metadata.clone());
+    }
+}
+
 /// Process a response chunk into stream events.
 fn process_response(
     response: &GenerateContentResponse,
     parts: &mut HashMap<usize, PartState>,
     next_part_index: &mut usize,
-    done: &mut bool,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
     // Get the first candidate
     let candidate = response.candidates.first()?;
@@ -268,19 +344,42 @@ fn process_response(
         }
     }
 
-    // Check for finish
-    if candidate.finish_reason.is_some() {
-        *done = true;
+    None
+}
 
-        // Emit end events for all parts
-        if let Some((idx, _)) = parts.drain().next() {
-            return Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
-                index: idx,
-            })));
+/// Build the terminal event from the captured finish reason and usage
+/// metadata; the optional cached count maps to `cache_read_tokens` only when
+/// reported, and the wire format has no cache-creation count.
+fn stream_complete_event(
+    finish_reason: FinishReason,
+    usage: Option<&UsageMetadata>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason);
+
+    if let Some(u) = usage {
+        event = event
+            .with_input_tokens(u.prompt_token_count)
+            .with_output_tokens(u.candidates_token_count);
+        if let Some(cached) = u.cached_content_token_count {
+            event = event.with_cache_read_tokens(cached);
         }
     }
 
-    None
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+/// Map a Google finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::Stop`], matching the non-streaming
+/// response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "STOP" => FinishReason::Stop,
+        "MAX_TOKENS" => FinishReason::Length,
+        "SAFETY" | "RECITATION" => FinishReason::ContentFilter,
+        "TOOL_CALLS" | "FUNCTION_CALL" => FinishReason::ToolCall,
+        _ => FinishReason::Stop,
+    }
 }
 
 #[cfg(test)]
@@ -326,6 +425,8 @@ mod tests {
         }
     }
 
+    /// A final chunk with a finish reason but no usageMetadata still ends the
+    /// stream with exactly one terminal event; every token field stays None.
     #[tokio::test]
     async fn test_parse_with_finish() {
         let chunk1 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
@@ -339,10 +440,258 @@ mod tests {
             events.push(result.unwrap());
         }
 
-        assert!(
-            events.len() >= 2,
-            "Expected at least 2 events, got {:?}",
+        // Text delta and part end precede the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
             events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish chunk arriving without a trailing newline still ends the
+    /// stream with the terminal event after the remaining buffer is drained
+    /// at EOF.
+    #[tokio::test]
+    async fn finish_chunk_without_trailing_newline_emits_terminal_stream_complete() {
+        let chunk1 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let chunk2 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":" World"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}"#;
+        // No trailing newline on the finish chunk: it is parsed from the
+        // remaining buffer at EOF.
+        let bytes = vec![Ok(make_chunk(chunk1)), Ok(Bytes::from(chunk2))];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A finish-only final chunk without a trailing newline still routes
+    /// through the EOF remaining-buffer branch to the terminal event.
+    #[tokio::test]
+    async fn finish_only_chunk_without_trailing_newline_emits_terminal_stream_complete() {
+        let chunk = r#"{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":3,"totalTokenCount":10}}"#;
+        // No trailing newline and no content parts: the EOF branch must
+        // route the captured finish reason to the terminal event itself.
+        let stream = stream::iter(vec![Ok(Bytes::from(chunk))]);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the terminal event, got {:?}",
+            events
+        );
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(7));
+                assert_eq!(complete.output_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A final chunk carrying usageMetadata ends the stream with exactly one
+    /// terminal event last, mapping prompt, candidates, and cached counts.
+    #[tokio::test]
+    async fn final_chunk_with_usage_metadata_emits_terminal_stream_complete() {
+        let chunk1 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let chunk2 = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":" World"}]},"finishReason":"MAX_TOKENS"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15,"cachedContentTokenCount":3}}"#;
+        let bytes = vec![
+            Ok(make_chunk(chunk1)),
+            Ok(make_chunk(chunk2)),
+            // A trailing [DONE] marker must not suppress the terminal event.
+            Ok(make_chunk("[DONE]")),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Content part events precede the part end and the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected PartStart, PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                // The wire format reports cached tokens but no cache-creation
+                // count.
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(3));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// The terminal event is sequenced after every open part's PartEnd, in
+    /// ascending index order.
+    #[tokio::test]
+    async fn terminal_event_follows_all_open_part_ends() {
+        let text_chunk =
+            r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let tool_chunk = r#"{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"search","args":{"q":"rust"}}}]}}]}"#;
+        let finish_chunk = r#"{"candidates":[{"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}"#;
+        let bytes = vec![
+            Ok(make_chunk(text_chunk)),
+            Ok(make_chunk(tool_chunk)),
+            Ok(make_chunk(finish_chunk)),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            5,
+            "Expected 2 PartStart, 2 PartEnd, StreamComplete, got {:?}",
+            events
+        );
+
+        match (&events[2], &events[3]) {
+            (
+                ModelResponseStreamEvent::PartEnd(first),
+                ModelResponseStreamEvent::PartEnd(second),
+            ) => {
+                assert_eq!(first.index, 0, "lowest open part closes first");
+                assert_eq!(second.index, 1);
+            }
+            other => panic!(
+                "expected PartEnd events before the terminal, got {:?}",
+                other
+            ),
+        }
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.input_tokens, Some(8));
+                assert_eq!(complete.output_tokens, Some(4));
+                // The optional cached count is absent on the wire: it stays
+                // None, never zero.
+                assert_eq!(complete.cache_read_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// Every Google finish reason string maps to the same core variant the
+    /// non-streaming path produces, with unknown strings defaulting to Stop.
+    #[tokio::test]
+    async fn finish_reason_strings_map_to_core_variants() {
+        for (wire, expected) in [
+            ("STOP", FinishReason::Stop),
+            ("MAX_TOKENS", FinishReason::Length),
+            ("SAFETY", FinishReason::ContentFilter),
+            ("RECITATION", FinishReason::ContentFilter),
+            ("TOOL_CALLS", FinishReason::ToolCall),
+            ("FUNCTION_CALL", FinishReason::ToolCall),
+            ("SOMETHING_NEW", FinishReason::Stop),
+        ] {
+            let chunk = format!(r#"{{"candidates":[{{"finishReason":"{wire}"}}]}}"#);
+            let stream = stream::iter(vec![Ok(make_chunk(&chunk))]);
+            let mut parser = GoogleStreamParser::new(stream);
+
+            let mut events = Vec::new();
+            while let Some(result) = parser.next().await {
+                events.push(result.unwrap());
+            }
+
+            match events.last() {
+                Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                    assert_eq!(complete.finish_reason, expected, "wire reason {wire}");
+                }
+                other => panic!("expected terminal event for {wire}, got {other:?}"),
+            }
+        }
+    }
+
+    /// A stream that ends without a finish reason emits no terminal event, so
+    /// consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn stream_end_without_finish_reason_emits_no_terminal_event() {
+        let chunk = r#"{"candidates":[{"content":{"role":"model","parts":[{"text":"Hello"}]}}]}"#;
+        let bytes = vec![Ok(make_chunk(chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = GoogleStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the part event, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
         );
     }
 }

--- a/serdes-ai-models/src/groq/mod.rs
+++ b/serdes-ai-models/src/groq/mod.rs
@@ -133,6 +133,7 @@ impl Model for GroqModel {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serdes_ai_core::FinishReason;
 
     #[test]
     fn test_groq_model_creation() {
@@ -151,5 +152,72 @@ mod tests {
 
         let model = GroqModel::gemma_9b("key");
         assert_eq!(model.name(), "gemma2-9b-it");
+    }
+
+    /// Groq streams by delegating to an inner OpenAI chat model, so a
+    /// streamed request over real HTTP inherits the terminal StreamComplete
+    /// emission at [DONE] with the buffered usage.
+    ///
+    /// The Groq base URL is fixed, so the test points the inner model at a
+    /// mock server and exercises the real `request_stream` delegation.
+    #[tokio::test]
+    async fn request_stream_inherits_terminal_stream_complete() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"llama-3.1-70b-versatile\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"llama-3.1-70b-versatile\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"llama-3.1-70b-versatile\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/chat/completions"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = GroqModel {
+            inner: OpenAIChatModel::new("llama-3.1-70b-versatile", "test-key")
+                .with_base_url(server.uri()),
+        };
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/huggingface/model.rs
+++ b/serdes-ai-models/src/huggingface/model.rs
@@ -525,9 +525,8 @@ mod tests {
     /// event, so consumers keep treating the truncated stream as incomplete.
     #[tokio::test]
     async fn request_stream_without_generated_text_emits_no_terminal_event() {
-        let sse_body = concat!(
-            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
-        );
+        let sse_body =
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n";
 
         let events = stream_events_for(sse_body).await;
 

--- a/serdes-ai-models/src/huggingface/model.rs
+++ b/serdes-ai-models/src/huggingface/model.rs
@@ -10,8 +10,9 @@ use crate::error::ModelError;
 use crate::model::{Model, ModelRequestParameters, StreamedResponse};
 use crate::profile::ModelProfile;
 use serdes_ai_core::{
-    messages::ModelResponseStreamEvent, FinishReason, ModelRequest, ModelRequestPart,
-    ModelResponse, ModelResponsePart, ModelSettings, TextPart, UserContent, UserContentPart,
+    messages::{ModelResponseStreamEvent, StreamCompleteEvent},
+    FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
+    TextPart, UserContent, UserContentPart,
 };
 
 /// HuggingFace Inference API base URL.
@@ -196,21 +197,16 @@ impl HuggingFaceModel {
             .ok_or_else(|| ModelError::invalid_response("No generated text"))?;
 
         let finish_reason = match &resp {
-            GenerateResponse::Single(r) => r.details.as_ref().and_then(|d| {
-                d.finish_reason.as_ref().map(|r| match r.as_str() {
-                    "length" => FinishReason::Length,
-                    "eos_token" | "stop" => FinishReason::Stop,
-                    _ => FinishReason::Stop,
-                })
-            }),
+            GenerateResponse::Single(r) => r
+                .details
+                .as_ref()
+                .and_then(|d| d.finish_reason.as_deref())
+                .map(map_finish_reason),
             GenerateResponse::Batch(results) => results.first().and_then(|r| {
-                r.details.as_ref().and_then(|d| {
-                    d.finish_reason.as_ref().map(|r| match r.as_str() {
-                        "length" => FinishReason::Length,
-                        "eos_token" | "stop" => FinishReason::Stop,
-                        _ => FinishReason::Stop,
-                    })
-                })
+                r.details
+                    .as_ref()
+                    .and_then(|d| d.finish_reason.as_deref())
+                    .map(map_finish_reason)
             }),
         };
 
@@ -296,6 +292,7 @@ impl Model for HuggingFaceModel {
         self.parse_response(resp)
     }
 
+    /// Stream a generation from the TGI endpoint.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
@@ -328,15 +325,16 @@ impl Model for HuggingFaceModel {
         }
 
         let stream = response.bytes_stream();
-        let model_id = self.model_id.clone();
 
-        // Parse SSE stream
-        let mapped = stream.filter_map(move |chunk| {
-            let _model_id = model_id.clone();
-            async move {
+        // Parse SSE stream; a chunk can carry several data lines, so every
+        // event it produces is emitted, with the terminal event last.
+        let events = stream
+            .filter_map(|chunk| async {
                 match chunk {
                     Ok(bytes) => {
                         let text = String::from_utf8_lossy(&bytes);
+                        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> =
+                            Vec::new();
                         // Parse SSE data lines
                         for line in text.lines() {
                             if let Some(data) = line.strip_prefix("data:") {
@@ -347,25 +345,61 @@ impl Model for HuggingFaceModel {
                                 if let Ok(resp) = serde_json::from_str::<StreamResponse>(data) {
                                     if let Some(token) = resp.token {
                                         if !token.special {
-                                            return Some(Ok(ModelResponseStreamEvent::text_delta(
+                                            events.push(Ok(ModelResponseStreamEvent::text_delta(
                                                 0, token.text,
                                             )));
                                         }
                                     }
                                     if resp.generated_text.is_some() {
-                                        return Some(Ok(ModelResponseStreamEvent::part_end(0)));
+                                        events.push(Ok(ModelResponseStreamEvent::part_end(0)));
+                                        let finish_reason = resp
+                                            .details
+                                            .as_ref()
+                                            .and_then(|d| d.finish_reason.as_deref())
+                                            .map(map_finish_reason)
+                                            .unwrap_or(FinishReason::Stop);
+                                        events.push(Ok(ModelResponseStreamEvent::StreamComplete(
+                                            StreamCompleteEvent::new(finish_reason),
+                                        )));
                                     }
                                 }
                             }
                         }
-                        None
+                        if events.is_empty() {
+                            None
+                        } else {
+                            Some(events)
+                        }
                     }
-                    Err(e) => Some(Err(ModelError::network(e.to_string()))),
+                    Err(e) => Some(vec![Err(ModelError::network(e.to_string()))]),
                 }
+            })
+            .flat_map(futures::stream::iter);
+
+        // The terminal event ends the stream: nothing is yielded after the
+        // first StreamComplete, keeping it exactly once and last.
+        let mut terminal_seen = false;
+        let mapped = events.take_while(move |event| {
+            let stop = terminal_seen;
+            if matches!(event, Ok(ModelResponseStreamEvent::StreamComplete(_))) {
+                terminal_seen = true;
             }
+            std::future::ready(!stop)
         });
 
         Ok(Box::pin(mapped))
+    }
+}
+
+/// Map a TGI finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::Stop`], matching the non-streaming
+/// response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "length" => FinishReason::Length,
+        "eos_token" | "stop" => FinishReason::Stop,
+        _ => FinishReason::Stop,
     }
 }
 
@@ -406,5 +440,153 @@ mod tests {
         assert!(prompt.contains("<|user|>"));
         assert!(prompt.contains("Hello!"));
         assert!(prompt.ends_with("<|assistant|>\n"));
+    }
+
+    // Streaming over wiremock (real HTTP request path).
+
+    /// Collect the events a streamed request yields for the given SSE body.
+    async fn stream_events_for(sse_body: &str) -> Vec<ModelResponseStreamEvent> {
+        use futures::StreamExt;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = HuggingFaceModel::new("test-model", "test-token").with_endpoint(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A streamed generation over real HTTP ends with exactly one terminal
+    /// StreamComplete after the part end, mapping the final chunk's finish
+    /// reason and leaving every token field `None`.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete() {
+        let sse_body = concat!(
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
+            "data:{\"token\":{\"id\":2,\"text\":\" world\",\"logprob\":null,\"special\":false}}\n\n",
+            "data:{\"generated_text\":\"Hello world\",\"details\":{\"finish_reason\":\"length\",\"generated_tokens\":2,\"seed\":null}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        // Text deltas precede the part end and the terminal event.
+        assert_eq!(
+            events.len(),
+            4,
+            "Expected 2 PartDelta, PartEnd, StreamComplete, got {:?}",
+            events
+        );
+        assert!(matches!(events[0], ModelResponseStreamEvent::PartDelta(_)));
+        assert!(matches!(events[1], ModelResponseStreamEvent::PartDelta(_)));
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Length);
+                // TGI reports no token counts in this mode.
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A stream that ends without a generated_text chunk emits no terminal
+    /// event, so consumers keep treating the truncated stream as incomplete.
+    #[tokio::test]
+    async fn request_stream_without_generated_text_emits_no_terminal_event() {
+        let sse_body = concat!(
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the text delta, got {:?}",
+            events
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_))),
+            "truncated stream must not emit a terminal event"
+        );
+    }
+
+    /// A data line after the generated_text line yields no event after the
+    /// terminal one, keeping the terminal the stream's last event.
+    #[tokio::test]
+    async fn request_stream_ignores_lines_after_generated_text() {
+        let sse_body = concat!(
+            "data:{\"token\":{\"id\":1,\"text\":\"Hello\",\"logprob\":null,\"special\":false}}\n\n",
+            "data:{\"generated_text\":\"Hello\",\"details\":{\"finish_reason\":\"stop\",\"generated_tokens\":1,\"seed\":null}}\n\n",
+            "data:{\"token\":{\"id\":2,\"text\":\" trailing\",\"logprob\":null,\"special\":false}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+        assert!(
+            matches!(
+                events.last(),
+                Some(ModelResponseStreamEvent::StreamComplete(_))
+            ),
+            "terminal event must be emitted last, got {:?}",
+            events.last()
+        );
+    }
+
+    /// A duplicated generated_text line still yields exactly one terminal
+    /// event.
+    #[tokio::test]
+    async fn request_stream_with_duplicated_generated_text_emits_one_terminal_event() {
+        let sse_body = concat!(
+            "data:{\"generated_text\":\"Hello\",\"details\":{\"finish_reason\":\"stop\",\"generated_tokens\":1,\"seed\":null}}\n\n",
+            "data:{\"generated_text\":\"Hello again\",\"details\":{\"finish_reason\":\"stop\",\"generated_tokens\":2,\"seed\":null}}\n\n",
+        );
+
+        let events = stream_events_for(sse_body).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
     }
 }

--- a/serdes-ai-models/src/lib.rs
+++ b/serdes-ai-models/src/lib.rs
@@ -537,12 +537,38 @@ mod tests {
         let result = build_model_with_config("unknown", "model", None, None, None);
         assert!(result.is_err());
     }
+
+    /// Setting a reasoning effort builds the Responses API model; gpt-5.1
+    /// reports reasoning support only on that path.
+    #[cfg(feature = "openai")]
+    #[test]
+    fn test_build_model_extended_reasoning_effort_selects_responses_model() {
+        let config = ExtendedModelConfig::new()
+            .with_api_key("test-key")
+            .with_reasoning_effort("xhigh");
+        let model = build_model_extended("openai", "gpt-5.1", config).unwrap();
+
+        assert_eq!(model.name(), "gpt-5.1");
+        assert!(model.profile().supports_reasoning);
+    }
+
+    /// Without a reasoning effort the openai branch keeps the chat
+    /// completions model, which does not report reasoning for gpt-5.1.
+    #[cfg(feature = "openai")]
+    #[test]
+    fn test_build_model_extended_without_reasoning_effort_keeps_chat_model() {
+        let config = ExtendedModelConfig::new().with_api_key("test-key");
+        let model = build_model_extended("openai", "gpt-5.1", config).unwrap();
+
+        assert_eq!(model.name(), "gpt-5.1");
+        assert!(!model.profile().supports_reasoning);
+    }
 }
 
 /// Extended configuration options for model building.
 ///
 /// This struct allows configuring advanced model features like extended thinking
-/// for Claude models, reasoning effort for OpenAI o1/o3, etc.
+/// for Claude models, reasoning effort for OpenAI reasoning models, etc.
 #[derive(Debug, Clone, Default)]
 pub struct ExtendedModelConfig {
     /// API key (overrides environment variable)
@@ -557,7 +583,8 @@ pub struct ExtendedModelConfig {
     pub enable_thinking: bool,
     /// Budget for thinking tokens (Anthropic Claude)
     pub thinking_budget: Option<u64>,
-    /// Reasoning effort (OpenAI o1/o3)
+    /// Reasoning effort for OpenAI reasoning models (e.g. "low", "high",
+    /// "xhigh", "max"); any string is sent verbatim
     pub reasoning_effort: Option<String>,
     /// Optional same-model retry policy. Retries are disabled when omitted.
     pub retry_policy: Option<RetryPolicy>,
@@ -600,7 +627,10 @@ impl ExtendedModelConfig {
         self
     }
 
-    /// Set reasoning effort for OpenAI o1/o3 models
+    /// Set reasoning effort for OpenAI reasoning models.
+    ///
+    /// Known efforts map to named variants case-insensitively; any other
+    /// string is sent to the API verbatim.
     pub fn with_reasoning_effort(mut self, effort: impl Into<String>) -> Self {
         self.reasoning_effort = Some(effort.into());
         self
@@ -622,7 +652,8 @@ impl ExtendedModelConfig {
 /// Build a model with extended configuration options.
 ///
 /// This function extends `build_model_with_config` to support advanced features
-/// like extended thinking for Claude models.
+/// like extended thinking for Claude models and reasoning effort for OpenAI
+/// reasoning models.
 ///
 /// # Arguments
 ///
@@ -640,6 +671,12 @@ impl ExtendedModelConfig {
 ///     .with_api_key("sk-...")
 ///     .with_thinking(Some(10000));
 /// let model = build_model_extended("anthropic", "claude-3-5-sonnet-20241022", config)?;
+///
+/// // Build OpenAI reasoning model with an effort level
+/// let config = ExtendedModelConfig::new()
+///     .with_api_key("sk-...")
+///     .with_reasoning_effort("max");
+/// let model = build_model_extended("openai", "gpt-5.1", config)?;
 /// ```
 pub fn build_model_extended(
     provider: &str,
@@ -653,33 +690,39 @@ pub fn build_model_extended(
         "openai" | "gpt" => {
             #[cfg(feature = "openai")]
             {
-                let model = if let Some(ref key) = config.api_key {
-                    OpenAIChatModel::new(model_name, key)
+                // Reasoning effort exists only on the Responses API, so an
+                // effort set here selects OpenAIResponsesModel over chat
+                // completions.
+                if config.reasoning_effort.is_some() {
+                    let model = openai_responses_model_from_config(model_name, &config)?;
+                    Ok(Arc::new(model) as Arc<dyn Model>)
                 } else {
-                    OpenAIChatModel::from_env(model_name)?
-                };
+                    let model = if let Some(ref key) = config.api_key {
+                        OpenAIChatModel::new(model_name, key)
+                    } else {
+                        OpenAIChatModel::from_env(model_name)?
+                    };
 
-                let model = if let Some(ref url) = config.base_url {
-                    model.with_base_url(url)
-                } else {
-                    model
-                };
+                    let model = if let Some(ref url) = config.base_url {
+                        model.with_base_url(url)
+                    } else {
+                        model
+                    };
 
-                let model = if let Some(t) = config.timeout {
-                    model.with_timeout(t)
-                } else {
-                    model
-                };
+                    let model = if let Some(t) = config.timeout {
+                        model.with_timeout(t)
+                    } else {
+                        model
+                    };
 
-                // TODO: Add reasoning_effort support when available in OpenAIChatModel
+                    let model = if let Some(ref client) = config.client {
+                        model.with_client(client.clone())
+                    } else {
+                        model
+                    };
 
-                let model = if let Some(ref client) = config.client {
-                    model.with_client(client.clone())
-                } else {
-                    model
-                };
-
-                Ok(Arc::new(model) as Arc<dyn Model>)
+                    Ok(Arc::new(model) as Arc<dyn Model>)
+                }
             }
             #[cfg(not(feature = "openai"))]
             {
@@ -833,4 +876,47 @@ pub fn build_model_extended(
         Some(policy) => Arc::new(RetryingModel::from_arc(model, policy)),
         None => model,
     })
+}
+
+/// Build the OpenAI Responses API model for the extended config, applying
+/// the configured reasoning effort and shared connection options.
+///
+/// Returns `ModelError::Configuration` when `config.reasoning_effort` is
+/// unset, because the effort is what selects the Responses API, or when
+/// `config.api_key` is unset and `OPENAI_API_KEY` is absent.
+#[cfg(feature = "openai")]
+pub(crate) fn openai_responses_model_from_config(
+    model_name: &str,
+    config: &ExtendedModelConfig,
+) -> ModelResult<OpenAIResponsesModel> {
+    let Some(effort) = config.reasoning_effort.as_deref() else {
+        return Err(ModelError::Configuration(
+            "Reasoning effort is required to build a Responses API model.".to_string(),
+        ));
+    };
+
+    let model = if let Some(ref key) = config.api_key {
+        OpenAIResponsesModel::new(model_name, key)
+    } else {
+        OpenAIResponsesModel::from_env(model_name)?
+    }
+    .with_reasoning_effort(effort);
+
+    let model = if let Some(ref url) = config.base_url {
+        model.with_base_url(url)
+    } else {
+        model
+    };
+
+    let model = if let Some(t) = config.timeout {
+        model.with_timeout(t)
+    } else {
+        model
+    };
+
+    if let Some(ref client) = config.client {
+        Ok(model.with_client(client.clone()))
+    } else {
+        Ok(model)
+    }
 }

--- a/serdes-ai-models/src/openai/chat.rs
+++ b/serdes-ai-models/src/openai/chat.rs
@@ -661,4 +661,72 @@ mod tests {
         assert_eq!(req.stream, Some(true));
         assert!(req.stream_options.is_some());
     }
+
+    /// A streaming chat completion over real HTTP ends with exactly one
+    /// terminal StreamComplete carrying the include_usage chunk's counts.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        use futures::StreamExt;
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let sse_body = concat!(
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"Hello\"}}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n",
+            "data: {\"id\":\"chatcmpl-1\",\"object\":\"chat.completion.chunk\",\"created\":1234567890,\"model\":\"gpt-4o\",\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5,\"total_tokens\":15,\"prompt_tokens_details\":{\"cached_tokens\":7}}}\n\n",
+            "data: [DONE]\n\n",
+        );
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/chat/completions"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(sse_body),
+            )
+            .mount(&server)
+            .await;
+
+        let model = OpenAIChatModel::new("gpt-4o", "sk-test-key").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+
+        // Part events precede the terminal event.
+        assert!(
+            matches!(events.first(), Some(ModelResponseStreamEvent::PartStart(_))),
+            "expected a leading part event, got {:?}",
+            events.first()
+        );
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(7));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -18,8 +18,9 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use serdes_ai_core::messages::{
-    ImageContent, RetryPromptPart, TextPart, ThinkingPart, ToolCallArgs, ToolCallPart,
-    ToolReturnPart, UserContent, UserContentPart, UserPromptPart,
+    ImageContent, ModelResponseStreamEvent, PartStartEvent, RetryPromptPart, StreamCompleteEvent,
+    TextPart, ThinkingPart, ToolCallArgs, ToolCallPart, ToolReturnPart, UserContent,
+    UserContentPart, UserPromptPart,
 };
 use serdes_ai_core::{
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
@@ -1157,6 +1158,7 @@ impl Model for OpenAIResponsesModel {
         self.process_response(resp)
     }
 
+    /// Stream a response through the non-streaming request fallback.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
@@ -1167,23 +1169,59 @@ impl Model for OpenAIResponsesModel {
         // TODO: Implement proper streaming with ResponsesStreamParser
         let response = self.request(messages, settings, params).await?;
 
-        // Convert to a single-event stream
-        let events: Vec<Result<serdes_ai_core::messages::ModelResponseStreamEvent, ModelError>> =
-            response
-                .parts
-                .into_iter()
-                .enumerate()
-                .map(|(idx, part)| {
-                    Ok(
-                        serdes_ai_core::messages::ModelResponseStreamEvent::PartStart(
-                            serdes_ai_core::messages::PartStartEvent::new(idx, part),
-                        ),
-                    )
-                })
-                .collect();
+        let ModelResponse {
+            parts,
+            finish_reason,
+            usage,
+            ..
+        } = response;
+
+        // Part events first, terminal event last; the request error above
+        // short-circuits failures before any event is emitted.
+        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> = parts
+            .into_iter()
+            .enumerate()
+            .map(|(idx, part)| {
+                Ok(ModelResponseStreamEvent::PartStart(PartStartEvent::new(
+                    idx, part,
+                )))
+            })
+            .collect();
+
+        events.push(Ok(stream_complete_event(finish_reason, usage.as_ref())));
 
         Ok(Box::pin(futures::stream::iter(events)))
     }
+}
+
+/// Build the terminal event from the finish reason and usage the
+/// non-streaming path mapped from the completed response.
+///
+/// Usage fields absent from the response stay `None`; a status the
+/// non-streaming mapping leaves unmapped defaults to [`FinishReason::Stop`],
+/// matching the chat stream parser's terminal default.
+fn stream_complete_event(
+    finish_reason: Option<FinishReason>,
+    usage: Option<&RequestUsage>,
+) -> ModelResponseStreamEvent {
+    let mut event = StreamCompleteEvent::new(finish_reason.unwrap_or(FinishReason::Stop));
+
+    if let Some(u) = usage {
+        if let Some(tokens) = u.request_tokens {
+            event = event.with_input_tokens(tokens);
+        }
+        if let Some(tokens) = u.response_tokens {
+            event = event.with_output_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_creation_tokens {
+            event = event.with_cache_creation_tokens(tokens);
+        }
+        if let Some(tokens) = u.cache_read_tokens {
+            event = event.with_cache_read_tokens(tokens);
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(event)
 }
 
 #[cfg(test)]
@@ -1283,5 +1321,134 @@ mod tests {
         let json = serde_json::to_string(&input).unwrap();
         assert!(json.contains("\"role\":\"tool\""));
         assert!(json.contains("\"tool_call_id\":\"call_123\""));
+    }
+
+    // Streaming fallback over wiremock (real HTTP request path).
+
+    /// Build a completed non-streaming Responses response body, with usage
+    /// attached only when the scenario provides it.
+    fn completed_response_body(usage: Option<serde_json::Value>) -> serde_json::Value {
+        let mut body = serde_json::json!({
+            "id": "resp_123",
+            "object": "response",
+            "created_at": 1234567890,
+            "model": "o3-mini",
+            "status": "completed",
+            "output": [{
+                "type": "message",
+                "id": "msg_1",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{ "type": "output_text", "text": "Hello", "annotations": [] }]
+            }],
+            "error": null,
+            "metadata": null,
+            "service_tier": null
+        });
+        if let Some(usage) = usage {
+            body["usage"] = usage;
+        }
+        body
+    }
+
+    /// Serve the given response body from a wiremock server and collect the
+    /// events `request_stream` yields against it.
+    async fn stream_events_for(body: serde_json::Value) -> Vec<ModelResponseStreamEvent> {
+        use futures::StreamExt;
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/responses"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+
+        let model = OpenAIResponsesModel::new("o3-mini", "sk-test").with_base_url(server.uri());
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let mut stream = model
+            .request_stream(
+                &[req],
+                &ModelSettings::new(),
+                &ModelRequestParameters::new(),
+            )
+            .await
+            .unwrap();
+
+        let mut events = Vec::new();
+        while let Some(result) = stream.next().await {
+            events.push(result.unwrap());
+        }
+        events
+    }
+
+    /// A streamed request over real HTTP replays the buffered completed
+    /// response as part events and ends with exactly one terminal
+    /// StreamComplete carrying the mapped finish reason and usage.
+    #[tokio::test]
+    async fn request_stream_emits_terminal_stream_complete_with_usage() {
+        let usage = serde_json::json!({
+            "input_tokens": 12,
+            "output_tokens": 7,
+            "total_tokens": 19,
+            "input_tokens_details": {"cached_tokens": 4},
+            "output_tokens_details": {"reasoning_tokens": 3}
+        });
+        let events = stream_events_for(completed_response_body(Some(usage))).await;
+
+        // Part events precede the terminal event.
+        match events.first() {
+            Some(ModelResponseStreamEvent::PartStart(start)) => {
+                assert_eq!(start.index, 0);
+                assert!(
+                    matches!(&start.part, ModelResponsePart::Text(t) if t.content == "Hello"),
+                    "expected the buffered text part first, got {:?}",
+                    start.part
+                );
+            }
+            other => panic!("expected a leading part event, got {:?}", other),
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(12));
+                assert_eq!(complete.output_tokens, Some(7));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(4));
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
+
+    /// A completed response without usage still ends with exactly one
+    /// terminal event, and every token field stays `None`.
+    #[tokio::test]
+    async fn request_stream_without_usage_yields_none_token_fields() {
+        let events = stream_events_for(completed_response_body(None)).await;
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
     }
 }

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -35,7 +35,7 @@ use std::time::Duration;
 /// OpenAI Responses API model settings.
 #[derive(Debug, Clone, Default)]
 pub struct OpenAIResponsesModelSettings {
-    /// Reasoning effort: "low", "medium", "high"
+    /// Reasoning effort (e.g. "low", "high", "xhigh", "max", or any custom string)
     pub reasoning_effort: Option<ReasoningEffort>,
 
     /// Reasoning summary: "concise", "detailed", "auto"
@@ -61,24 +61,74 @@ pub struct OpenAIResponsesModelSettings {
 }
 
 /// Reasoning effort level for reasoning models.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// Known efforts are named variants; newer models may accept efforts this
+/// crate does not know about, which can be expressed with
+/// [`ReasoningEffort::Custom`]. The value is sent to the API verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ReasoningEffort {
-    /// Minimal reasoning - fastest responses
+    /// Minimal reasoning - fastest responses (gpt-5 family)
+    Minimal,
+    /// Low reasoning
     Low,
     /// Balanced reasoning - default
     #[default]
     Medium,
-    /// Deep reasoning - most thorough
+    /// Deep reasoning
     High,
+    /// Extra-deep reasoning (newer models, e.g. gpt-5.1)
+    XHigh,
+    /// Maximum reasoning (newer models, e.g. gpt-5.1-pro)
+    Max,
+    /// Any other effort string, passed through verbatim.
+    Custom(String),
 }
 
 impl ReasoningEffort {
-    fn as_str(&self) -> &'static str {
+    /// The effort string sent to the API.
+    fn as_str(&self) -> &str {
         match self {
+            Self::Minimal => "minimal",
             Self::Low => "low",
             Self::Medium => "medium",
             Self::High => "high",
+            Self::XHigh => "xhigh",
+            Self::Max => "max",
+            Self::Custom(s) => s,
         }
+    }
+
+    /// Parse an effort string. Known (case-insensitive) values map to named
+    /// variants; anything else becomes [`ReasoningEffort::Custom`] with the
+    /// original string preserved.
+    pub fn parse(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "minimal" => Self::Minimal,
+            "low" => Self::Low,
+            "medium" => Self::Medium,
+            "high" => Self::High,
+            "xhigh" => Self::XHigh,
+            "max" => Self::Max,
+            _ => Self::Custom(s.to_string()),
+        }
+    }
+}
+
+impl From<&str> for ReasoningEffort {
+    fn from(s: &str) -> Self {
+        Self::parse(s)
+    }
+}
+
+impl From<String> for ReasoningEffort {
+    fn from(s: String) -> Self {
+        Self::parse(&s)
+    }
+}
+
+impl std::fmt::Display for ReasoningEffort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -702,9 +752,12 @@ impl OpenAIResponsesModel {
     }
 
     /// Set the reasoning effort level.
+    ///
+    /// Accepts a [`ReasoningEffort`] or any string; known efforts map to
+    /// named variants and unknown strings pass through verbatim.
     #[must_use]
-    pub fn with_reasoning_effort(mut self, effort: ReasoningEffort) -> Self {
-        self.default_settings.reasoning_effort = Some(effort);
+    pub fn with_reasoning_effort(mut self, effort: impl Into<ReasoningEffort>) -> Self {
+        self.default_settings.reasoning_effort = Some(effort.into());
         self
     }
 
@@ -939,7 +992,7 @@ impl OpenAIResponsesModel {
             || self.default_settings.reasoning_summary.is_some()
         {
             Some(ReasoningConfig {
-                effort: self.default_settings.reasoning_effort,
+                effort: self.default_settings.reasoning_effort.clone(),
                 summary: self.default_settings.reasoning_summary,
             })
         } else {
@@ -1190,6 +1243,8 @@ impl Model for OpenAIResponsesModel {
 mod tests {
     use super::*;
 
+    /// Every effort variant serializes as its API string; custom values
+    /// pass through verbatim.
     #[test]
     fn test_reasoning_effort_serialization() {
         assert_eq!(
@@ -1204,6 +1259,43 @@ mod tests {
             serde_json::to_string(&ReasoningEffort::High).unwrap(),
             "\"high\""
         );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::Minimal).unwrap(),
+            "\"minimal\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::XHigh).unwrap(),
+            "\"xhigh\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::Max).unwrap(),
+            "\"max\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ReasoningEffort::Custom("ultra".to_string())).unwrap(),
+            "\"ultra\""
+        );
+    }
+
+    /// Known efforts parse case-insensitively; unknown strings become
+    /// `Custom` with the original casing preserved.
+    #[test]
+    fn test_reasoning_effort_parse_maps_known_and_keeps_custom_verbatim() {
+        assert_eq!(ReasoningEffort::parse("xhigh"), ReasoningEffort::XHigh);
+        assert_eq!(ReasoningEffort::parse("MAX"), ReasoningEffort::Max);
+        assert_eq!(
+            ReasoningEffort::from("Minimal"),
+            ReasoningEffort::Minimal
+        );
+        assert_eq!(
+            ReasoningEffort::from(String::from("xhigh")),
+            ReasoningEffort::XHigh
+        );
+        assert_eq!(
+            ReasoningEffort::parse("UltraDeep"),
+            ReasoningEffort::Custom("UltraDeep".to_string())
+        );
+        assert_eq!(ReasoningEffort::XHigh.to_string(), "xhigh");
     }
 
     #[test]
@@ -1239,6 +1331,58 @@ mod tests {
             model.default_settings.reasoning_effort,
             Some(ReasoningEffort::High)
         );
+    }
+
+    /// The effort builder accepts strings, mapping known values to variants.
+    #[test]
+    fn test_model_builder_accepts_effort_strings() {
+        let model = OpenAIResponsesModel::new("gpt-5.1", "sk-test")
+            .with_reasoning_effort("xhigh")
+            .with_reasoning_effort("max");
+        assert_eq!(
+            model.default_settings.reasoning_effort,
+            Some(ReasoningEffort::Max)
+        );
+    }
+
+    /// A set effort reaches the request body as the reasoning config.
+    #[test]
+    fn test_build_request_serializes_reasoning_effort() {
+        let model =
+            OpenAIResponsesModel::new("gpt-5.1-pro", "sk-test").with_reasoning_effort("max");
+        let mut req = ModelRequest::new();
+        req.add_user_prompt("Hello");
+
+        let request = model.build_request(
+            &[req],
+            &ModelSettings::new(),
+            &ModelRequestParameters::new(),
+            false,
+        );
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(
+            json.contains(r#""reasoning":{"effort":"max"}"#),
+            "expected max effort in request, got: {json}"
+        );
+    }
+
+    /// The extended-config path applies the configured effort and options
+    /// to the built Responses model, not just the model selection.
+    #[test]
+    fn test_extended_config_applies_effort_to_responses_model() {
+        let config = crate::ExtendedModelConfig::new()
+            .with_api_key("test-key")
+            .with_reasoning_effort("xhigh")
+            .with_base_url("https://custom.api.com/v1");
+
+        let model = crate::openai_responses_model_from_config("gpt-5.1", &config).unwrap();
+
+        assert_eq!(
+            model.default_settings.reasoning_effort,
+            Some(ReasoningEffort::XHigh)
+        );
+        assert_eq!(model.base_url, "https://custom.api.com/v1");
     }
 
     #[test]

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -1283,10 +1283,7 @@ mod tests {
     fn test_reasoning_effort_parse_maps_known_and_keeps_custom_verbatim() {
         assert_eq!(ReasoningEffort::parse("xhigh"), ReasoningEffort::XHigh);
         assert_eq!(ReasoningEffort::parse("MAX"), ReasoningEffort::Max);
-        assert_eq!(
-            ReasoningEffort::from("Minimal"),
-            ReasoningEffort::Minimal
-        );
+        assert_eq!(ReasoningEffort::from("Minimal"), ReasoningEffort::Minimal);
         assert_eq!(
             ReasoningEffort::from(String::from("xhigh")),
             ReasoningEffort::XHigh

--- a/serdes-ai-models/src/openai/stream.rs
+++ b/serdes-ai-models/src/openai/stream.rs
@@ -541,8 +541,7 @@ mod tests {
             .get("http://127.0.0.1:1")
             .send()
             .await
-            .err()
-            .expect("connection to closed loopback port must fail");
+            .expect_err("connection to closed loopback port must fail");
 
         let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
         let bytes = vec![Ok(make_chunk_bytes(text_chunk)), Err(err)];

--- a/serdes-ai-models/src/openai/stream.rs
+++ b/serdes-ai-models/src/openai/stream.rs
@@ -2,20 +2,6 @@
 //!
 //! This module provides streaming support for OpenAI chat completions.
 
-use super::types::ChatCompletionChunk;
-use crate::error::ModelError;
-use bytes::Bytes;
-use futures::Stream;
-use pin_project_lite::pin_project;
-use serdes_ai_core::messages::{
-    ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent, TextPart, ThinkingPart,
-    ThinkingPartDelta, ToolCallArgs, ToolCallPart,
-};
-use serdes_ai_core::ModelResponsePart;
-use std::collections::HashMap;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 pin_project! {
     /// OpenAI SSE stream parser.
     pub struct OpenAIStreamParser<S> {
@@ -34,12 +20,32 @@ pin_project! {
         current_thinking_index: Option<usize>,
         // Next part index to use
         next_part_index: usize,
-        // Finished
+        // Finished: terminal event emitted or stream failed; no further events
         done: bool,
+        // data: [DONE] marker observed; terminal event still pending
+        done_seen: bool,
+        // Last seen non-None finish reason across chunks
+        last_finish_reason: Option<FinishReason>,
+        // Buffered usage from the include_usage chunk
+        usage: Option<Usage>,
         // Pending PartEnd events to emit (queued when multiple parts close at once)
         pending_part_ends: Vec<usize>,
     }
 }
+
+use super::types::{ChatCompletionChunk, Usage};
+use crate::error::ModelError;
+use bytes::Bytes;
+use futures::Stream;
+use pin_project_lite::pin_project;
+use serdes_ai_core::messages::{
+    FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
+    StreamCompleteEvent, TextPart, ThinkingPart, ThinkingPartDelta, ToolCallArgs, ToolCallPart,
+};
+use serdes_ai_core::ModelResponsePart;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// State for an in-progress tool call.
 #[derive(Debug, Clone, Default)]
@@ -67,6 +73,9 @@ where
             current_thinking_index: None,
             next_part_index: 0,
             done: false,
+            done_seen: false,
+            last_finish_reason: None,
+            usage: None,
             pending_part_ends: Vec::new(),
         }
     }
@@ -104,11 +113,23 @@ where
                     this.thinking_started,
                     this.current_thinking_index,
                     this.next_part_index,
-                    this.done,
+                    this.done_seen,
+                    this.last_finish_reason,
+                    this.usage,
                     this.pending_part_ends,
                 ) {
                     return Poll::Ready(Some(event));
                 }
+            }
+
+            // [DONE] observed and all buffered lines consumed: emit the
+            // terminal event. Queued part ends were already drained above.
+            if *this.done_seen {
+                *this.done = true;
+                return Poll::Ready(Some(Ok(stream_complete_event(
+                    *this.last_finish_reason,
+                    this.usage.as_ref(),
+                ))));
             }
 
             // Need more data
@@ -120,6 +141,9 @@ where
                     // Continue to process buffer
                 }
                 Poll::Ready(Some(Err(e))) => {
+                    // Mark done so no event (including the terminal event) is
+                    // emitted after an error.
+                    *this.done = true;
                     return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
                 }
                 Poll::Ready(None) => {
@@ -135,13 +159,26 @@ where
                                 this.thinking_started,
                                 this.current_thinking_index,
                                 this.next_part_index,
-                                this.done,
+                                this.done_seen,
+                                this.last_finish_reason,
+                                this.usage,
                                 this.pending_part_ends,
                             ) {
                                 return Poll::Ready(Some(event));
                             }
                         }
                     }
+
+                    // A [DONE] in the final (newline-less) line still emits
+                    // the terminal event before the stream ends.
+                    if *this.done_seen {
+                        *this.done = true;
+                        return Poll::Ready(Some(Ok(stream_complete_event(
+                            *this.last_finish_reason,
+                            this.usage.as_ref(),
+                        ))));
+                    }
+
                     return Poll::Ready(None);
                 }
                 Poll::Pending => return Poll::Pending,
@@ -160,7 +197,9 @@ fn parse_sse_line(
     thinking_started: &mut bool,
     current_thinking_index: &mut Option<usize>,
     next_part_index: &mut usize,
-    done: &mut bool,
+    done_seen: &mut bool,
+    last_finish_reason: &mut Option<FinishReason>,
+    usage: &mut Option<Usage>,
     pending_part_ends: &mut Vec<usize>,
 ) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
     let line = line.trim();
@@ -174,13 +213,19 @@ fn parse_sse_line(
     if let Some(data) = line.strip_prefix("data: ") {
         // Check for stream end
         if data == "[DONE]" {
-            *done = true;
+            *done_seen = true;
             return None;
         }
 
         // Parse the JSON chunk
         match serde_json::from_str::<ChatCompletionChunk>(data) {
             Ok(chunk) => {
+                // Buffer usage for the terminal event; the usage chunk has
+                // empty choices and produces no part events.
+                if let Some(chunk_usage) = chunk.usage {
+                    *usage = Some(chunk_usage);
+                }
+
                 // Process each choice
                 for choice in chunk.choices {
                     let delta = choice.delta;
@@ -288,8 +333,11 @@ fn parse_sse_line(
                         }
                     }
 
-                    // Handle finish reason - emit part end events
-                    if choice.finish_reason.is_some() {
+                    // Handle finish reason - remember it for the terminal
+                    // event and emit part end events
+                    if let Some(reason) = choice.finish_reason.as_deref() {
+                        *last_finish_reason = Some(map_finish_reason(reason));
+
                         // Collect all part indices that need to be closed
                         let mut parts_to_close = Vec::new();
 
@@ -327,6 +375,47 @@ fn parse_sse_line(
     }
 
     None
+}
+
+/// Build the terminal event from the last seen finish reason and the buffered
+/// usage chunk; fields absent from the wire stay `None`.
+fn stream_complete_event(
+    finish_reason: Option<FinishReason>,
+    usage: Option<&Usage>,
+) -> ModelResponseStreamEvent {
+    let reason = finish_reason.unwrap_or(FinishReason::Stop);
+    let mut event = StreamCompleteEvent::new(reason);
+
+    if let Some(u) = usage {
+        event = event
+            .with_input_tokens(u.prompt_tokens)
+            .with_output_tokens(u.completion_tokens);
+        // The OpenAI wire format reports cached prompt tokens but has no
+        // cache-creation count, so cache_creation_tokens stays None.
+        if let Some(cached) = u
+            .prompt_tokens_details
+            .as_ref()
+            .and_then(|d| d.cached_tokens)
+        {
+            event = event.with_cache_read_tokens(cached);
+        }
+    }
+
+    ModelResponseStreamEvent::StreamComplete(event)
+}
+
+/// Map an OpenAI finish reason string to a [`FinishReason`].
+///
+/// Unknown reasons map to [`FinishReason::Stop`], matching the non-streaming
+/// response mapping.
+fn map_finish_reason(reason: &str) -> FinishReason {
+    match reason {
+        "stop" => FinishReason::Stop,
+        "length" => FinishReason::Length,
+        "content_filter" => FinishReason::ContentFilter,
+        "tool_calls" => FinishReason::ToolCall,
+        _ => FinishReason::Stop,
+    }
 }
 
 #[cfg(test)]
@@ -394,15 +483,88 @@ mod tests {
         }
     }
 
+    /// [DONE] without a usage chunk emits exactly one terminal event with the
+    /// default finish reason and all token fields None; nothing follows it.
     #[tokio::test]
     async fn test_parse_done() {
         let bytes = vec![Ok(Bytes::from("data: [DONE]\n\n"))];
         let stream = stream::iter(bytes);
         let mut parser = OpenAIStreamParser::new(stream);
 
-        // Should return None (stream ended)
-        let event = parser.next().await;
-        assert!(event.is_none());
+        let event = parser.next().await.unwrap().unwrap();
+        match event {
+            ModelResponseStreamEvent::StreamComplete(complete) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, None);
+                assert_eq!(complete.output_tokens, None);
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected StreamComplete, got {:?}", other),
+        }
+
+        // The terminal event is the final event of the stream.
+        assert!(parser.next().await.is_none());
+    }
+
+    /// EOF without [DONE] emits no terminal event (truncated streams stay
+    /// detectable by the agent loop).
+    #[tokio::test]
+    async fn test_eof_without_done_emits_no_terminal_event() {
+        let chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+        let bytes = vec![Ok(make_chunk_bytes(chunk))];
+        let stream = stream::iter(bytes);
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only the part event: {:?}",
+            events
+        );
+        assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
+    }
+
+    /// A transport error mid-stream ends the stream with the error and never
+    /// emits the terminal event afterwards.
+    #[tokio::test]
+    async fn stream_error_suppresses_terminal_event() {
+        // reqwest::Error has no public constructor; a refused connection to a
+        // closed loopback port is the cheapest real one to obtain.
+        let client = reqwest::Client::builder().no_proxy().build().unwrap();
+        let err = client
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .err()
+            .expect("connection to closed loopback port must fail");
+
+        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+        let bytes = vec![Ok(make_chunk_bytes(text_chunk)), Err(err)];
+        let stream = stream::iter(bytes);
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result);
+        }
+
+        assert_eq!(
+            events.len(),
+            2,
+            "expected only the part event and the error: {:?}",
+            events
+        );
+        assert!(matches!(
+            events[0],
+            Ok(ModelResponseStreamEvent::PartStart(_))
+        ));
+        assert!(events[1].is_err());
     }
 
     #[tokio::test]
@@ -412,9 +574,99 @@ mod tests {
         let stream = stream::iter(bytes);
         let mut parser = OpenAIStreamParser::new(stream);
 
-        // Should return None since no parts are open
+        // Should return None since no parts are open and no [DONE] arrived
         let event = parser.next().await;
         assert!(event.is_none());
+    }
+
+    /// The include_usage chunk is buffered and produces no part events; its
+    /// counts are carried on the terminal event at [DONE].
+    #[tokio::test]
+    async fn usage_chunk_then_done_populates_terminal_event() {
+        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+        let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
+
+        let bytes = vec![
+            Ok(make_chunk_bytes(text_chunk)),
+            Ok(make_chunk_bytes(finish_chunk)),
+            Ok(make_chunk_bytes(usage_chunk)),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let stream = stream::iter(bytes);
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        // The usage chunk is ignored for part events: only PartStart and
+        // PartEnd precede the terminal event.
+        assert_eq!(
+            events.len(),
+            3,
+            "expected PartStart, PartEnd, StreamComplete: {:?}",
+            events
+        );
+        assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
+        assert!(matches!(events[1], ModelResponseStreamEvent::PartEnd(_)));
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(10));
+                assert_eq!(complete.output_tokens, Some(5));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, Some(7));
+            }
+            other => panic!("expected terminal StreamComplete, got {:?}", other),
+        }
+    }
+
+    /// Finish reason strings map onto the terminal event; unknown reasons
+    /// default to Stop.
+    #[tokio::test]
+    async fn finish_reason_maps_onto_terminal_event() {
+        let cases = [
+            ("stop", FinishReason::Stop),
+            ("length", FinishReason::Length),
+            ("content_filter", FinishReason::ContentFilter),
+            ("tool_calls", FinishReason::ToolCall),
+            ("function_call", FinishReason::Stop),
+            ("unknown_reason", FinishReason::Stop),
+        ];
+
+        for (wire_reason, expected) in cases {
+            let finish_chunk = format!(
+                r#"{{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{{"index":0,"delta":{{}},"finish_reason":"{wire_reason}"}}]}}"#
+            );
+            let bytes = vec![
+                Ok(make_chunk_bytes(&finish_chunk)),
+                Ok(Bytes::from("data: [DONE]\n\n")),
+            ];
+            let stream = stream::iter(bytes);
+            let mut parser = OpenAIStreamParser::new(stream);
+
+            let mut terminals = 0;
+            let mut finish_reason = None;
+            while let Some(result) = parser.next().await {
+                if let ModelResponseStreamEvent::StreamComplete(complete) = result.unwrap() {
+                    terminals += 1;
+                    finish_reason = Some(complete.finish_reason);
+                }
+            }
+
+            assert_eq!(
+                terminals, 1,
+                "expected one terminal event for {wire_reason}"
+            );
+            assert_eq!(
+                finish_reason,
+                Some(expected),
+                "finish reason mapping for {wire_reason}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -441,7 +693,9 @@ mod tests {
     }
 
     /// Regression test: when finish_reason is received with multiple open parts
-    /// (text + tool calls), ALL PartEnd events must be emitted, not just the first.
+    /// (text + tool calls), ALL PartEnd events must be emitted, not just the
+    /// first. The terminal event follows the queued part ends and is emitted
+    /// exactly once, last.
     #[tokio::test]
     async fn test_multiple_part_ends_on_finish() {
         // Scenario: text part starts, then 2 tool calls start, then finish_reason
@@ -450,12 +704,15 @@ mod tests {
         let tool1_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{\"q\":\"test\"}"}}]}}]}"#;
         let tool2_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"lookup","arguments":"{\"id\":1}"}}]}}]}"#;
         let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
+        let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
 
         let bytes = vec![
             Ok(make_chunk_bytes(text_chunk)),
             Ok(make_chunk_bytes(tool1_chunk)),
             Ok(make_chunk_bytes(tool2_chunk)),
             Ok(make_chunk_bytes(finish_chunk)),
+            Ok(make_chunk_bytes(usage_chunk)),
+            Ok(Bytes::from("data: [DONE]\n\n")),
         ];
         let stream = stream::iter(bytes);
         let mut parser = OpenAIStreamParser::new(stream);
@@ -471,6 +728,7 @@ mod tests {
         // - 1 PartStart for tool call 1 (index 1)
         // - 1 PartStart for tool call 2 (index 2)
         // - 3 PartEnd events (for indices 0, 1, 2)
+        // - 1 StreamComplete terminal event
         let part_starts: Vec<_> = events
             .iter()
             .filter(|e| matches!(e, ModelResponseStreamEvent::PartStart(_)))
@@ -512,5 +770,28 @@ mod tests {
             vec![0, 1, 2],
             "All part indices should be closed"
         );
+
+        // Exactly one terminal event, carrying the buffered usage, emitted
+        // after every queued part end.
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+        assert!(
+            matches!(
+                events.last(),
+                Some(ModelResponseStreamEvent::StreamComplete(_))
+            ),
+            "terminal event must be emitted last, got {:?}",
+            events.last()
+        );
+        if let Some(ModelResponseStreamEvent::StreamComplete(complete)) = events.last() {
+            assert_eq!(complete.finish_reason, FinishReason::ToolCall);
+            assert_eq!(complete.input_tokens, Some(10));
+            assert_eq!(complete.output_tokens, Some(5));
+            assert_eq!(complete.cache_creation_tokens, None);
+            assert_eq!(complete.cache_read_tokens, Some(7));
+        }
     }
 }

--- a/serdes-ai-models/src/openrouter/model.rs
+++ b/serdes-ai-models/src/openrouter/model.rs
@@ -466,4 +466,50 @@ mod tests {
         );
         assert!(body.get("provider").is_some() && body.get("transforms").is_some());
     }
+
+    /// OpenRouter streams through `OpenAIStreamParser`, so its streams
+    /// inherit the terminal StreamComplete emission at [DONE] with the
+    /// buffered usage from its include_usage request.
+    #[tokio::test]
+    async fn openrouter_stream_inherits_terminal_stream_complete() {
+        use bytes::Bytes;
+        use futures::{stream, StreamExt};
+        use serdes_ai_core::messages::ModelResponseStreamEvent;
+
+        let content = r#"{"id":"gen-1","object":"chat.completion.chunk","created":1234567890,"model":"anthropic/claude-3-opus","choices":[{"index":0,"delta":{"content":"Hi"}}]}"#;
+        let finish = r#"{"id":"gen-1","object":"chat.completion.chunk","created":1234567890,"model":"anthropic/claude-3-opus","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+        let usage = r#"{"id":"gen-1","object":"chat.completion.chunk","created":1234567890,"model":"anthropic/claude-3-opus","choices":[],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}"#;
+
+        // request_stream wraps response.bytes_stream() in OpenAIStreamParser;
+        // feed it the SSE bytes OpenRouter returns for include_usage streams.
+        let bytes = vec![
+            Ok(Bytes::from(format!("data: {}\n\n", content))),
+            Ok(Bytes::from(format!("data: {}\n\n", finish))),
+            Ok(Bytes::from(format!("data: {}\n\n", usage))),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let mut parser = OpenAIStreamParser::new(stream::iter(bytes));
+
+        let mut events = Vec::new();
+        while let Some(result) = parser.next().await {
+            events.push(result.unwrap());
+        }
+
+        let terminals: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+            .collect();
+        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+
+        match events.last() {
+            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+                assert_eq!(complete.finish_reason, FinishReason::Stop);
+                assert_eq!(complete.input_tokens, Some(3));
+                assert_eq!(complete.output_tokens, Some(2));
+                assert_eq!(complete.cache_creation_tokens, None);
+                assert_eq!(complete.cache_read_tokens, None);
+            }
+            other => panic!("expected terminal StreamComplete last, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
Integration branch merging the five open feature PRs into a single verified `0.3.0` release.

## Merged PRs

| PR | Summary |
|---|---|
| #53 | Nix flake: fix `native-tls` builds, bump toolchain |
| #55 | Flexible `ReasoningEffort` (`Minimal`/`XHigh`/`Max`/`Custom`) for OpenAI |
| #52 | `with_header`/`with_appended_header` on `AnthropicModel` |
| #51 | Token usage on `AgentStreamEvent` + two run-loop fixes |
| #54 | All provider streams emit terminal `StreamComplete` with usage |

## Conflicts resolved

- **Version bump.** #51 bumped to `0.2.7`, #54 to `0.3.0`. Resolved to **0.3.0** — both are source-breaking, so the combined release is a minor bump. `Cargo.lock` was regenerated rather than hand-merged.
- **CHANGELOG.** #52's entry had landed in a stray `[Unreleased]` section at the bottom of the file, below `0.1.1`. All five PRs are consolidated into one `0.3.0` section at the top with an explicit **Breaking** subsection; the trailing block now holds only its "Planned" list.

## Fix beyond merging

Three clippy errors in test code introduced by #54 (`err_expect` ×2, `useless_concat`) — lints present in clippy 1.92 but not in the toolchain that ran on the original PR. Committed separately as `38646f9`.

## Semantic interactions verified

The merge was silent on these, so they were checked by hand:

- **#51 × #54 compose rather than collide.** The agent loop's `usage_from_stream_complete` consumes exactly the usage #54 now emits, so provider token counts flow through to the new `AgentStreamEvent` usage fields. #51's "clean stream end without `StreamComplete` is a success" fallback remains as the safety net for parsers that still don't emit one.
- **#55 × #54** both edited `openai/responses.rs` and git auto-merged it. The result was read directly: reasoning configuration and terminal-event emission occupy disjoint code paths.

## Breaking changes

- Streams now yield one extra event — code treating every event as content must skip `StreamComplete` (#54).
- `AgentStreamEvent` struct-variants gain `usage` fields, source-breaking for exhaustive matches without `..` (#51).
- Callers setting `reasoning_effort` on the OpenAI branch of `build_model_extended` previously got a chat model with the value silently dropped; they now get a Responses model with reasoning enabled (#55).

## Verification

Local, on the fully integrated tree: build OK, **1327 tests passed / 0 failed**, `clippy --all-targets --all-features -D warnings` clean, `fmt --check` clean.

Worth noting: #51 and #52 never ran CI (no checks reported on those fork branches), so this PR is the first CI run over the combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)