### PR TITLE
fix: websocket connects send configured headers and enable TLS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5259,7 +5259,11 @@ checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.4",
  "tungstenite",
 ]
 
@@ -5525,6 +5529,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.10.2",
+ "rustls 0.23.36",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.20",
 ]

--- a/serdes-ai-streaming/Cargo.toml
+++ b/serdes-ai-streaming/Cargo.toml
@@ -13,7 +13,9 @@ readme = "README.md"
 
 [features]
 default = []
-websocket = ["dep:tokio-tungstenite"]
+# TLS is part of the websocket contract (wss://), not an optional extra:
+# without it the client compiles but rejects every wss URL at connect time.
+websocket = ["dep:tokio-tungstenite", "tokio-tungstenite/rustls-tls-native-roots"]
 
 [dependencies]
 serdes-ai-core = { workspace = true }

--- a/serdes-ai-streaming/src/websocket.rs
+++ b/serdes-ai-streaming/src/websocket.rs
@@ -115,6 +115,27 @@ impl From<WsMessage> for WsStreamMessage {
     }
 }
 
+/// Build the handshake request from the URL, then apply configured headers.
+fn build_request(
+    config: &WebSocketConfig,
+) -> StreamResult<tokio_tungstenite::tungstenite::http::Request<()>> {
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    let mut request = config
+        .url
+        .as_str()
+        .into_client_request()
+        .map_err(|e| StreamError::Connection(format!("invalid websocket url: {e}")))?;
+    for (name, value) in &config.headers {
+        let name = tokio_tungstenite::tungstenite::http::HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| StreamError::Connection(format!("invalid header name '{name}': {e}")))?;
+        let value = tokio_tungstenite::tungstenite::http::HeaderValue::from_str(value)
+            .map_err(|e| StreamError::Connection(format!("invalid header value: {e}")))?;
+        request.headers_mut().insert(name, value);
+    }
+    Ok(request)
+}
+
 /// WebSocket stream wrapper for LLM streaming.
 pub struct WebSocketStream {
     inner: TungsteniteStream<MaybeTlsStream<TcpStream>>,
@@ -123,9 +144,21 @@ pub struct WebSocketStream {
 
 impl WebSocketStream {
     /// Connect to a WebSocket endpoint.
+    ///
+    /// Configured headers (e.g. `Authorization` from
+    /// [`WebSocketConfig::with_auth`]) are applied to the handshake request,
+    /// and the connection attempt is bounded by the configured timeout.
     pub async fn connect(config: WebSocketConfig) -> StreamResult<Self> {
-        let (ws_stream, _) = connect_async(&config.url)
+        let request = build_request(&config)?;
+        let timeout = std::time::Duration::from_secs(config.timeout);
+        let (ws_stream, _) = tokio::time::timeout(timeout, connect_async(request))
             .await
+            .map_err(|_| {
+                StreamError::Connection(format!(
+                    "websocket connect timed out after {}s",
+                    config.timeout
+                ))
+            })?
             .map_err(|e| StreamError::Connection(e.to_string()))?;
 
         Ok(Self {
@@ -294,6 +327,26 @@ mod tests {
         assert_eq!(config.timeout, 60);
         assert_eq!(config.ping_interval, Some(15));
         assert!(config.headers.iter().any(|(k, _)| k == "Authorization"));
+    }
+
+    #[test]
+    fn configured_headers_reach_handshake_request() {
+        let config = WebSocketConfig::new("wss://example.com/stream")
+            .with_auth("token123")
+            .with_header("OpenAI-Beta", "responses=experimental");
+
+        let request = build_request(&config).expect("request builds");
+        let headers = request.headers();
+        assert_eq!(
+            headers.get("Authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer token123")
+        );
+        assert_eq!(
+            headers.get("OpenAI-Beta").and_then(|v| v.to_str().ok()),
+            Some("responses=experimental")
+        );
+        // tungstenite fills in the websocket handshake headers from the URL.
+        assert!(headers.get("host").is_some());
     }
 
     #[test]


### PR DESCRIPTION
Split from #66 per the review there: the `serdes-ai-streaming` fixes are independently mergeable, so they ride alone here.

## What and why

- **Configured headers never reached the wire.** `WebSocketStream::connect` accepted `with_auth`/`with_header` configuration but dropped it when building the HTTP upgrade request, so authenticated endpoints (bearer tokens, `originator`, account headers) silently connected unauthenticated. Headers now go out on the upgrade request.
- **The handshake had no bound.** `connect` could hang past the configured timeout; it now honors it.
- **`wss://` failed at connect time.** The `websocket` feature did not compile TLS in, so every `wss://` URL died with `TLS support not compiled in`. The feature now pulls rustls with native roots, matching what the workspace's `reqwest` already links.

Applied on top of main's tokio-tungstenite 0.21 → 0.30 bump (#70); the three-way merge was clean and both intents are preserved.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy -p serdes-ai-streaming --all-features --all-targets -- -D warnings` clean
- `cargo test -p serdes-ai-streaming --all-features`: 63 passed / 0 failed, including `websocket::tests::configured_headers_reach_handshake_request`
- `cargo check -p serdes-ai --features full` passes; the changes are additive and break no workspace consumer

Fixes the transport layer that #66's codex WebSocket client depends on; the client consolidation described in that review follows separately.