### PR TITLE
deps(cli): move rand to 0.10 and apply the remaining patch bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3012,9 +3012,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "open"
-version = "5.4.1"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9cfef937e9c486488c7e3d949ae31c0f1d06bdacd75b99c086cb35356e30408"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "is-wsl",
  "libc",
@@ -3172,7 +3172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -3304,15 +3304,6 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
 
 [[package]]
 name = "precomputed-hash"
@@ -3474,12 +3465,10 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
- "libc",
- "rand_chacha",
  "rand_core 0.6.4",
 ]
 
@@ -3495,23 +3484,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -4270,7 +4246,7 @@ dependencies = [
  "open",
  "portable-pty",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.10.2",
  "ratatui",
  "reedline",
  "regex",

--- a/serdes-ai-cli/Cargo.toml
+++ b/serdes-ai-cli/Cargo.toml
@@ -54,7 +54,7 @@ regex = "1.10"
 open = "5.0"
 url = "2.5"
 urlencoding = "2.1"
-rand = "0.8"
+rand = "0.10"
 base64 = "0.22"
 sha2 = "0.10"
 

--- a/serdes-ai-cli/src/oauth.rs
+++ b/serdes-ai-cli/src/oauth.rs
@@ -202,12 +202,9 @@ async fn exchange_code_for_token(
 
 /// Generate PKCE code verifier
 fn generate_code_verifier() -> String {
-    use rand::Rng;
-
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
-    let mut rng = rand::thread_rng();
     (0..128)
-        .map(|_| CHARSET[rng.gen_range(0..CHARSET.len())] as char)
+        .map(|_| CHARSET[rand::random_range(0..CHARSET.len())] as char)
         .collect()
 }
 
@@ -221,12 +218,9 @@ fn generate_code_challenge(verifier: &str) -> String {
 
 /// Generate random state parameter
 fn generate_state() -> String {
-    use rand::Rng;
-
     const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    let mut rng = rand::thread_rng();
     (0..32)
-        .map(|_| CHARSET[rng.gen_range(0..CHARSET.len())] as char)
+        .map(|_| CHARSET[rand::random_range(0..CHARSET.len())] as char)
         .collect()
 }
 


### PR DESCRIPTION
Supersedes #67 and #69, which conflict on the lockfile after #70 and which dependabot will not rebase.

## What changed

- **rand 0.8 to 0.10 in `serdes-ai-cli` (#67):** #67 failed CI because rand 0.10 dropped `thread_rng` and `Rng::gen_range`. The two PKCE helpers in `oauth.rs` now use the free function `rand::random_range`, matching what `serdes-ai-retries` already does on 0.10. The only rand 0.8 left in the lockfile is a transitive build dependency of `scraper` via `phf`.
- **open 5.4.3, once_cell 1.21.4 (#69):** the two bumps from that group that #70 had not already landed.

## Verification

Locally: `cargo fmt --check` clean, `cargo clippy --workspace --all-features -D warnings` clean, `cargo test --workspace --all-features` 1690 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LyK5xR9w87CFD4bvuEzPCB