### PR TITLE
feat: add reliable streaming with checkpoints, native Responses SSE, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,103 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Typed streaming and execution parity
+- Align nonstreaming cooperative cancellation with bounded awaited checkpoint
+  saves; terminal success wins, failed saves do not recursively persist, and
+  pending cancellation stops model/tool work after nonterminal saves.
+- Preserve supported Responses multi-content native replay grouping through
+  streaming, nonstreaming and serde without duplicate native message IDs.
+- Reject malformed mixed final-output calls without dispatching ordinary tools;
+  retain paired retry history in both execution paths.
+- Add Agent::run_stream_typed and TypedAgentStream::finish/take_output to recover
+  validator-transformed Output after terminal checkpoint success, without changing
+  existing event streams. Partial token/filter outcomes have no typed output.
+- Honor streaming parallel-tool settings with bounded, ordered results and retries.
+- Correct explicit output-tool mixed-call Early/Exhaustive decisions in streaming
+  and nonstreaming; acknowledge skipped calls without executing early side effects.
+- Support interleaved Responses message content slots; retain/check indexed
+  reasoning summaries and native content metadata. See PR_NOTES for snapshot-only
+  metadata and explicit cooperative-cancellation/replay guarantees.
+
+### Responses terminal metadata
+- Add serde-default StreamCompleteEvent.metadata and TerminalMetadata, mapped to
+  existing response vendor fields; add terminal handlers to streaming accumulators.
+- Preserve bounded native output records and detailed usage without automatic opaque
+  item replay. Refusal maps to ContentFilter. Unsupported indexed stream content
+  fails explicitly instead of concatenating slots incorrectly.
+- Add optional Agent RunUsage.token_totals_complete. StreamCompleteEvent/RunUsage
+  struct literals require new fields; old serde data remains readable.
+- Redact ModelResponse Debug. See latest PR_NOTES for incomplete scope and limits.
+
+### Streaming lifetime and validation
+- Unify both streaming constructors; cancellation/consumer closure now covers
+  the whole worker lifetime, including final delivery, tools and summaries.
+- Add ConsumerDetached and ValidationFailed checkpoint boundaries. Committed
+  successful terminal checkpoints win over later consumer disappearance.
+- Run configured schema parsing, async output validators and dynamic prompts in
+  streaming; validation exhaustion errors instead of signaling valid output.
+- Add explicit SummarizeOrTruncate strategy; Summarize stops on summary failure.
+  Summary requests are bounded and their usage counts toward run limits.
+- Enum additions require exhaustive-match updates. AgentStream stays type-erased;
+  parallel tools and complete mixed-output parity remain unresolved (PR_NOTES).
+
+### Native Responses SSE and checkpoint hardening
+- Replace Responses streaming JSON fallback with true incremental SSE transport;
+  preserve reasoning/function items and reject premature EOF/provider failures.
+- Map incomplete_details max_output_tokens to Length and content_filter separately;
+  skip tool dispatch for both partial terminal reasons in streaming agents.
+- Add optional CheckpointSink partial_interval and save_timeout, Partial boundary,
+  cancellation-aware policy/event delivery, and additional failure snapshots.
+- Re-export lifecycle APIs through the serdes-ai facade; redact ThinkingPartDelta
+  Debug. ResponsesApiResponse gains incomplete_details (struct-literal breaking).
+- See the latest PR_NOTES section for exact supported events and remaining gaps.
+
+### Agent lifecycle and context hooks
+- Add awaited application `CheckpointSink` and versioned, serializable
+  `AgentCheckpoint` at request/response/tool-batch/terminal boundaries, including
+  partial streaming cancellation/provider failures. Snapshot Debug is redacted.
+- Apply configured history processors before every primary request in streaming
+  and non-streaming runs and update canonical active history. Custom policy /
+  processors disable legacy streaming automatic compression.
+- Add fallible async `ContextPolicy`, actual model/settings/tools context, and
+  explicit `ContextFailurePolicy` (Stop by default, KeepHistory opt-in).
+- Select cancellation during streaming request establishment and pending tools;
+  non-streaming cancellation now covers the whole step. No automatic side-effect
+  replay or exactly-once guarantee is introduced.
+- New AgentRunError ContextPolicy/Checkpoint variants require exhaustive matches
+  to be updated. Existing history_processor API remains source-compatible.
+- See PR_NOTES.md for precise boundary guarantees and remaining cancellation,
+  provider, archive-retention and resumability gaps.
+
+### Fixed
+- OpenAI Chat SSE rejects premature EOF with `IncompleteStream`, rejects malformed
+  frames and structured provider errors, preserves split UTF-8 and all deltas in a
+  frame, closes thinking/tool/text parts deterministically, and emits completion
+  once. Usage-only frames are retained; absent usage remains absent.
+- Native Chat token limits select `max_completion_tokens` for reasoning profiles,
+  o4 and GPT-5 names. `stream_usage` is honored instead of forced on.
+- Both streaming agent loops stop on `Length` without dispatching truncated tools
+  or reissuing the request. Interrupted native Chat tools never reach dispatch.
+- Buffered Responses rejects cancelled/in-progress statuses, rejects malformed
+  function arguments rather than substituting `{}`, and replays native reasoning
+  and function items in order. Empty-summary encrypted reasoning is retained.
+- Thinking and Responses item Debug output redacts reasoning payloads.
+
+### Added
+- `OpenAIChatModel::with_max_completion_tokens(bool)` overrides cap-key selection
+  for aliases; `with_finish_reason_terminal(bool)` explicitly permits compatible
+  endpoints that finish at clean EOF without `[DONE]` (default remains strict).
+
+### Compatibility
+- Stricter Chat error behavior affects adapters sharing `OpenAIStreamParser`.
+- New public `ResponseInput::Item` variant, `ResponsesApiRequest::include` field,
+  and `ResponseOutputItem::Reasoning::encrypted_content` field require downstream
+  exhaustive matches/struct literals to be updated. These are source-breaking.
+- Responses is still a buffered HTTP fallback, not native SSE. See PR_NOTES.md
+  for coverage and remaining work. Nothing in this section is published yet.
+
 ## [0.3.0] - 2026-08-24
 
 Combined release integrating PRs #51, #52, #53, #54 and #55. Streaming is now a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,6 +4224,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/PR_NOTES.md
+++ b/PR_NOTES.md
@@ -1,0 +1,547 @@
+# Reliability branch: authoritative current status
+
+Owner: planning-agent-a12d28. Worktree: /Users/gabe/repos/fedstew/serdesAI.
+Branch: feat/reliable-streaming-and-checkpoints. HEAD/base:
+d0aae194fc6a8bf98bd9c1f6206099af4c126046. All work remains uncommitted;
+prior dirty/untracked changes retained. No delegation, commits, publication,
+real-provider calls, or application changes.
+
+## Typed validated streaming output
+
+Agent::run_stream_typed(prompt, deps, RunOptions) returns TypedAgentStream<Output>.
+It yields the same AgentStreamEvent values as the backward-compatible AgentStream.
+Use finish().await to drain with backpressure and recover Result<Option<Output>,
+AgentRunError>, or take_output() after completion to retrieve the value once.
+The value is the actual schema/validator-transformed Output, not reparsed raw text.
+No Clone/Serialize bound is added to Output. Values are published after terminal
+checkpoint success; Length/ContentFilter partials return None, not validated output.
+The facade reexports TypedAgentStream. Existing stream APIs remain source-compatible.
+
+## Tool execution and output decisions
+
+Streaming batches honor parallel_tool_calls and max_concurrent_tools; buffered
+ordered futures bound concurrency and retain result order. Zero concurrency is
+clamped to one in streaming and nonstreaming, avoiding a deadlock. Tool retries
+obey per-tool limits and use the run's context/call IDs. Dropping a batch drops
+in-flight futures, but external effects remain potentially committed/unknown.
+AfterResponse is awaited before dispatch and AfterTools after complete batches.
+
+An explicit native output-tool plus ordinary tools is now handled in BOTH run.rs
+and streaming: validate final output first; Early skips ordinary side effects;
+Exhaustive executes them then finishes with the validated output. Skipped/output
+calls receive protocol acknowledgements. Validation rejection does not execute
+ordinary tools and retries with protocol-associated results. Plain explanatory
+text plus ordinary tools retains existing tool-first behavior. This is an
+intentional semantic correction for explicit output tools, not blanket text-first
+execution. Error/retry text and some history acknowledgement strings still differ
+between paths; complete byte-for-byte history parity is not claimed.
+
+## Native Responses indexed output and metadata
+
+Message content slots map to distinct native text parts. Slots must be declared
+contiguously (0..N); deltas can interleave afterward without scrambling array order.
+A real localhost HTTP fixture emits slot 1 before slot 0's text and verifies the
+accumulated first/second parts. Slot count is bounded to 1025 per item. Unsupported
+message content types fail explicitly; opaque top-level built-in/image output
+records are archival only and never authorize application tools/replay.
+
+Reasoning slot deltas are retained per summary_index and checked against the
+ordered item snapshot. Slot zero streams immediately; later slots are buffered
+until the snapshot to avoid corrupting the single encrypted reasoning block.
+The exact summary array/encrypted content remains in native metadata. Annotation
+and refusal slot metadata are emitted from item snapshots; individual annotation/
+refusal delta events are not yet exposed incrementally. Repeated completed item
+snapshots do not append duplicate text/signature metadata.
+
+Optional StreamCompleteEvent.metadata carries response_id, actual model, status,
+created_at/service_tier/incomplete_details, native usage and ordered output_records.
+It flows to ModelResponse vendor fields and Agent checkpoints. Both accumulator
+helpers offer handle_stream_complete; callers using get_parts alone must adopt the
+terminal handler/get_response API to preserve response-level metadata. Retained
+item/terminal metadata rejects >2 MiB. RequestUsage retains detailed usage; agent
+RunUsage.token_totals_complete distinguishes complete counts from lower bounds.
+Empty output retains IDs even if output validation subsequently rejects it.
+TerminalMetadata, ModelResponse and text/thinking delta Debug are redacted.
+
+## Lifecycle semantics
+
+Both stream constructors use one worker supervisor observing explicit cancellation
+and receiver closure through model setup, idle reads, policies, summary calls,
+validators, tools and channel sends. Successful terminal checkpoint wins over
+later detach/cancel. Sink rejection/timeout is never recursively saved. A new
+synchronized test cancels during an in-progress BeforeRequest save, releases it,
+and verifies no model call and exactly one Cancelled checkpoint afterward.
+Earlier detach/request/summary/tool/full-channel/deadline tests remain green.
+
+No async Drop persistence task is launched. Runtime shutdown, panic/forced abort
+and blocking callbacks cannot guarantee awaited persistence. External effects
+cannot be rolled back. Nonstreaming steps now use a task-local save scope: cancellation outside a save
+cancels work promptly; cancellation during a save awaits its configured timeout.
+A completed nonterminal save checks cancellation before model/tool work proceeds.
+Successful terminal save wins; rejection/timeout returns Checkpoint error without
+recursive persistence. Completed/failed runs cannot write another terminal outcome
+on repeated step(). Direct future drop/task abort remains outside cooperative
+cancellation guarantees. Deterministic tests cover both BeforeRequest and Terminal
+saves with cancellation plus success, rejection, and timeout (six cases).
+
+## Validation on latest code
+
+- cargo test --workspace: 1525 passed, 0 failed, 106 ignored.
+- cargo check --workspace: passed.
+- cargo check -p serdes-ai-models --no-default-features --features
+  openai,anthropic,azure,groq,openrouter: passed.
+- cargo fmt --all -- --check and git diff --check: passed.
+
+New paired real-Agent fixtures: transformed typed output vs run(), mixed explicit
+output-tool Early/Exhaustive side effects, bounded concurrency at 1 and 2.
+Native HTTP Agent fixtures: empty-output ID, actual provider model, refusal,
+encrypted reasoning, detailed metadata and checkpoint serde roundtrip. Native
+chunked HTTP fixture: interleaved message slots retain semantic part order.
+Existing native provider interruption, usage and replay regressions remain green.
+No all-features/AWS, live API, app opt-in or adapter-retirement claim.
+
+## Remaining concrete limitations
+
+- No incremental later-summary-slot rendering or annotation/refusal delta API;
+  exact data arrives at item/terminal snapshots. Cross-item content declarations
+  that arrive out of semantic order are not fully supported.
+- Supported Responses message/text/refusal and reasoning records now replay from
+  one shared whitelist conversion over ordered native metadata, preserving content
+  arrays and one message ID per original item. A localhost test proves exact
+  stream/nonstream/serde request equality. Function replay requires a corresponding
+  canonical typed call; opaque built-in/image/audio records are never replayed.
+  Callers editing response parts must also discard stale vendor_details before
+  replay; native metadata is authoritative for passive content grouping.
+- No exhaustive provider/retry/history-order parity suite beyond
+  the new explicit fixtures; not every public EndStrategy/error case is proven.
+- Cross-item descending declarations fail with typed InvalidResponse, preserving
+  already emitted partials and emitting no completion or new callable part.
+- Malformed mixed output-tool retry tests prove both paths retain preceding calls,
+  matching result IDs/order, and execute no ordinary side effect before correction.
+- No automatic resume, transaction journal or exactly-once side-effect guarantee.
+- Images/audio are opaque archival records, not decoded/rendered generated output.
+
+Source-breaking additions from the branch: StreamCompleteEvent.metadata and
+RunUsage.token_totals_complete struct fields; lifecycle/compression enum variants.
+Serde defaults accept old serialized data. See CHANGELOG for preceding additions.
+New typed API is additive. No dependency/app patch was applied; test an app only
+in a disposable worktree with compatible local Cargo patch versions.
+
+---
+# Historical implementation notes (not the current contract)
+
+# Current status: unified streaming lifetime and real output validation
+
+Owner: planning-agent-a12d28. Implementation: code-puppy-6b924b.
+Worktree /Users/gabe/repos/fedstew/serdesAI; branch
+feat/reliable-streaming-and-checkpoints; base/HEAD
+ d0aae194fc6a8bf98bd9c1f6206099af4c126046.
+Earlier dirty/untracked work was retained. No commits, fetch, delegation, pushes,
+publication, live providers, or application/dependency edits in this pass.
+
+## Implemented in this pass
+
+Both streaming constructors now use ONE worker loop. stream_lifecycle.rs observes
+receiver closure and cancellation across the entire worker future, not just sends.
+This includes RunStart, final delivery, request setup, idle streams, tools, custom
+policies, dynamic prompts, validators and legacy summaries. Before work starts the
+supervisor retains initial history/prompt. During streaming it retains native
+parts/metadata before downstream delivery. ConsumerDetached and ValidationFailed
+are new CheckpointBoundary variants (exhaustive-match source breaking).
+
+A successful Terminal checkpoint wins over later cancellation/detachment. Before
+that commit, detach records ConsumerDetached; explicit cancellation records
+Cancelled. If both signals are ready on the same poll, detach wins. Final error
+notification is best effort and never waits for channel space. Returned worker
+failure without another terminal snapshot gets a Failed checkpoint. Already
+recorded terminal boundaries and sink failures suppress another save attempt.
+
+An in-progress sink save is polled through its configured deadline before the
+worker is dropped. A successful save cannot advance to another side effect while
+interruption finalization is pending. Sink rejection/deadline is never recursively
+saved. There is no async Drop or detached persistence task. Runtime shutdown,
+process termination, panic, external task abort and blocking user callbacks cannot
+guarantee an awaited checkpoint; synchronous RAII cleanup is the only guarantee
+available when futures are dropped. External side effects cannot be undone.
+
+Legacy summary calls have a deadline (model_settings.timeout, or 30 seconds).
+Successful summary usage is folded once into aggregate usage; failed requests
+count as requests without inventing tokens. Limits are rechecked before the main
+request. Summarize now stops on failed/empty summaries. Use the new explicit
+SummarizeOrTruncate compatibility strategy to allow fallback. Existing small-
+history/nothing-to-compress paths retain their legacy behavior. CompressionStrategy
+has a new source-breaking enum variant; ContextCompression literals are unchanged.
+
+Streaming now invokes the configured OutputSchema and async OutputValidator chain
+with shared deps, run ID, settings, metadata and retry count. Dynamic prompts and
+instructions run once per run and survive validation retries. Parsing/validation
+failures retain rejected native responses, add retry protocol messages, and obey
+max_output_retries. Exhaustion records ValidationFailed and cannot emit OutputReady
+or RunComplete. Retry prompts deliberately use generic redacted diagnostics.
+Output-tool calls are parsed as output, not dispatched as application tools.
+Ordinary tools retain priority over accompanying output, matching current run.rs.
+Tool contexts now preserve run identity and retryable tool errors obey max_retries.
+AfterResponse checkpoints include current response usage. Length/content-filter
+partials still complete as partial runs but no longer emit OutputReady.
+
+## Important remaining gaps — not full parity / not adapter retirement ready
+
+- AgentStream remains type-erased: validators actually execute, but transformed
+  typed output is not exposed by OutputReady. Use non-streaming run for the typed
+  result. A generic stream result API remains future work.
+- Streaming tools remain sequential; parallel_tool_calls/max_concurrent_tools
+  parity is NOT implemented in this pass. Mixed output-tool plus ordinary-tool
+  responses still need protocol acknowledgement/parity fixtures. EndStrategy
+  follows ordinary-tool priority but exhaustive multi-output behavior is not
+  comprehensively verified against run.rs. These are unresolved, not claimed done.
+- Partial Length/ContentFilter terminal runs bypass output validation by design;
+  RunComplete means the partial run ended, not a validated typed output. Consumers
+  must use OutputReady to distinguish validated completion.
+- No exact-once external execution, automatic restore, panic-safe async journal,
+  or durability guarantee beyond the app's sink. The full requested cancellation
+  matrix (including every sink race and structured tool retry combination) is not
+  complete; see actual tests rather than assuming blanket coverage.
+- Richer Responses output metadata is intentionally left to the next pass.
+- Existing mock/third-party stream EOF compatibility and response retention
+  limitations remain. The native OpenAI parsers enforce their own strict EOF.
+
+## Validation (latest source)
+
+cargo test --workspace: 1512 passed, 0 failed, 106 ignored.
+cargo check --workspace: passed.
+cargo check -p serdes-ai-models --no-default-features --features
+openai,anthropic,azure,groq,openrouter: passed.
+cargo fmt --all -- --check and git diff --check: passed.
+No all-features/AWS or real-provider execution claimed.
+
+New stream_parity integration tests exercise actual AgentStream constructors:
+async validator retry + dynamic prompt/deps, structured schema exhaustion,
+pre-start detach, idle partial detach, terminal winner, pending request and legacy
+summary cleanup, and pending async tool cleanup without another request. A focused
+supervisor test fills a one-slot final channel then cancels after terminal commit.
+Earlier checkpoint interval/sink timeout/full-channel tests remain green.
+
+Changed modules: agent.rs/builder.rs share schema, validator and prompt objects via
+Arc internally without changing builder call signatures; stream.rs removes the
+duplicate implementation; stream_lifecycle.rs and stream_output.rs isolate new
+behavior; lifecycle.rs/run.rs add documented enum semantics. Tests are in
+serdes-ai-agent/tests/stream_parity.rs. The large preexisting stream.rs was reduced
+substantially rather than mechanically split; new helper files are below 600 lines.
+
+---
+# Historical notes below (superseded wherever they conflict with current status)
+
+# Latest status: native Responses SSE and lifecycle hardening
+
+This section supersedes earlier chronological pass notes below. All changes are
+local/uncommitted on feat/reliable-streaming-and-checkpoints at the original
+worktree/base. No app checkout or dependencies changed.
+
+## Native Responses now streams
+
+`openai/responses_stream.rs` incrementally parses the actual HTTP bytes_stream;
+`request_stream` sends stream:true and never calls the buffered request method.
+SSE records support CRLF, multiline data and arbitrary UTF-8 byte boundaries.
+Text, reasoning summary and function-argument deltas emit immediately. Native
+reasoning items retain IDs, summary arrays and encrypted_content, including empty
+summaries. IDs are preserved in part provider_details (response_id/item_id).
+Item order is checked; function JSON is validated before completed success.
+
+Terminal response.completed is required for safe function dispatch; incomplete
+max_output_tokens maps to Length, content_filter maps separately; unknown reasons
+fail closed. response.failed/error and response.cancelled are errors, EOF before a
+terminal record is IncompleteStream. No error is followed by a success terminal.
+Both Agent streaming loops skip tools for Length and ContentFilter. Non-streaming
+request remains JSON HTTP; incomplete_details now uses the same explicit reasons.
+
+Scope: text/reasoning/function-call Responses events, not complete audio/image or
+built-in-tool telemetry. Multiple text content slots are concatenated in their
+arrival order within each native item. Unknown telemetry events are ignored;
+unknown terminal incomplete reasons fail. No raw SSE is logged. Thinking delta
+Debug now redacts signatures/content. There is a 16 MiB pending-record cap, not a
+whole-response memory cap. Terminal-only responses are accepted; this is distinct
+from buffering the HTTP transport. Response IDs are in part metadata, not a new
+StreamComplete field; empty-output response IDs are not surfaced yet. Detailed
+reasoning-token counters beyond standard usage fields are not exposed by the
+existing terminal event type.
+
+## Lifecycle additions
+
+CheckpointSink now has default methods partial_interval() (None by default) and
+save_timeout() (30 seconds). Apps can request 300ms Partial snapshots while a
+stream is active or idle. Intervals clamp to >=10ms and missed ticks delay rather
+than burst. Save is awaited with backpressure, not a background unbounded queue.
+The framework does not claim the application sink is disk-durable.
+
+Save timeout stops the run without retry or further tool/model calls. A timeout
+may leave an application write committed: reconcile before resume. Streaming
+cancellation does not preempt save, so latency is bounded by save_timeout for
+cooperative async implementations. Blocking synchronous sink work cannot be
+preempted by Tokio. Non-streaming whole-step cancellation may still preempt save.
+
+Cancellable streaming now selects cancellation during custom policy preparation
+and ordinary blocked event sends. Current native partial state is captured before
+awaiting consumer delivery. Cancellation/error notification uses try_send where
+needed: a saturated/dropped consumer may not receive that notification, but the
+awaited checkpoint remains authoritative. Failure checkpoints added for context
+policy errors, usage-limit exits and empty response EOF; sink failure never
+recursively checkpoints. Before-tool cancellation now also checkpoints.
+
+Residual lifecycle gaps: legacy automatic summarization is not cancellation-
+selected; RunStart/final RunComplete delivery still uses legacy channel behavior;
+receiver-drop exits are not universally journaled; no transactional tool journal,
+exactly-once replay or automatic resume; streaming output-validator/dynamic-prompt
+parity is still incomplete. Normal tool errors remain model-visible retry results,
+not terminal run failure. Non-streaming response archive retention remains legacy.
+No claim is made that every possible early exit has a terminal snapshot yet.
+
+Facade exports are available at serdes_ai::{AgentCheckpoint, CheckpointBoundary,
+CheckpointSink, ContextPolicy, ContextPolicyInput, ContextFailurePolicy}, as well
+as serdes_ai::agent module. Existing durability_hook example still compiles.
+
+## New regression coverage
+
+- models/tests/responses_sse.rs: actual localhost HTTP/1.1 chunked SSE with
+  one-byte chunks, completed/length/content-filter, EOF/malformed/failed/cancelled,
+  encrypted empty-summary reasoning and fragmented function arguments.
+- agent/tests/responses_native_agent.rs: actual native Responses Agent only
+  dispatches tools after completed; EOF never dispatches.
+- agent/tests/checkpoint_interval.rs: idle partial snapshots, full-channel
+  cancellation, pending policy cancellation, sink deadline without recursive save
+  or model calls.
+- Existing JSON reasoning replay and provider/lifecycle safety suites retained;
+  former buffered stream fixtures now serve SSE terminal records.
+
+Commands: cargo test --workspace; cargo check --workspace; cargo fmt --all --
+--check; cargo check -p serdes-ai-models --no-default-features --features
+openai,anthropic,azure,groq,openrouter; cargo run -p serdes-ai-agent --example
+durability_hook. No all-features/AWS or live-provider claims.
+
+## Testing the application without changing its checkout
+
+Not attempted this pass. Use a disposable app copy/worktree, then add temporary
+[patch.crates-io] paths for every participating serdes-ai crate from this workspace.
+The app's exact 0.2.6 requirements must also be adjusted in that disposable copy
+to compatible 0.3.0 requirements: Cargo patches cannot override incompatible
+version constraints. Inspect cargo tree for duplicate framework versions before
+running native_provider_gate. Those tests characterize published defects and
+need positive expectation updates for the branch. Delete the disposable copy
+when done; do not edit the real app manifest/lockfile. Adapter removal still
+requires application-level verification and resolution of the limits above.
+
+---
+
+# Native provider reliability: local review notes
+
+Owner: planning-agent-a12d28. Implementation: code-puppy-87bdd6.
+
+## Checkout
+
+- Worktree: `/Users/gabe/repos/fedstew/serdesAI` (original worktree).
+- Branch: `feat/reliable-streaming-and-checkpoints`.
+- Base: `d0aae194fc6a8bf98bd9c1f6206099af4c126046`; local `main` and
+  `origin/main` agreed. Initial checkout was clean; no repository/ancestor
+  AGENTS.md was found. No fetch, stash, reset, commits, pushes or publishing.
+- Workspace version is 0.3.0. These are **uncommitted, unpublished** changes.
+
+## Implemented contracts
+
+Chat defaults to `[DONE]` as transport completion, not EOF. A finish frame
+preserves `Length`/other existing typed reasons but does not bypass trailing
+usage reception. Compatible endpoints may explicitly opt into finish-frame plus
+clean EOF with `with_finish_reason_terminal(true)`. Transport errors remain
+errors even with that option. Errors never produce a later success terminal.
+Dropping a stream releases its inner HTTP stream; it does not fabricate a
+cancellation/success event after the consumer has gone away.
+
+The parser buffers bytes through UTF-8 boundaries, queues all events from one
+frame, handles no-space `data:` and CRLF, closes parts in index order, and does
+not concatenate alternative choices into one response. Malformed JSON/schema
+frames fail without logging raw payloads. Unknown Chat finish strings retain the
+existing Stop mapping. SSE multiline-data records and resource-size limits are
+not implemented in this pass.
+
+Usage-only frames populate the terminal event; missing usage remains None.
+Request/aggregate usage code already existed locally and was not redesigned.
+Aggregate completeness across mixed known/unknown requests is still a follow-up.
+The request's stream_usage flag is now honored, including false.
+
+Chat cap selection uses the model profile plus o4/GPT-5 names; explicit true/false
+builder override handles deployment aliases and legacy-compatible servers.
+Tools, output schema, custom clients, URLs and headers retain existing plumbing.
+
+Responses **still uses its buffered HTTP request fallback**. It now rejects
+cancelled and in-progress results, preserves reasoning IDs, exact summary item
+boundaries and encrypted_content (in ThinkingPart.signature), and emits native
+reasoning/function-call/function-call-output replay items. It requests
+reasoning.encrypted_content. Thinking and raw Responses items redact Debug
+payloads. No invented Chat signature fields were introduced. Anthropic already
+has native signature deltas and truncation checks; its existing suite passed.
+Unknown reasoning fields are not yet retained.
+
+Both agent stream loops treat Length as terminal partial output and skip tools
+on that response. Native parser errors short-circuit before tool execution;
+localhost Agent tests verify both interrupted tools and token-limit partial tools.
+The agent's legacy clean-EOF fallback for other/mock models remains unchanged.
+
+## API compatibility
+
+Additive model builders are source-compatible. Error behavior is intentionally
+stricter. The public ResponseInput enum gains Item; ResponsesApiRequest gains
+include; ResponseOutputItem::Reasoning gains encrypted_content. Exhaustive
+matches and literals may require edits (source-breaking). Debug formatting is
+intentionally changed. A shared Chat parser means inherited OpenAI-compatible
+adapters also get strict EOF behavior; wrapper-specific opt-in forwarding is not
+added here. Review release/version policy before merging.
+
+The Chat parser's existing tests moved to stream_tests.rs; both files are under
+600 lines. Existing large response/core/agent files were kept cohesive rather
+than split by arbitrary line count.
+
+## Reproducible validation (no provider credentials)
+
+Passed locally:
+
+```sh
+cargo fmt --all -- --check
+cargo check --workspace --offline
+cargo check -p serdes-ai-models --no-default-features --offline
+cargo check -p serdes-ai-models --no-default-features --features openai,anthropic,azure,groq,openrouter --offline
+cargo test -p serdes-ai-models --no-default-features --features openai,anthropic
+cargo test -p serdes-ai-core -p serdes-ai-streaming -p serdes-ai-agent
+cargo test -p serdes-ai-models -p serdes-ai-agent --tests
+cargo test -p serdes-ai-agent --test native_stream_interruption
+```
+
+No-feature check has an existing unused-import warning in models/lib.rs.
+New integration files exercise actual localhost native models, cap request keys,
+usage-only frames, malformed/provider errors, EOF, native encrypted replay,
+cancelled Responses and agent dispatch safety. Parser-level tests exercise every
+byte split and drop cancellation; they are not a real socket cancellation test.
+
+```sh
+cargo test --workspace --offline
+```
+
+Blocked before execution by uncached `anes v0.1.6`; no network dependency download
+was attempted for this command. Full all-features/AWS matrix was not run.
+
+## Remaining before retiring the app adapter
+
+1. Implement actual Responses SSE with response.completed/incomplete/failed
+   terminal handling, preserving emitted partials and usage/metadata.
+2. Complete Responses incomplete_details mapping (currently every incomplete
+   response maps to Length), and preserve partial tool arguments without inventing
+   valid arguments on buffered incomplete responses.
+3. Add new Anthropic native HTTP signature replay coverage, unknown metadata
+   preservation policy, and full aggregate-usage completeness tracking.
+4. Native socket cancellation and cancellable-agent integration coverage;
+   current drop test covers parser lifetime only.
+5. Agent lifecycle hooks/checkpoints, resumability and remaining non-Chat provider
+   EOF contracts. No app SQLite/UI or production changes belong in this PR.
+
+This is a meaningful Chat repair and buffered Responses metadata improvement,
+not completion of the entire reliability/checkpoint roadmap.
+
+## Agent lifecycle pass (same branch, still uncommitted)
+
+Public APIs added in `serdes-ai-agent/src/lifecycle.rs`, re-exported at crate root:
+
+- `ContextPolicy<Deps>::prepare(ContextPolicyInput, Vec<ModelRequest>)`;
+  `ContextPolicyInput` exposes RunContext, request settings/parameters (tools and
+  schema) and actual model/profile/context window. Policies own independent
+  summary models/tokenizers; no app tokenizer is hardwired.
+- `ContextFailurePolicy::{Stop, KeepHistory}`. Stop is default; KeepHistory is
+  explicit opt-in, retaining the processor output before the failed policy.
+- Builder `context_policy`, `context_failure_policy`, `checkpoint_sink`.
+- Existing `history_processor` is unchanged publicly and acts as the infallible
+  compatibility path. Its collection now uses Arc internally so spawned runs can
+  apply every processor before every primary model request.
+- `CheckpointSink::save(&AgentCheckpoint)` is asynchronous and awaited.
+- `AgentCheckpoint` version 1 stores run/step/boundary, canonical messages,
+  optional current/partial ModelResponse and RunUsage. `from_json` checks version
+  and only deserializes: it never dispatches tools or resumes a run.
+- `CheckpointBoundary`: BeforeRequest, AfterResponse, AfterTools, Terminal,
+  Cancelled, Failed, ModelFailed(ModelFailureKind). Provider failure snapshots
+  retain typed classification without raw provider error strings.
+- `AgentRunError::{ContextPolicy, Checkpoint}` are new variants, source-breaking
+  for exhaustive downstream matches. RunUsage gains serde support.
+
+### Guarantee and scope
+
+All three request loops now replace canonical active messages with processor /
+policy output. Attached processors or policy disable streaming legacy automatic
+compression, avoiding double compaction. Custom policy failure does not silently
+truncate. Native message blocks are retained structurally; configured policy
+outputs are checked for orphan/unresolved ID-bearing tool pairs. Policies remain
+responsible for preserving signatures and intentionally dropping whole groups;
+validation does not prove arbitrary application transformations semantically safe.
+Legacy no-policy compression behavior is unchanged, including its historical
+summary fallback. Non-streaming result.responses remains its existing archive;
+streaming keeps only the latest response outside compacted active history.
+
+BeforeRequest is saved after preparation and before HTTP; AfterResponse is saved
+before tool dispatch; AfterTools follows committed batch returns; Terminal is
+saved before RunComplete. Sink rejection stops further model/tool calls and is
+not retried automatically. Streaming failure/cancellation snapshots retain raw
+partial text, thinking/signatures and tool argument fragments, not repaired JSON.
+No snapshot is persisted on every token. Snapshot Debug redacts payloads; JSON is
+sensitive and storage encryption/access policy belongs to the application.
+
+Cancellable streaming now selects cancellation during request establishment and
+pending async tools as well as stream reads. Cancellation drops the owned future
+(RAII cleanup runs); it cannot undo an external effect or await arbitrary async
+Drop cleanup. A cancelled tool is not emitted as ToolExecuted success or appended
+as a completed batch. Applications must reconcile ambiguous external effects
+before manually resuming. Non-streaming step cancellation now covers the whole
+step and emits an interrupted boundary; it may interrupt a sink save itself.
+Awaited sink durability is intentionally not preempted in the streaming loops.
+
+### Still not guaranteed / follow-up
+
+- Streaming context-policy preparation, legacy compression and blocked consumer
+  event sends are not yet cancellation-selected. Ordinary `run_stream` has no
+  cancellation token; use public `AgentStream::new_with_cancel` for cancellation.
+- Legacy clean-EOF fallback for other/mock providers remains. Native Chat and
+  Anthropic errors are safe; this is not universal provider terminal enforcement.
+- Not every early exit (usage/output validation/context-policy failures) currently
+  emits a failure checkpoint in streaming; those remain typed returned errors.
+- There is no atomic transaction between remote tool side effects and sink save,
+  per-tool in-flight journal, automatic replay, or automatic restore API.
+  AfterTools is a batch boundary; cancellation within a batch may require external
+  reconciliation of earlier tools. Do not infer exactly-once execution.
+- Snapshot aggregate usage inherits existing unknown-count limitations; response
+  usage is Option and stays unknown when absent.
+- Dynamic prompt parity, configurable non-streaming response archive retention,
+  an explicit remaining-budget field beyond model profile/settings, and complete
+  native Responses SSE are not implemented in this pass.
+
+### Tests and example
+
+`serdes-ai-agent/tests/lifecycle_hooks.rs`: 8 passing tests covering canonical
+processor/checkpoint parity, repeated tool iterations with shrinking active
+history, explicit policy failure behavior, sink failure before tools, native
+partial/signature roundtrip and redacted Debug, typed partial EOF snapshot,
+localhost delayed request cancellation, stream cancellation and pending tool
+cleanup without successful completion.
+
+`serdes-ai-agent/examples/durability_hook.rs` demonstrates an app-owned sink with
+no database coupling and deserialization without replay. Its in-memory example
+store is not claimed to provide durable storage.
+
+Passed after this pass:
+
+```sh
+cargo test -p serdes-ai-agent
+cargo test -p serdes-ai-agent --test lifecycle_hooks
+cargo test --workspace
+cargo check --workspace
+cargo fmt --all -- --check
+cargo run -p serdes-ai-agent --example durability_hook
+git diff --check
+```
+
+The earlier offline `anes` blocker is resolved: public dev dependencies were
+downloaded and the full default-feature workspace test suite passed. This does
+not mean all-features/AWS or real-provider testing. Earlier provider patches and
+native safety tests remain in place. Adapter retirement is still **not ready**.

--- a/serdes-ai-agent/Cargo.toml
+++ b/serdes-ai-agent/Cargo.toml
@@ -42,3 +42,4 @@ tokio-test = { workspace = true }
 mockall = { workspace = true }
 rstest = { workspace = true }
 pretty_assertions = { workspace = true }
+wiremock = { workspace = true }

--- a/serdes-ai-agent/examples/durability_hook.rs
+++ b/serdes-ai-agent/examples/durability_hook.rs
@@ -1,0 +1,31 @@
+//! Application sink example. Replace this in-memory store with your own awaited
+//! transactional persistence; encrypt snapshots and never log their payloads.
+use async_trait::async_trait;
+use serdes_ai_agent::{AgentBuilder, AgentCheckpoint, CheckpointSink};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+struct ApplicationStore(Arc<Mutex<Vec<String>>>);
+#[async_trait]
+impl CheckpointSink for ApplicationStore {
+    async fn save(&self, checkpoint: &AgentCheckpoint) -> Result<(), String> {
+        let encoded = serde_json::to_string(checkpoint).map_err(|error| error.to_string())?;
+        self.0.lock().map_err(|_| "store poisoned")?.push(encoded);
+        Ok(())
+    }
+}
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let store = ApplicationStore::default();
+    let agent = AgentBuilder::<(), String>::new(serdes_ai_models::FunctionModel::constant_text(
+        "local example",
+    ))
+    .checkpoint_sink(store.clone())
+    .build();
+    agent.run("hello", ()).await?;
+    let last = store.0.lock().unwrap().last().unwrap().clone();
+    let checkpoint = AgentCheckpoint::from_json(&last)?;
+    // Parsing a snapshot does not replay tools or contact any provider.
+    println!("saved boundary: {:?}", checkpoint.boundary);
+    Ok(())
+}

--- a/serdes-ai-agent/src/agent.rs
+++ b/serdes-ai-agent/src/agent.rs
@@ -62,17 +62,17 @@ pub struct Agent<Deps = (), Output = String> {
     /// This avoids cloning on every run.
     pub(crate) static_system_prompt: Arc<str>,
     /// Dynamic instruction functions.
-    pub(crate) instruction_fns: Vec<Box<dyn InstructionFn<Deps>>>,
+    pub(crate) instruction_fns: Vec<Arc<dyn InstructionFn<Deps>>>,
     /// Dynamic system prompt functions.
-    pub(crate) system_prompt_fns: Vec<Box<dyn SystemPromptFn<Deps>>>,
+    pub(crate) system_prompt_fns: Vec<Arc<dyn SystemPromptFn<Deps>>>,
     /// Registered tool definitions.
     pub(crate) tools: Vec<RegisteredTool<Deps>>,
     /// Cached tool definitions - pre-computed to avoid cloning on every step.
     pub(crate) cached_tool_defs: Arc<Vec<ToolDefinition>>,
     /// Output schema.
-    pub(crate) output_schema: Box<dyn OutputSchema<Output>>,
+    pub(crate) output_schema: Arc<dyn OutputSchema<Output>>,
     /// Output validators.
-    pub(crate) output_validators: Vec<Box<dyn OutputValidator<Output, Deps>>>,
+    pub(crate) output_validators: Vec<Arc<dyn OutputValidator<Output, Deps>>>,
     /// End strategy for tool calls.
     pub(crate) end_strategy: EndStrategy,
     /// Maximum retries for output validation.
@@ -83,7 +83,10 @@ pub struct Agent<Deps = (), Output = String> {
     /// Usage limits.
     pub(crate) usage_limits: Option<UsageLimits>,
     /// History processors.
-    pub(crate) history_processors: Vec<Box<dyn HistoryProcessor<Deps>>>,
+    pub(crate) history_processors: Vec<Arc<dyn HistoryProcessor<Deps>>>,
+    pub(crate) context_policy: Option<Arc<dyn crate::lifecycle::ContextPolicy<Deps>>>,
+    pub(crate) context_failure: crate::lifecycle::ContextFailurePolicy,
+    pub(crate) checkpoint_sink: Option<Arc<dyn crate::lifecycle::CheckpointSink>>,
     /// Instrumentation settings.
     #[allow(dead_code)]
     pub(crate) instrument: Option<InstrumentationSettings>,
@@ -241,6 +244,19 @@ where
     ) -> Result<AgentStream, AgentRunError> {
         self.run_stream_with_options(prompt, deps, RunOptions::default())
             .await
+    }
+
+    /// Stream events and recover the exact output after schema/validator transforms.
+    pub async fn run_stream_typed(
+        &self,
+        prompt: impl Into<UserContent>,
+        deps: Deps,
+        options: RunOptions,
+    ) -> Result<crate::TypedAgentStream<Output>, AgentRunError> {
+        Ok(crate::TypedAgentStream {
+            stream: self.run_stream_with_options(prompt, deps, options).await?,
+            marker: std::marker::PhantomData,
+        })
     }
 
     /// Run stream with options.

--- a/serdes-ai-agent/src/builder.rs
+++ b/serdes-ai-agent/src/builder.rs
@@ -234,7 +234,10 @@ pub struct AgentBuilder<Deps = (), Output = String> {
     max_output_retries: u32,
     max_tool_retries: u32,
     usage_limits: Option<UsageLimits>,
-    history_processors: Vec<Box<dyn HistoryProcessor<Deps>>>,
+    history_processors: Vec<Arc<dyn HistoryProcessor<Deps>>>,
+    context_policy: Option<Arc<dyn crate::lifecycle::ContextPolicy<Deps>>>,
+    context_failure: crate::lifecycle::ContextFailurePolicy,
+    checkpoint_sink: Option<Arc<dyn crate::lifecycle::CheckpointSink>>,
     instrument: Option<InstrumentationSettings>,
     parallel_tool_calls: bool,
     max_concurrent_tools: Option<usize>,
@@ -299,6 +302,9 @@ where
             max_tool_retries: 3,
             usage_limits: None,
             history_processors: Vec::new(),
+            context_policy: None,
+            context_failure: Default::default(),
+            checkpoint_sink: None,
             instrument: None,
             parallel_tool_calls: true,
             max_concurrent_tools: None,
@@ -652,10 +658,35 @@ where
         self
     }
 
+    /// Install a fallible context policy and disable legacy automatic compression.
+    pub fn context_policy(
+        mut self,
+        policy: impl crate::lifecycle::ContextPolicy<Deps> + 'static,
+    ) -> Self {
+        self.context_policy = Some(Arc::new(policy));
+        self
+    }
+    /// Explicit behavior when the custom policy fails (default: stop).
+    pub fn context_failure_policy(
+        mut self,
+        policy: crate::lifecycle::ContextFailurePolicy,
+    ) -> Self {
+        self.context_failure = policy;
+        self
+    }
+    /// Await this persistence hook at lifecycle boundaries.
+    pub fn checkpoint_sink(
+        mut self,
+        sink: impl crate::lifecycle::CheckpointSink + 'static,
+    ) -> Self {
+        self.checkpoint_sink = Some(Arc::new(sink));
+        self
+    }
+
     /// Add history processor.
     #[must_use]
     pub fn history_processor<P: HistoryProcessor<Deps> + 'static>(mut self, processor: P) -> Self {
-        self.history_processors.push(Box::new(processor));
+        self.history_processors.push(Arc::new(processor));
         self
     }
 
@@ -753,17 +784,20 @@ where
             name: self.name,
             model_settings: self.model_settings,
             static_system_prompt,
-            instruction_fns: self.instruction_fns,
-            system_prompt_fns: self.system_prompt_fns,
+            instruction_fns: self.instruction_fns.into_iter().map(Arc::from).collect(),
+            system_prompt_fns: self.system_prompt_fns.into_iter().map(Arc::from).collect(),
             tools: self.tools,
             cached_tool_defs,
-            output_schema,
-            output_validators: self.output_validators,
+            output_schema: Arc::from(output_schema),
+            output_validators: self.output_validators.into_iter().map(Arc::from).collect(),
             end_strategy: self.end_strategy,
             max_output_retries: self.max_output_retries,
             max_tool_retries: self.max_tool_retries,
             usage_limits: self.usage_limits,
             history_processors: self.history_processors,
+            context_policy: self.context_policy,
+            context_failure: self.context_failure,
+            checkpoint_sink: self.checkpoint_sink,
             instrument: self.instrument,
             parallel_tool_calls: self.parallel_tool_calls,
             max_concurrent_tools: self.max_concurrent_tools,
@@ -794,6 +828,9 @@ impl<Deps: Send + Sync + 'static> AgentBuilder<Deps, String> {
             max_tool_retries: self.max_tool_retries,
             usage_limits: self.usage_limits,
             history_processors: self.history_processors,
+            context_policy: self.context_policy,
+            context_failure: self.context_failure,
+            checkpoint_sink: self.checkpoint_sink,
             instrument: self.instrument,
             parallel_tool_calls: self.parallel_tool_calls,
             max_concurrent_tools: self.max_concurrent_tools,
@@ -823,6 +860,9 @@ impl<Deps: Send + Sync + 'static> AgentBuilder<Deps, String> {
             max_tool_retries: self.max_tool_retries,
             usage_limits: self.usage_limits,
             history_processors: self.history_processors,
+            context_policy: self.context_policy,
+            context_failure: self.context_failure,
+            checkpoint_sink: self.checkpoint_sink,
             instrument: self.instrument,
             parallel_tool_calls: self.parallel_tool_calls,
             max_concurrent_tools: self.max_concurrent_tools,
@@ -855,6 +895,9 @@ impl<Deps: Send + Sync + 'static> AgentBuilder<Deps, String> {
             max_tool_retries: self.max_tool_retries,
             usage_limits: self.usage_limits,
             history_processors: self.history_processors,
+            context_policy: self.context_policy,
+            context_failure: self.context_failure,
+            checkpoint_sink: self.checkpoint_sink,
             instrument: self.instrument,
             parallel_tool_calls: self.parallel_tool_calls,
             max_concurrent_tools: self.max_concurrent_tools,

--- a/serdes-ai-agent/src/context.rs
+++ b/serdes-ai-agent/src/context.rs
@@ -169,8 +169,13 @@ pub fn generate_run_id() -> String {
 }
 
 /// Usage tracking for a run.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct RunUsage {
+    /// Whether all recorded requests reported both input/output token counts.
+    /// None denotes older serialized state or no requests yet; false means totals
+    /// are known lower bounds, not complete billing totals.
+    #[serde(default)]
+    pub token_totals_complete: Option<bool>,
     /// Total request tokens.
     pub request_tokens: u64,
     /// Total response tokens.
@@ -195,6 +200,11 @@ impl RunUsage {
 
     /// Add usage from a model request.
     pub fn add_request(&mut self, usage: serdes_ai_core::RequestUsage) {
+        let prior = self
+            .token_totals_complete
+            .unwrap_or(self.request_count == 0);
+        self.token_totals_complete =
+            Some(prior && usage.request_tokens.is_some() && usage.response_tokens.is_some());
         if let Some(req) = usage.request_tokens {
             self.request_tokens += req;
         }
@@ -221,6 +231,7 @@ impl RunUsage {
     /// a runaway agent loop, and a provider that omits usage would otherwise
     /// leave it permanently inert.
     pub fn record_request(&mut self) {
+        self.token_totals_complete = Some(false);
         self.request_count += 1;
     }
 

--- a/serdes-ai-agent/src/errors.rs
+++ b/serdes-ai-agent/src/errors.rs
@@ -10,6 +10,12 @@ use thiserror::Error;
 /// Errors that can occur during agent run execution.
 #[derive(Debug, Error)]
 pub enum AgentRunError {
+    /// Context preparation failed before a model request.
+    #[error("Context policy failed: {0}")]
+    ContextPolicy(String),
+    /// Durable observer rejected a boundary. No retry is automatic.
+    #[error("Checkpoint failed: {0}")]
+    Checkpoint(String),
     /// Model returned an error.
     #[error("Model error: {0}")]
     Model(#[from] ModelError),

--- a/serdes-ai-agent/src/lib.rs
+++ b/serdes-ai-agent/src/lib.rs
@@ -77,9 +77,19 @@ pub mod context;
 pub mod errors;
 pub mod history;
 pub mod instructions;
+pub mod lifecycle;
+pub use lifecycle::{
+    AgentCheckpoint, CheckpointBoundary, CheckpointSink, ContextFailurePolicy, ContextPolicy,
+    ContextPolicyInput,
+};
 pub mod output;
 pub mod run;
 pub mod stream;
+mod stream_lifecycle;
+mod stream_output;
+mod stream_tools;
+mod typed_stream;
+pub use typed_stream::TypedAgentStream;
 
 // Re-exports
 pub use agent::{Agent, EndStrategy, InstrumentationSettings, RegisteredTool, ToolExecutor};

--- a/serdes-ai-agent/src/lifecycle.rs
+++ b/serdes-ai-agent/src/lifecycle.rs
@@ -1,0 +1,279 @@
+//! Application-owned context policy and durable observation, without storage coupling.
+use crate::{AgentRunError, HistoryProcessor, RunContext, RunUsage};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serdes_ai_core::{ModelRequest, ModelResponse, ModelSettings};
+use serdes_ai_models::{Model, ModelRequestParameters};
+use std::sync::Arc;
+
+/// Serializable boundary. Restoring this data never executes tools automatically.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum CheckpointBoundary {
+    /// Canonical context is prepared; no request has started.
+    BeforeRequest,
+    /// Periodic partial snapshot; not a safe automatic replay boundary.
+    Partial,
+    /// Response received; no tools from this response have started.
+    AfterResponse,
+    /// Completed tool batch has been appended to active history.
+    AfterTools,
+    /// Run has finished normally (including token-limited output).
+    Terminal,
+    /// Execution was interrupted; pending tool results are not committed.
+    Cancelled,
+    /// Consumer detached before a committed terminal boundary.
+    ConsumerDetached,
+    /// Output parsing/validation exhausted its retry budget.
+    ValidationFailed,
+    /// Execution failed. Partial response may be present.
+    Failed,
+    /// Typed provider failure without embedding raw provider error text.
+    ModelFailed(serdes_ai_core::ModelFailureKind),
+}
+
+/// Versioned snapshot, not an automatic side-effect replay command.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct AgentCheckpoint {
+    /// Currently 1. Consumers must reject unknown versions.
+    pub version: u32,
+    /// Stable run identifier.
+    pub run_id: String,
+    /// Request iteration.
+    pub step: u32,
+    /// Safe observation boundary.
+    pub boundary: CheckpointBoundary,
+    /// Canonical active context, not an ever-growing immutable archive.
+    pub messages: Vec<ModelRequest>,
+    /// Current response, including partial text/thinking/tool arguments on failure.
+    pub response: Option<ModelResponse>,
+    /// Aggregate usage. Per-response unknown usage stays None in response.
+    pub usage: RunUsage,
+}
+impl std::fmt::Debug for AgentCheckpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentCheckpoint")
+            .field("version", &self.version)
+            .field("step", &self.step)
+            .field("boundary", &self.boundary)
+            .field("payload", &"<redacted>")
+            .finish()
+    }
+}
+impl AgentCheckpoint {
+    /// Decode a supported snapshot. This does not resume execution.
+    pub fn from_json(json: &str) -> Result<Self, AgentRunError> {
+        let checkpoint: Self = serde_json::from_str(json)?;
+        if checkpoint.version != 1 {
+            return Err(AgentRunError::Checkpoint(
+                "unsupported checkpoint version".into(),
+            ));
+        }
+        Ok(checkpoint)
+    }
+}
+
+/// Application persistence hook. Completion is awaited before further side effects.
+/// Implementations own transactions, encryption, retention and idempotency.
+#[async_trait]
+pub trait CheckpointSink: Send + Sync {
+    /// Optional partial-stream snapshot interval. None disables periodic snapshots.
+    /// Intervals below 10ms are clamped to 10ms to bound overhead.
+    fn partial_interval(&self) -> Option<std::time::Duration> {
+        None
+    }
+    /// Maximum wait per save. Timeout stops execution; the application must
+    /// reconcile a potentially committed write. Cancellation does not interrupt save.
+    fn save_timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(30)
+    }
+
+    /// Persist a snapshot or stop the run. No automatic retry is performed.
+    async fn save(&self, checkpoint: &AgentCheckpoint) -> Result<(), String>;
+}
+
+/// Inputs for an application tokenizer/summary policy. An independent summary
+/// model may be owned by the policy; the framework never selects one implicitly.
+pub struct ContextPolicyInput<'a, Deps> {
+    /// Dependencies and run identity.
+    pub context: &'a RunContext<Deps>,
+    /// Actual request settings.
+    pub settings: &'a ModelSettings,
+    /// Tools and output schema included in this request.
+    pub parameters: &'a ModelRequestParameters,
+    /// Actual native model, including profile/context window.
+    pub model: &'a dyn Model,
+}
+/// Fallible asynchronous context policy. Preserve native blocks and tool pairs.
+#[async_trait]
+pub trait ContextPolicy<Deps>: Send + Sync {
+    /// Return the replacement canonical active history. Failure stops by default.
+    async fn prepare(
+        &self,
+        input: ContextPolicyInput<'_, Deps>,
+        messages: Vec<ModelRequest>,
+    ) -> Result<Vec<ModelRequest>, String>;
+}
+/// Explicit policy failure behavior; no implicit summarize-to-truncate fallback.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum ContextFailurePolicy {
+    /// Stop before requesting the model.
+    #[default]
+    Stop,
+    /// Explicitly retain the pre-policy history (it may exceed model budget).
+    KeepHistory,
+}
+
+pub(crate) async fn prepare<Deps: Send + Sync>(
+    processors: &[Arc<dyn HistoryProcessor<Deps>>],
+    policy: Option<&Arc<dyn ContextPolicy<Deps>>>,
+    failure: ContextFailurePolicy,
+    input: ContextPolicyInput<'_, Deps>,
+    messages: &mut Vec<ModelRequest>,
+) -> Result<(), AgentRunError> {
+    let mut candidate = messages.clone();
+    for processor in processors {
+        candidate = processor.process(input.context, candidate).await;
+    }
+    if let Some(policy) = policy {
+        match policy.prepare(input, candidate.clone()).await {
+            Ok(prepared) => candidate = prepared,
+            Err(error) => match failure {
+                ContextFailurePolicy::Stop => return Err(AgentRunError::ContextPolicy(error)),
+                ContextFailurePolicy::KeepHistory => {}
+            },
+        }
+    }
+    if policy.is_some() || !processors.is_empty() {
+        validate_tool_pairs(&candidate)?;
+    }
+    *messages = candidate;
+    Ok(())
+}
+
+tokio::task_local! {
+    pub(crate) static SAVE_SCOPE: (Arc<std::sync::atomic::AtomicBool>, tokio_util::sync::CancellationToken);
+}
+
+pub(crate) async fn save(
+    sink: Option<&Arc<dyn CheckpointSink>>,
+    run_id: &str,
+    step: u32,
+    boundary: CheckpointBoundary,
+    messages: &[ModelRequest],
+    response: Option<&ModelResponse>,
+    usage: &RunUsage,
+) -> Result<(), AgentRunError> {
+    let terminal = boundary == CheckpointBoundary::Terminal;
+    let scope = SAVE_SCOPE.try_with(Clone::clone).ok();
+    if let Some((saving, _)) = &scope {
+        saving.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
+    if let Some(sink) = sink {
+        let checkpoint = AgentCheckpoint {
+            version: 1,
+            run_id: run_id.into(),
+            step,
+            boundary,
+            messages: messages.to_vec(),
+            response: response.cloned(),
+            usage: usage.clone(),
+        };
+        tokio::time::timeout(sink.save_timeout(), sink.save(&checkpoint))
+            .await
+            .map_err(|_| {
+                AgentRunError::Checkpoint(
+                    "checkpoint deadline exceeded; reconcile storage before resume".into(),
+                )
+            })?
+            .map_err(AgentRunError::Checkpoint)?;
+    }
+    if let Some((saving, token)) = scope {
+        saving.store(false, std::sync::atomic::Ordering::SeqCst);
+        if token.is_cancelled() && !terminal {
+            return Err(AgentRunError::Cancelled);
+        }
+    }
+    Ok(())
+}
+
+// Refuse a policy that leaves a tool result without its native call. Never repair
+// by inventing calls or arguments. Policies should compact whole interaction groups.
+fn validate_tool_pairs(messages: &[ModelRequest]) -> Result<(), AgentRunError> {
+    use serdes_ai_core::{ModelRequestPart, ModelResponsePart};
+    let mut calls = std::collections::HashSet::new();
+    for message in messages {
+        for part in &message.parts {
+            match part {
+                ModelRequestPart::ModelResponse(response) => {
+                    for part in &response.parts {
+                        if let ModelResponsePart::ToolCall(call) = part {
+                            if let Some(id) = &call.tool_call_id {
+                                calls.insert(id.clone());
+                            }
+                        }
+                    }
+                }
+                ModelRequestPart::ToolReturn(result) => {
+                    if let Some(id) = &result.tool_call_id {
+                        if !calls.remove(id) {
+                            return Err(AgentRunError::ContextPolicy(
+                                "orphan tool result after context policy".into(),
+                            ));
+                        }
+                    }
+                }
+                ModelRequestPart::RetryPrompt(retry) => {
+                    if let Some(id) = &retry.tool_call_id {
+                        calls.remove(id);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    if !calls.is_empty() {
+        return Err(AgentRunError::ContextPolicy(
+            "unresolved tool calls in prepared history; reconcile before resuming".into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn partial_timer(sink: Option<&Arc<dyn CheckpointSink>>) -> tokio::time::Interval {
+    let interval = sink
+        .and_then(|sink| sink.partial_interval())
+        .unwrap_or(std::time::Duration::from_secs(86400 * 365))
+        .max(std::time::Duration::from_millis(10));
+    let mut timer = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
+    timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    timer
+}
+
+/// Update the checkpoint copy before awaiting downstream event delivery.
+pub(crate) fn apply_partial(
+    response: &mut ModelResponse,
+    event: &serdes_ai_core::ModelResponseStreamEvent,
+) {
+    use serdes_ai_core::ModelResponseStreamEvent as Event;
+    match event {
+        Event::PartStart(start) => {
+            if start.index == response.parts.len() {
+                response.parts.push(start.part.clone());
+            } else if let Some(part) = response.parts.get_mut(start.index) {
+                *part = start.part.clone();
+            }
+        }
+        Event::PartDelta(delta) => {
+            if let Some(part) = response.parts.get_mut(delta.index) {
+                let _ = delta.delta.apply(part);
+            }
+        }
+        Event::StreamComplete(complete) => {
+            response.finish_reason = Some(complete.finish_reason);
+            if let Some(metadata) = &complete.metadata {
+                metadata.apply(response);
+            }
+        }
+        _ => {}
+    }
+}

--- a/serdes-ai-agent/src/run.rs
+++ b/serdes-ai-agent/src/run.rs
@@ -24,6 +24,8 @@ pub enum CompressionStrategy {
     Truncate,
     /// Use LLM to summarize older messages into condensed form.
     Summarize,
+    /// Legacy summary with explicitly permitted truncation fallback.
+    SummarizeOrTruncate,
 }
 
 /// Context compression configuration.
@@ -352,6 +354,50 @@ where
         if self.state.finished {
             return Ok(StepResult::Finished);
         }
+        let token = self.cancel_token.clone().unwrap_or_default();
+        let saving = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let result = {
+            let work = crate::lifecycle::SAVE_SCOPE
+                .scope((saving.clone(), token.clone()), self.step_inner());
+            tokio::pin!(work);
+            tokio::select! {
+                biased;
+                result = &mut work => result,
+                _ = token.cancelled() => {
+                    if saving.load(std::sync::atomic::Ordering::SeqCst) { work.await }
+                    else { Err(AgentRunError::Cancelled) }
+                }
+            }
+        };
+        if let Err(error) = &result {
+            self.state.finished = true;
+            self.state.final_output = None;
+            let boundary = if matches!(error, AgentRunError::Cancelled) {
+                crate::lifecycle::CheckpointBoundary::Cancelled
+            } else {
+                crate::lifecycle::CheckpointBoundary::Failed
+            };
+            // Do not recursively retry an already-failed sink.
+            if !matches!(error, AgentRunError::Checkpoint(_)) {
+                crate::lifecycle::save(
+                    self.agent.checkpoint_sink.as_ref(),
+                    &self.ctx.run_id,
+                    self.state.step,
+                    boundary,
+                    &self.state.messages,
+                    self.state.responses.last(),
+                    &self.state.usage,
+                )
+                .await?;
+            }
+        }
+        result
+    }
+
+    async fn step_inner(&mut self) -> Result<StepResult, AgentRunError> {
+        if self.state.finished {
+            return Ok(StepResult::Finished);
+        }
 
         // Check for cancellation at the start of each step
         if let Some(ref token) = self.cancel_token {
@@ -387,14 +433,35 @@ where
             params = params.with_output_schema(schema);
         }
 
-        // Process message history
-        let messages = self.process_history().await;
+        crate::lifecycle::prepare(
+            &self.agent.history_processors,
+            self.agent.context_policy.as_ref(),
+            self.agent.context_failure,
+            crate::lifecycle::ContextPolicyInput {
+                context: &self.ctx,
+                settings: &self.ctx.model_settings,
+                parameters: &params,
+                model: self.agent.model(),
+            },
+            &mut self.state.messages,
+        )
+        .await?;
+        crate::lifecycle::save(
+            self.agent.checkpoint_sink.as_ref(),
+            &self.ctx.run_id,
+            self.state.step,
+            crate::lifecycle::CheckpointBoundary::BeforeRequest,
+            &self.state.messages,
+            None,
+            &self.state.usage,
+        )
+        .await?;
 
         // Make model request
         let mut response = self
             .agent
             .model()
-            .request(&messages, &self.ctx.model_settings, &params)
+            .request(&self.state.messages, &self.ctx.model_settings, &params)
             .await?;
 
         // Persist canonical tool args to avoid carrying malformed raw args in history.
@@ -413,19 +480,32 @@ where
         }
         self.state.responses.push(response.clone());
 
-        // Process response
-        self.process_response(response).await
-    }
-
-    async fn process_history(&self) -> Vec<ModelRequest> {
-        let mut messages = self.state.messages.clone();
-
-        // Apply history processors
-        for processor in &self.agent.history_processors {
-            messages = processor.process(&self.ctx, messages).await;
-        }
-
-        messages
+        crate::lifecycle::save(
+            self.agent.checkpoint_sink.as_ref(),
+            &self.ctx.run_id,
+            self.state.step,
+            crate::lifecycle::CheckpointBoundary::AfterResponse,
+            &self.state.messages,
+            Some(&response),
+            &self.state.usage,
+        )
+        .await?;
+        let result = self.process_response(response).await?;
+        crate::lifecycle::save(
+            self.agent.checkpoint_sink.as_ref(),
+            &self.ctx.run_id,
+            self.state.step,
+            if self.state.finished {
+                crate::lifecycle::CheckpointBoundary::Terminal
+            } else {
+                crate::lifecycle::CheckpointBoundary::AfterTools
+            },
+            &self.state.messages,
+            self.state.responses.last(),
+            &self.state.usage,
+        )
+        .await?;
+        Ok(result)
     }
 
     async fn process_response(
@@ -457,8 +537,8 @@ where
                             .parse_tool_call(&tc.tool_name, &args)
                         {
                             found_output = Some(output);
-                            continue;
                         }
+                        continue;
                     }
 
                     // Regular tool call
@@ -472,6 +552,77 @@ where
                 }
                 ModelResponsePart::BuiltinToolCall(_) => {
                     // Builtin tool calls are handled by the provider
+                }
+            }
+        }
+
+        // A native final-output tool is explicit final-output evidence. Text
+        // alongside regular tools remains explanatory, preserving legacy behavior.
+        let explicit_output = response.parts.iter().any(|part| {
+            matches!(part,
+            ModelResponsePart::ToolCall(call) if self.agent.is_output_tool(&call.tool_name))
+        });
+        if explicit_output && !tool_calls.is_empty() {
+            let validation = crate::stream_output::validate(
+                self.agent.output_schema.as_ref(),
+                &self.agent.output_validators,
+                &response,
+                &self.ctx,
+            )
+            .await;
+            match validation {
+                Ok(output) => {
+                    let mut returns = if self.agent.end_strategy == EndStrategy::Exhaustive {
+                        self.execute_tool_calls(tool_calls).await
+                    } else {
+                        tool_calls
+                            .into_iter()
+                            .map(|call| {
+                                (
+                                    call.tool_name,
+                                    call.tool_call_id,
+                                    Ok(ToolReturn::text("Skipped: final output accepted")),
+                                )
+                            })
+                            .collect()
+                    };
+                    for part in &response.parts {
+                        if let ModelResponsePart::ToolCall(call) = part {
+                            if self.agent.is_output_tool(&call.tool_name) {
+                                returns.push((
+                                    call.tool_name.clone(),
+                                    call.tool_call_id.clone(),
+                                    Ok(ToolReturn::text("Final output accepted")),
+                                ));
+                            }
+                        }
+                    }
+                    self.add_tool_returns(returns)?;
+                    self.state.final_output = Some(output);
+                    self.state.finished = true;
+                    return Ok(StepResult::OutputReady);
+                }
+                Err(error) => {
+                    self.state.output_retries += 1;
+                    if self.state.output_retries > self.agent.max_output_retries {
+                        return Err(AgentRunError::OutputValidationFailed(error));
+                    }
+                    let returns = response
+                        .parts
+                        .iter()
+                        .filter_map(|part| match part {
+                            ModelResponsePart::ToolCall(call) => Some((
+                                call.tool_name.clone(),
+                                call.tool_call_id.clone(),
+                                Ok(ToolReturn::text(
+                                    "Not executed: final output rejected; retry",
+                                )),
+                            )),
+                            _ => None,
+                        })
+                        .collect();
+                    self.add_tool_returns(returns)?;
+                    return Ok(StepResult::RetryingOutput);
                 }
             }
         }
@@ -694,7 +845,7 @@ where
         use std::sync::Arc;
         use tokio::sync::Semaphore;
 
-        let semaphore = Arc::new(Semaphore::new(max_concurrent));
+        let semaphore = Arc::new(Semaphore::new(max_concurrent.max(1)));
 
         let wrapped_futures: Vec<_> = futures
             .into_iter()

--- a/serdes-ai-agent/src/stream.rs
+++ b/serdes-ai-agent/src/stream.rs
@@ -6,9 +6,11 @@
 use crate::agent::{Agent, RegisteredTool};
 use crate::context::{RunContext, RunUsage, generate_run_id};
 use crate::errors::AgentRunError;
+use crate::lifecycle::{self, CheckpointBoundary, ContextPolicyInput};
 use crate::run::{CompressionStrategy, RunOptions};
 use chrono::Utc;
 use futures::{Stream, StreamExt};
+use serdes_ai_core::ClassifyModelFailure;
 use serdes_ai_core::messages::{
     ModelResponseStreamEvent, StreamCompleteEvent, ToolCallArgs, ToolReturnPart, UserContent,
 };
@@ -21,6 +23,26 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+
+// Await durability before allowing the caller to advance to another side effect.
+macro_rules! checkpoint {
+    ($sink:expr, $id:expr, $step:expr, $boundary:expr, $messages:expr, $response:expr, $usage:expr, $tx:expr) => {
+        if let Err(error) = lifecycle::save(
+            $sink.as_ref(),
+            &$id,
+            $step,
+            $boundary,
+            &$messages,
+            $response,
+            &$usage,
+        )
+        .await
+        {
+            let _ = $tx.try_send(Err(error));
+            return;
+        }
+    };
+}
 
 // Conditional tracing - use no-op macros when tracing feature is disabled
 #[cfg(feature = "tracing-integration")]
@@ -152,6 +174,7 @@ pub enum AgentStreamEvent {
 /// 2. Cancel any pending tool calls
 /// 3. Emit a [`AgentStreamEvent::Cancelled`] event with partial results
 pub struct AgentStream {
+    output: Arc<std::sync::Mutex<Option<Box<dyn std::any::Any + Send + Sync>>>>,
     rx: mpsc::Receiver<Result<AgentStreamEvent, AgentRunError>>,
     /// Cancellation token for this stream (if cancellation is enabled).
     cancel_token: Option<CancellationToken>,
@@ -168,31 +191,20 @@ fn canonicalize_tool_call_args_in_response(response: &mut ModelResponse) {
 }
 
 fn usage_from_stream_complete(event: &StreamCompleteEvent) -> Option<RequestUsage> {
-    if event.input_tokens.is_none()
-        && event.output_tokens.is_none()
-        && event.cache_creation_tokens.is_none()
-        && event.cache_read_tokens.is_none()
-    {
-        return None;
-    }
-
-    let mut usage = RequestUsage::new();
-    if let Some(tokens) = event.input_tokens {
-        usage = usage.request_tokens(tokens);
-    }
-    if let Some(tokens) = event.output_tokens {
-        usage = usage.response_tokens(tokens);
-    }
-    if let Some(tokens) = event.cache_creation_tokens {
-        usage = usage.cache_creation_tokens(tokens);
-    }
-    if let Some(tokens) = event.cache_read_tokens {
-        usage = usage.cache_read_tokens(tokens);
-    }
-    Some(usage)
+    event.request_usage()
 }
 
 impl AgentStream {
+    pub(crate) fn take_typed_output<O: Send + Sync + 'static>(&mut self) -> Option<O> {
+        self.output
+            .lock()
+            .unwrap()
+            .take()?
+            .downcast::<O>()
+            .ok()
+            .map(|value| *value)
+    }
+
     /// Create a new streaming agent run.
     ///
     /// This spawns a background task that handles the actual streaming
@@ -207,718 +219,7 @@ impl AgentStream {
         Deps: Send + Sync + 'static,
         Output: Send + Sync + 'static,
     {
-        let run_id = generate_run_id();
-        let (tx, rx) = mpsc::channel(64);
-
-        // Clone what we need for the spawned task
-        let model = agent.model_arc();
-        let model_name = model.name().to_string();
-        let model_settings = options
-            .model_settings
-            .clone()
-            .unwrap_or_else(|| agent.model_settings.clone());
-
-        // Get the static system prompt - for streaming we use just the static part
-        // Dynamic prompts are not supported in streaming mode for simplicity
-        let static_system_prompt = agent.static_system_prompt().to_string();
-
-        let tool_definitions = agent.tool_definitions();
-        let native_output_schema = agent.native_output_schema();
-        let _end_strategy = agent.end_strategy;
-        let usage_limits = agent.usage_limits.clone();
-        let run_usage_limits = options.usage_limits.clone();
-
-        // Clone tool executors - now possible because RegisteredTool implements Clone!
-        let tools: Vec<RegisteredTool<Deps>> = agent.tools.to_vec();
-
-        // Wrap deps in Arc for shared access in tool execution
-        let deps = Arc::new(deps);
-
-        let initial_history = options.message_history.clone();
-        let _metadata = options.metadata.clone();
-        let compression_config = options.compression.clone();
-        let run_id_clone = run_id.clone();
-
-        debug!(run_id = %run_id, "AgentStream: spawning streaming task");
-
-        // Spawn the streaming task
-        tokio::spawn(async move {
-            info!(run_id = %run_id_clone, "AgentStream: task started");
-
-            // Emit RunStart
-            debug!("AgentStream: emitting RunStart");
-            if tx
-                .send(Ok(AgentStreamEvent::RunStart {
-                    run_id: run_id_clone.clone(),
-                }))
-                .await
-                .is_err()
-            {
-                warn!("AgentStream: receiver dropped before RunStart");
-                return;
-            }
-
-            // Build initial messages
-            let mut messages = initial_history.unwrap_or_default();
-            debug!(
-                initial_messages = messages.len(),
-                "AgentStream: building messages"
-            );
-
-            // Add system prompt if non-empty
-            if !static_system_prompt.is_empty() {
-                let mut req = ModelRequest::new();
-                req.add_system_prompt(static_system_prompt.clone());
-                messages.push(req);
-            }
-
-            // Add user prompt
-            let mut user_req = ModelRequest::new();
-            user_req.add_user_prompt(prompt);
-            messages.push(user_req);
-
-            let mut responses: Vec<ModelResponse> = Vec::new();
-            let mut usage = RunUsage::new();
-            let mut step = 0u32;
-            let mut finished = false;
-            let mut finish_reason: Option<FinishReason>;
-
-            // Main agent loop
-            while !finished {
-                step += 1;
-
-                // Check usage limits
-                if let Some(ref limits) = usage_limits {
-                    if let Err(e) = limits.check(&usage) {
-                        let _ = tx.send(Err(e.into())).await;
-                        return;
-                    }
-                }
-
-                if let Some(ref limits) = run_usage_limits {
-                    if let Err(e) = limits.check(&usage) {
-                        let _ = tx.send(Err(e.into())).await;
-                        return;
-                    }
-                }
-
-                // Emit RequestStart
-                if tx
-                    .send(Ok(AgentStreamEvent::RequestStart { step }))
-                    .await
-                    .is_err()
-                {
-                    return;
-                }
-
-                // Build request parameters
-                let mut params = ModelRequestParameters::new()
-                    .with_tools_arc(tool_definitions.clone())
-                    .with_allow_text(true);
-
-                // Carry the structured-output request to the provider, as the
-                // blocking path does.
-                if let Some(schema) = native_output_schema.clone() {
-                    params = params.with_output_schema(schema);
-                }
-
-                // === Context Size Calculation & Compression ===
-
-                // Calculate context size by serializing (this is the actual request size)
-                let (request_bytes, estimated_tokens) = {
-                    let messages_json = serde_json::to_string(&messages).unwrap_or_default();
-                    let tools_json = serde_json::to_string(&*tool_definitions).unwrap_or_default();
-                    let bytes = messages_json.len() + tools_json.len();
-                    (bytes, bytes / 4)
-                };
-
-                // Get context limit from model profile
-                let context_limit = model.profile().context_window;
-
-                // Emit ContextInfo event
-                let _ = tx
-                    .send(Ok(AgentStreamEvent::ContextInfo {
-                        estimated_tokens,
-                        request_bytes,
-                        context_limit,
-                    }))
-                    .await;
-
-                // Check if compression is needed
-                if let Some(ref compression) = compression_config {
-                    if let Some(limit) = context_limit {
-                        let threshold_tokens = (limit as f64 * compression.threshold) as usize;
-
-                        if estimated_tokens > threshold_tokens {
-                            let messages_before = messages.len();
-                            let original_tokens = estimated_tokens;
-
-                            // Apply compression based on strategy
-                            let strategy_name = match compression.strategy {
-                                CompressionStrategy::Truncate => {
-                                    // Use TruncateByTokens with keep_first_n=2 (system + first user)
-                                    use crate::history::{HistoryProcessor, TruncateByTokens};
-                                    let truncator =
-                                        TruncateByTokens::new(compression.target_tokens as u64)
-                                            .keep_first_n(2);
-
-                                    // Create a minimal context for the processor
-                                    let temp_ctx = RunContext::new((), &model_name);
-                                    messages = truncator.process(&temp_ctx, messages).await;
-                                    "truncate"
-                                }
-                                CompressionStrategy::Summarize => {
-                                    // Use the same model to summarize the conversation history
-                                    // Keep first 2 messages (system + first user) and last few messages
-                                    // Summarize everything in between
-
-                                    if messages.len() <= 4 {
-                                        // Too few messages to summarize, just truncate
-                                        use crate::history::{HistoryProcessor, TruncateByTokens};
-                                        let truncator =
-                                            TruncateByTokens::new(compression.target_tokens as u64)
-                                                .keep_first_n(2);
-                                        let temp_ctx = RunContext::new((), &model_name);
-                                        messages = truncator.process(&temp_ctx, messages).await;
-                                        "truncate (too few messages)"
-                                    } else {
-                                        // Split messages: first 2 (keep), middle (summarize), last 2 (keep)
-                                        let first_two: Vec<_> =
-                                            messages.iter().take(2).cloned().collect();
-                                        let last_two: Vec<_> = messages
-                                            .iter()
-                                            .rev()
-                                            .take(2)
-                                            .cloned()
-                                            .collect::<Vec<_>>()
-                                            .into_iter()
-                                            .rev()
-                                            .collect();
-                                        let middle: Vec<_> = messages
-                                            .iter()
-                                            .skip(2)
-                                            .take(messages.len().saturating_sub(4))
-                                            .cloned()
-                                            .collect();
-
-                                        if middle.is_empty() {
-                                            // Nothing to summarize
-                                            "summarize (nothing to compress)"
-                                        } else {
-                                            // Build summarization prompt
-                                            let middle_json = serde_json::to_string_pretty(&middle)
-                                                .unwrap_or_default();
-                                            let summary_prompt = format!(
-                                                "Condense this conversation history into a brief summary while preserving:\n\
-                                                - Key decisions and conclusions\n\
-                                                - Important information discovered\n\
-                                                - Tool calls made and their essential results\n\
-                                                - Any errors or issues encountered\n\n\
-                                                Keep the summary concise but complete enough to continue the conversation.\n\n\
-                                                Conversation to summarize:\n{}\n\n\
-                                                Respond with ONLY the summary, no preamble.",
-                                                middle_json
-                                            );
-
-                                            // Create a minimal request for summarization
-                                            let mut summary_req = ModelRequest::new();
-                                            summary_req.add_user_prompt(summary_prompt);
-
-                                            // Call the model (non-streaming for simplicity)
-                                            let summary_params = ModelRequestParameters::new();
-                                            match model
-                                                .request(
-                                                    &[summary_req],
-                                                    &model_settings,
-                                                    &summary_params,
-                                                )
-                                                .await
-                                            {
-                                                Ok(response) => {
-                                                    // Extract text from response
-                                                    let summary_text = response
-                                                        .parts
-                                                        .iter()
-                                                        .filter_map(|p| match p {
-                                                            ModelResponsePart::Text(t) => {
-                                                                Some(t.content.clone())
-                                                            }
-                                                            _ => None,
-                                                        })
-                                                        .collect::<Vec<_>>()
-                                                        .join("\n");
-
-                                                    if !summary_text.is_empty() {
-                                                        // Build new message list: first 2 + summary + last 2
-                                                        let mut new_messages = first_two;
-
-                                                        // Add summary as a "previous context" message
-                                                        let mut summary_msg = ModelRequest::new();
-                                                        summary_msg.add_user_prompt(format!(
-                                                            "[Previous conversation summary]\n{}\n[End of summary - continuing conversation]",
-                                                            summary_text
-                                                        ));
-                                                        new_messages.push(summary_msg);
-
-                                                        new_messages.extend(last_two);
-                                                        messages = new_messages;
-                                                        "summarize"
-                                                    } else {
-                                                        // Fallback to truncate if summary failed
-                                                        use crate::history::{
-                                                            HistoryProcessor, TruncateByTokens,
-                                                        };
-                                                        let truncator = TruncateByTokens::new(
-                                                            compression.target_tokens as u64,
-                                                        )
-                                                        .keep_first_n(2);
-                                                        let temp_ctx =
-                                                            RunContext::new((), &model_name);
-                                                        messages = truncator
-                                                            .process(&temp_ctx, messages)
-                                                            .await;
-                                                        "truncate (summary empty)"
-                                                    }
-                                                }
-                                                Err(_e) => {
-                                                    warn!(
-                                                        "Summarization failed, falling back to truncate: {}",
-                                                        _e
-                                                    );
-                                                    use crate::history::{
-                                                        HistoryProcessor, TruncateByTokens,
-                                                    };
-                                                    let truncator = TruncateByTokens::new(
-                                                        compression.target_tokens as u64,
-                                                    )
-                                                    .keep_first_n(2);
-                                                    let temp_ctx = RunContext::new((), &model_name);
-                                                    messages = truncator
-                                                        .process(&temp_ctx, messages)
-                                                        .await;
-                                                    "truncate (summary failed)"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            };
-
-                            // Calculate new size
-                            let new_bytes = serde_json::to_string(&messages)
-                                .map(|s| s.len())
-                                .unwrap_or(0);
-                            let compressed_tokens = new_bytes / 4;
-
-                            // Emit compression event
-                            let _ = tx
-                                .send(Ok(AgentStreamEvent::ContextCompressed {
-                                    original_tokens,
-                                    compressed_tokens,
-                                    strategy: strategy_name.to_string(),
-                                    messages_before,
-                                    messages_after: messages.len(),
-                                }))
-                                .await;
-                        }
-                    }
-                }
-                // === End Context Compression ===
-
-                // Make streaming request
-                info!(
-                    step = step,
-                    message_count = messages.len(),
-                    "AgentStream: calling model.request_stream"
-                );
-                let stream_result = model
-                    .request_stream(&messages, &model_settings, &params)
-                    .await;
-
-                let mut model_stream = match stream_result {
-                    Ok(s) => {
-                        debug!("AgentStream: model.request_stream succeeded, got stream");
-                        s
-                    }
-                    Err(e) => {
-                        error!(error = %e, "AgentStream: model.request_stream failed");
-                        let _ = tx
-                            .send(Ok(AgentStreamEvent::Error {
-                                message: e.to_string(),
-                            }))
-                            .await;
-                        let _ = tx.send(Err(AgentRunError::Model(e))).await;
-                        return;
-                    }
-                };
-
-                // Collect response parts while streaming
-                let mut response_parts: Vec<ModelResponsePart> = Vec::new();
-                // Track stream events (used by tracing when enabled)
-                let mut stream_event_count = 0u32;
-                // Provider-reported finish reason (set by StreamComplete event)
-                let mut stream_finish_reason: Option<FinishReason> = None;
-                let mut stream_usage: Option<RequestUsage> = None;
-
-                // Process stream events
-                debug!("AgentStream: starting to process model stream events");
-                while let Some(event_result) = model_stream.next().await {
-                    {
-                        stream_event_count += 1;
-                        let _ = stream_event_count;
-                    }
-                    match event_result {
-                        Ok(event) => {
-                            match event {
-                                ModelResponseStreamEvent::PartStart(start) => {
-                                    match &start.part {
-                                        ModelResponsePart::Text(t) => {
-                                            if !t.content.is_empty() {
-                                                let _ = tx
-                                                    .send(Ok(AgentStreamEvent::TextDelta {
-                                                        text: t.content.clone(),
-                                                    }))
-                                                    .await;
-                                            }
-                                        }
-                                        ModelResponsePart::ToolCall(tc) => {
-                                            let _ = tx
-                                                .send(Ok(AgentStreamEvent::ToolCallStart {
-                                                    tool_name: tc.tool_name.clone(),
-                                                    tool_call_id: tc.tool_call_id.clone(),
-                                                }))
-                                                .await;
-                                            // If args are already present (non-streaming models),
-                                            // send them as a delta immediately
-                                            if let Ok(args_str) = tc.args.to_json_string() {
-                                                if !args_str.is_empty() && args_str != "{}" {
-                                                    let _ = tx
-                                                        .send(Ok(AgentStreamEvent::ToolCallDelta {
-                                                            delta: args_str,
-                                                            tool_call_id: tc.tool_call_id.clone(),
-                                                        }))
-                                                        .await;
-                                                }
-                                            }
-                                        }
-                                        ModelResponsePart::Thinking(t) if !t.content.is_empty() => {
-                                            let _ = tx
-                                                .send(Ok(AgentStreamEvent::ThinkingDelta {
-                                                    text: t.content.clone(),
-                                                }))
-                                                .await;
-                                        }
-                                        _ => {}
-                                    }
-                                    response_parts.push(start.part.clone());
-                                }
-                                ModelResponseStreamEvent::PartDelta(delta) => {
-                                    use serdes_ai_core::messages::ModelResponsePartDelta;
-                                    match &delta.delta {
-                                        ModelResponsePartDelta::Text(t) => {
-                                            let _ = tx
-                                                .send(Ok(AgentStreamEvent::TextDelta {
-                                                    text: t.content_delta.clone(),
-                                                }))
-                                                .await;
-                                            // Update the part
-                                            if let Some(ModelResponsePart::Text(text)) =
-                                                response_parts.get_mut(delta.index)
-                                            {
-                                                text.content.push_str(&t.content_delta);
-                                            }
-                                        }
-                                        ModelResponsePartDelta::ToolCall(tc) => {
-                                            // Get tool_call_id from the existing response part
-                                            let tool_call_id =
-                                                response_parts.get(delta.index).and_then(|p| {
-                                                    if let ModelResponsePart::ToolCall(tc) = p {
-                                                        tc.tool_call_id.clone()
-                                                    } else {
-                                                        None
-                                                    }
-                                                });
-                                            let _ = tx
-                                                .send(Ok(AgentStreamEvent::ToolCallDelta {
-                                                    delta: tc.args_delta.clone(),
-                                                    tool_call_id,
-                                                }))
-                                                .await;
-                                            // Update args - accumulate the delta into the tool call
-                                            if let Some(ModelResponsePart::ToolCall(tool_call)) =
-                                                response_parts.get_mut(delta.index)
-                                            {
-                                                tc.apply(tool_call);
-                                            }
-                                        }
-                                        ModelResponsePartDelta::Thinking(t) => {
-                                            let _ = tx
-                                                .send(Ok(AgentStreamEvent::ThinkingDelta {
-                                                    text: t.content_delta.clone(),
-                                                }))
-                                                .await;
-                                            if let Some(ModelResponsePart::Thinking(think)) =
-                                                response_parts.get_mut(delta.index)
-                                            {
-                                                t.apply(think);
-                                            }
-                                        }
-                                        _ => {}
-                                    }
-                                }
-                                ModelResponseStreamEvent::PartEnd(_) => {
-                                    // Part finished
-                                }
-                                ModelResponseStreamEvent::StreamComplete(sc) => {
-                                    stream_finish_reason = Some(sc.finish_reason);
-                                    stream_usage = usage_from_stream_complete(&sc);
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            let _ = tx
-                                .send(Ok(AgentStreamEvent::Error {
-                                    message: e.to_string(),
-                                }))
-                                .await;
-                            let _ = tx.send(Err(AgentRunError::Model(e))).await;
-                            return;
-                        }
-                    }
-                }
-
-                info!(
-                    stream_events = stream_event_count,
-                    parts = response_parts.len(),
-                    "AgentStream: finished processing model stream"
-                );
-
-                // A stream may legitimately end without an explicit terminal StreamComplete
-                // (in-memory/mock streams, and OpenAI/Google/etc. parsers which never emit one).
-                // Anthropic's parser surfaces REAL truncation separately as an explicit Err
-                // (handled above), so a clean end here with content is a successful completion.
-                // Default the finish reason to Stop. (The `response_parts.is_empty()` guard in
-                // the next block still catches a stream that produced nothing.)
-                if stream_finish_reason.is_none() {
-                    debug!(
-                        parts = response_parts.len(),
-                        "stream ended without terminal StreamComplete; defaulting finish_reason=Stop"
-                    );
-                }
-                let stream_finish_reason = stream_finish_reason.unwrap_or(FinishReason::Stop);
-
-                // If the stream produced no parts at all, treat it as an error
-                if response_parts.is_empty() {
-                    let _ = tx
-                        .send(Ok(AgentStreamEvent::Error {
-                            message: "model stream ended without producing any content".to_string(),
-                        }))
-                        .await;
-                    let _ = tx
-                        .send(Err(AgentRunError::Model(
-                            serdes_ai_models::ModelError::incomplete_stream(
-                                "model stream ended without producing any content",
-                            ),
-                        )))
-                        .await;
-                    return;
-                }
-
-                // Build the complete response using the provider-reported finish reason
-                let mut response = ModelResponse {
-                    parts: response_parts.clone(),
-                    model_name: Some(model.name().to_string()),
-                    timestamp: Utc::now(),
-                    finish_reason: Some(stream_finish_reason),
-                    usage: stream_usage,
-                    vendor_id: None,
-                    vendor_details: None,
-                    kind: "response".to_string(),
-                };
-                canonicalize_tool_call_args_in_response(&mut response);
-
-                finish_reason = response.finish_reason;
-                responses.push(response.clone());
-
-                // Accumulate run-wide usage, mirroring the non-streaming run()
-                // path so streaming and non-streaming agree. The request is
-                // counted either way, so max_requests bounds the loop even
-                // against a provider that reports no usage.
-                match &response.usage {
-                    Some(u) => usage.add_request(u.clone()),
-                    None => usage.record_request(),
-                }
-
-                // Emit ResponseComplete
-                let _ = tx
-                    .send(Ok(AgentStreamEvent::ResponseComplete {
-                        step,
-                        usage: response.usage.clone(),
-                    }))
-                    .await;
-
-                // Check for tool calls that need execution
-                let tool_calls: Vec<_> = response
-                    .parts
-                    .iter()
-                    .filter_map(|p| {
-                        if let ModelResponsePart::ToolCall(tc) = p {
-                            Some(tc.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-
-                if !tool_calls.is_empty() {
-                    // Add response to messages for proper alternation
-                    let mut response_req = ModelRequest::new();
-                    response_req
-                        .parts
-                        .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
-                    messages.push(response_req);
-
-                    let mut tool_req = ModelRequest::new();
-
-                    for tc in tool_calls {
-                        let _ = tx
-                            .send(Ok(AgentStreamEvent::ToolCallComplete {
-                                tool_name: tc.tool_name.clone(),
-                                tool_call_id: tc.tool_call_id.clone(),
-                            }))
-                            .await;
-
-                        usage.record_tool_call();
-
-                        // Find the tool by name
-                        let tool = tools.iter().find(|t| t.definition.name == tc.tool_name);
-
-                        match tool {
-                            Some(tool) => {
-                                // Create a RunContext for tool execution
-                                let tool_ctx =
-                                    RunContext::with_shared_deps(deps.clone(), model_name.clone())
-                                        .for_tool(&tc.tool_name, tc.tool_call_id.clone());
-
-                                // Execute the tool
-                                let result =
-                                    tool.executor.execute(tc.args.to_json(), &tool_ctx).await;
-
-                                match result {
-                                    Ok(ret) => {
-                                        let _ = tx
-                                            .send(Ok(AgentStreamEvent::ToolExecuted {
-                                                tool_name: tc.tool_name.clone(),
-                                                tool_call_id: tc.tool_call_id.clone(),
-                                                success: true,
-                                                error: None,
-                                            }))
-                                            .await;
-
-                                        // Use ToolReturnPart for successful execution
-                                        let mut part =
-                                            ToolReturnPart::new(&tc.tool_name, ret.content);
-                                        if let Some(id) = tc.tool_call_id.clone() {
-                                            part = part.with_tool_call_id(id);
-                                        }
-                                        tool_req.parts.push(ModelRequestPart::ToolReturn(part));
-                                    }
-                                    Err(e) => {
-                                        let error_msg = e.to_string();
-                                        let _ = tx
-                                            .send(Ok(AgentStreamEvent::ToolExecuted {
-                                                tool_name: tc.tool_name.clone(),
-                                                tool_call_id: tc.tool_call_id.clone(),
-                                                success: false,
-                                                error: Some(error_msg.clone()),
-                                            }))
-                                            .await;
-
-                                        // Use ToolReturnPart with error content for tool errors
-                                        let mut part = ToolReturnPart::error(
-                                            &tc.tool_name,
-                                            format!("Tool error: {}", e),
-                                        );
-                                        if let Some(id) = tc.tool_call_id.clone() {
-                                            part = part.with_tool_call_id(id);
-                                        }
-                                        tool_req.parts.push(ModelRequestPart::ToolReturn(part));
-                                    }
-                                }
-                            }
-                            None => {
-                                let error_msg = format!("Unknown tool: {}", tc.tool_name);
-                                let _ = tx
-                                    .send(Ok(AgentStreamEvent::ToolExecuted {
-                                        tool_name: tc.tool_name.clone(),
-                                        tool_call_id: tc.tool_call_id.clone(),
-                                        success: false,
-                                        error: Some(error_msg.clone()),
-                                    }))
-                                    .await;
-
-                                // Unknown tool - use ToolReturnPart with error
-                                let mut part = ToolReturnPart::error(
-                                    &tc.tool_name,
-                                    format!("Unknown tool: {}", tc.tool_name),
-                                );
-                                if let Some(id) = tc.tool_call_id.clone() {
-                                    part = part.with_tool_call_id(id);
-                                }
-                                tool_req.parts.push(ModelRequestPart::ToolReturn(part));
-                            }
-                        }
-                    }
-
-                    if !tool_req.parts.is_empty() {
-                        messages.push(tool_req);
-                    }
-
-                    // Continue to let model respond to tool "error"
-                    continue;
-                }
-
-                // No tool calls - check finish condition
-                if finish_reason.is_some_and(|r| r.is_complete()) {
-                    // Add final response to messages for complete history
-                    let mut response_req = ModelRequest::new();
-                    response_req
-                        .parts
-                        .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
-                    messages.push(response_req);
-
-                    finished = true;
-                    let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
-                } else if let Some(r) = finish_reason {
-                    // finish_reason is Some but NOT complete, and there were no
-                    // tool calls (the tool-call path `continue`d before reaching
-                    // here). The loop is about to silently re-issue the same
-                    // request - make that observable. NOT a behavior change:
-                    // termination is unchanged; termination-on-Length/etc. is a
-                    // separate P2 follow-up. `let _ = &r` keeps `r` "used" so the
-                    // no-op `warn!` build (tracing-integration off) stays clean.
-                    let _ = &r;
-                    warn!(
-                        finish_reason = ?r,
-                        "stream completed with a non-terminal finish reason and no tool calls; re-issuing request (this can loop - see follow-up for Length/ContentFilter/Error handling)"
-                    );
-                }
-            }
-
-            // Emit RunComplete
-            let _ = tx
-                .send(Ok(AgentStreamEvent::RunComplete {
-                    run_id: run_id_clone,
-                    messages,
-                    usage,
-                }))
-                .await;
-        });
-
-        Ok(AgentStream {
-            rx,
-            cancel_token: None,
-        })
+        Self::new_with_cancel(agent, prompt, deps, options, CancellationToken::new()).await
     }
 
     /// Create a new streaming agent run with cancellation support.
@@ -957,6 +258,10 @@ impl AgentStream {
         Deps: Send + Sync + 'static,
         Output: Send + Sync + 'static,
     {
+        let output = Arc::new(std::sync::Mutex::new(
+            None::<Box<dyn std::any::Any + Send + Sync>>,
+        ));
+        let output_writer = output.clone();
         let run_id = generate_run_id();
         let (tx, rx) = mpsc::channel(64);
 
@@ -968,570 +273,1088 @@ impl AgentStream {
             .clone()
             .unwrap_or_else(|| agent.model_settings.clone());
 
-        let static_system_prompt = agent.static_system_prompt().to_string();
+        // Share schema, validators and prompt generators with the worker.
+        let mut static_system_prompt = agent.static_system_prompt().to_string();
+        let dynamic_prompts = agent.system_prompt_fns.clone();
+        let dynamic_instructions = agent.instruction_fns.clone();
+        let output_schema = agent.output_schema.clone();
+        let output_validators = agent.output_validators.clone();
+        let max_output_retries = agent.max_output_retries;
+
         let tool_definitions = agent.tool_definitions();
         let native_output_schema = agent.native_output_schema();
         let _end_strategy = agent.end_strategy;
+        let parallel_tools = agent.parallel_tool_calls;
+        let max_concurrent_tools = agent.max_concurrent_tools;
         let usage_limits = agent.usage_limits.clone();
         let run_usage_limits = options.usage_limits.clone();
+
+        // Clone tool executors - now possible because RegisteredTool implements Clone!
         let tools: Vec<RegisteredTool<Deps>> = agent.tools.to_vec();
+
+        // Wrap deps in Arc for shared access in tool execution
         let deps = Arc::new(deps);
 
         let initial_history = options.message_history.clone();
         let _metadata = options.metadata.clone();
-        let compression_config = options.compression.clone();
+        let processors = agent.history_processors.clone();
+        let context_policy = agent.context_policy.clone();
+        let context_failure = agent.context_failure;
+        let supervisor = crate::stream_lifecycle::StreamLifecycle::new(
+            agent.checkpoint_sink.clone(),
+            run_id.clone(),
+        );
+        let checkpoint_sink: Option<Arc<dyn crate::CheckpointSink>> = Some(supervisor.clone());
+        let compression_config = if context_policy.is_some() || !processors.is_empty() {
+            None
+        } else {
+            options.compression.clone()
+        };
         let run_id_clone = run_id.clone();
-        let cancel_token_clone = cancel_token.clone();
 
-        debug!(run_id = %run_id, "AgentStream: spawning streaming task with cancellation support");
+        debug!(run_id = %run_id, "AgentStream: spawning streaming task");
 
+        // Spawn the streaming task
+        let mut initial_snapshot = initial_history.clone().unwrap_or_default();
+        let mut initial_prompt = ModelRequest::new();
+        initial_prompt.add_user_prompt(prompt.clone());
+        initial_snapshot.push(initial_prompt);
+        supervisor.update(&initial_snapshot, None, 0, &RunUsage::new());
+        let supervisor_tx = tx.clone();
+        let supervisor_token = cancel_token.clone();
         tokio::spawn(async move {
-            info!(run_id = %run_id_clone, "AgentStream: task started with cancellation support");
+            let work = async {
+                let mut validated_output = None;
+                info!(run_id = %run_id_clone, "AgentStream: task started");
 
-            // Track partial content for cancellation reporting
-            let mut accumulated_text = String::new();
-            let mut accumulated_thinking = String::new();
-            let mut pending_tool_names: Vec<String> = Vec::new();
-
-            // Emit RunStart
-            if tx
-                .send(Ok(AgentStreamEvent::RunStart {
-                    run_id: run_id_clone.clone(),
-                }))
-                .await
-                .is_err()
-            {
-                return;
-            }
-
-            // Build initial messages
-            let mut messages = initial_history.unwrap_or_default();
-
-            if !static_system_prompt.is_empty() {
-                let mut req = ModelRequest::new();
-                req.add_system_prompt(static_system_prompt.clone());
-                messages.push(req);
-            }
-
-            let mut user_req = ModelRequest::new();
-            user_req.add_user_prompt(prompt);
-            messages.push(user_req);
-
-            let mut responses: Vec<ModelResponse> = Vec::new();
-            let mut usage = RunUsage::new();
-            let mut step = 0u32;
-            let mut finished = false;
-            let mut finish_reason: Option<FinishReason>;
-
-            // Main agent loop with cancellation support
-            while !finished {
-                // Check for cancellation at the start of each iteration
-                if cancel_token_clone.is_cancelled() {
-                    info!(run_id = %run_id_clone, "AgentStream: cancelled at loop start");
-                    let _ = tx
-                        .send(Ok(AgentStreamEvent::Cancelled {
-                            partial_text: if accumulated_text.is_empty() {
-                                None
-                            } else {
-                                Some(accumulated_text)
-                            },
-                            partial_thinking: if accumulated_thinking.is_empty() {
-                                None
-                            } else {
-                                Some(accumulated_thinking)
-                            },
-                            pending_tools: pending_tool_names,
-                            usage: usage.clone(),
-                        }))
-                        .await;
-                    let _ = tx.send(Err(AgentRunError::Cancelled)).await;
-                    return;
-                }
-
-                step += 1;
-
-                // Check usage limits
-                if let Some(ref limits) = usage_limits {
-                    if let Err(e) = limits.check(&usage) {
-                        let _ = tx.send(Err(e.into())).await;
-                        return;
+                let mut policy_context =
+                    RunContext::with_shared_deps(deps.clone(), model_name.clone());
+                policy_context.run_id = run_id_clone.clone();
+                policy_context.model_settings = model_settings.clone();
+                policy_context.metadata = _metadata.clone();
+                for prompt in &dynamic_prompts {
+                    if let Some(text) = prompt.generate(&policy_context).await {
+                        if !text.is_empty() {
+                            static_system_prompt.push_str("\n\n");
+                            static_system_prompt.push_str(&text);
+                        }
                     }
                 }
-
-                if let Some(ref limits) = run_usage_limits {
-                    if let Err(e) = limits.check(&usage) {
-                        let _ = tx.send(Err(e.into())).await;
-                        return;
+                for instruction in &dynamic_instructions {
+                    if let Some(text) = instruction.generate(&policy_context).await {
+                        if !text.is_empty() {
+                            static_system_prompt.push_str("\n\n");
+                            static_system_prompt.push_str(&text);
+                        }
                     }
                 }
-
+                let mut output_retries = 0u32;
+                // Emit RunStart
+                debug!("AgentStream: emitting RunStart");
                 if tx
-                    .send(Ok(AgentStreamEvent::RequestStart { step }))
+                    .send(Ok(AgentStreamEvent::RunStart {
+                        run_id: run_id_clone.clone(),
+                    }))
                     .await
                     .is_err()
                 {
+                    warn!("AgentStream: receiver dropped before RunStart");
                     return;
                 }
 
-                let mut params = ModelRequestParameters::new()
-                    .with_tools_arc(tool_definitions.clone())
-                    .with_allow_text(true);
+                // Build initial messages
+                let mut messages = initial_history.unwrap_or_default();
+                debug!(
+                    initial_messages = messages.len(),
+                    "AgentStream: building messages"
+                );
 
-                // Carry the structured-output request to the provider, as the
-                // blocking path does.
-                if let Some(schema) = native_output_schema.clone() {
-                    params = params.with_output_schema(schema);
+                // Add system prompt if non-empty
+                if !static_system_prompt.is_empty() {
+                    let mut req = ModelRequest::new();
+                    req.add_system_prompt(static_system_prompt.clone());
+                    messages.push(req);
                 }
 
-                // Context size calculation (simplified - full version in main new())
-                let (request_bytes, estimated_tokens) = {
-                    let messages_json = serde_json::to_string(&messages).unwrap_or_default();
-                    let tools_json = serde_json::to_string(&*tool_definitions).unwrap_or_default();
-                    let bytes = messages_json.len() + tools_json.len();
-                    (bytes, bytes / 4)
-                };
+                // Add user prompt
+                let mut user_req = ModelRequest::new();
+                user_req.add_user_prompt(prompt);
+                messages.push(user_req);
+                supervisor.update(&messages, None, 0, &RunUsage::new());
 
-                let context_limit = model.profile().context_window;
+                let mut responses: Vec<ModelResponse> = Vec::new();
+                let mut usage = RunUsage::new();
+                let mut step = 0u32;
+                let mut finished = false;
+                let mut finish_reason: Option<FinishReason>;
 
-                let _ = tx
-                    .send(Ok(AgentStreamEvent::ContextInfo {
-                        estimated_tokens,
-                        request_bytes,
-                        context_limit,
-                    }))
-                    .await;
+                // Main agent loop
+                while !finished {
+                    step += 1;
 
-                // Context compression (simplified version)
-                if let Some(ref compression) = compression_config {
-                    if let Some(limit) = context_limit {
-                        let threshold_tokens = (limit as f64 * compression.threshold) as usize;
-                        if estimated_tokens > threshold_tokens {
-                            use crate::history::{HistoryProcessor, TruncateByTokens};
-                            let truncator = TruncateByTokens::new(compression.target_tokens as u64)
-                                .keep_first_n(2);
-                            let temp_ctx = RunContext::new((), &model_name);
-                            messages = truncator.process(&temp_ctx, messages).await;
-                        }
-                    }
-                }
-
-                // Make streaming request with cancellation support
-                let stream_result = model
-                    .request_stream(&messages, &model_settings, &params)
-                    .await;
-
-                let mut model_stream = match stream_result {
-                    Ok(s) => s,
-                    Err(e) => {
-                        let _ = tx
-                            .send(Ok(AgentStreamEvent::Error {
-                                message: e.to_string(),
-                            }))
-                            .await;
-                        let _ = tx.send(Err(AgentRunError::Model(e))).await;
-                        return;
-                    }
-                };
-
-                let mut response_parts: Vec<ModelResponsePart> = Vec::new();
-
-                // Provider-reported finish reason (set by StreamComplete event)
-                let mut stream_finish_reason: Option<FinishReason> = None;
-                let mut stream_usage: Option<RequestUsage> = None;
-
-                // Process stream events with cancellation check
-                loop {
-                    tokio::select! {
-                        biased;
-
-                        _ = cancel_token_clone.cancelled() => {
-                            info!(run_id = %run_id_clone, "AgentStream: cancelled during model stream");
-                            let _ = tx
-                                .send(Ok(AgentStreamEvent::Cancelled {
-                                    partial_text: if accumulated_text.is_empty() {
-                                        None
-                                    } else {
-                                        Some(accumulated_text)
-                                    },
-                                    partial_thinking: if accumulated_thinking.is_empty() {
-                                        None
-                                    } else {
-                                        Some(accumulated_thinking)
-                                    },
-                                    pending_tools: pending_tool_names,
-                                    usage: usage.clone(),
-                                }))
-                                .await;
-                            let _ = tx.send(Err(AgentRunError::Cancelled)).await;
+                    // Check usage limits
+                    if let Some(ref limits) = usage_limits {
+                        if let Err(e) = limits.check(&usage) {
+                            checkpoint!(
+                                checkpoint_sink,
+                                run_id_clone,
+                                step,
+                                CheckpointBoundary::Failed,
+                                messages,
+                                responses.last(),
+                                usage,
+                                tx
+                            );
+                            let _ = tx.send(Err(e.into())).await;
                             return;
                         }
+                    }
 
-                        event_result = model_stream.next() => {
-                            match event_result {
-                                Some(Ok(event)) => {
-                                    match event {
-                                        ModelResponseStreamEvent::PartStart(start) => {
-                                            match &start.part {
-                                                ModelResponsePart::Text(t) => {
-                                                    if !t.content.is_empty() {
-                                                        accumulated_text.push_str(&t.content);
-                                                        let _ = tx
-                                                            .send(Ok(AgentStreamEvent::TextDelta {
-                                                                text: t.content.clone(),
-                                                            }))
-                                                            .await;
-                                                    }
-                                                }
-                                                ModelResponsePart::ToolCall(tc) => {
-                                                    pending_tool_names.push(tc.tool_name.clone());
-                                                    let _ = tx
-                                                        .send(Ok(AgentStreamEvent::ToolCallStart {
-                                                            tool_name: tc.tool_name.clone(),
-                                                            tool_call_id: tc.tool_call_id.clone(),
-                                                        }))
-                                                        .await;
-                                                    if let Ok(args_str) = tc.args.to_json_string() {
-                                                        if !args_str.is_empty() && args_str != "{}" {
-                                                            let _ = tx
-                                                                .send(Ok(AgentStreamEvent::ToolCallDelta {
-                                                                    delta: args_str,
-                                                                    tool_call_id: tc.tool_call_id.clone(),
-                                                                }))
-                                                                .await;
+                    if let Some(ref limits) = run_usage_limits {
+                        if let Err(e) = limits.check(&usage) {
+                            checkpoint!(
+                                checkpoint_sink,
+                                run_id_clone,
+                                step,
+                                CheckpointBoundary::Failed,
+                                messages,
+                                responses.last(),
+                                usage,
+                                tx
+                            );
+                            let _ = tx.send(Err(e.into())).await;
+                            return;
+                        }
+                    }
+
+                    // Emit RequestStart
+                    if tx
+                        .send(Ok(AgentStreamEvent::RequestStart { step }))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+
+                    // Build request parameters
+                    let mut params = ModelRequestParameters::new()
+                        .with_tools_arc(tool_definitions.clone())
+                        .with_allow_text(true);
+
+                    // Carry the structured-output request to the provider, as the
+                    // blocking path does.
+                    if let Some(schema) = native_output_schema.clone() {
+                        params = params.with_output_schema(schema);
+                    }
+
+                    // === Context Size Calculation & Compression ===
+
+                    // Calculate context size by serializing (this is the actual request size)
+                    let (request_bytes, estimated_tokens) = {
+                        let messages_json = serde_json::to_string(&messages).unwrap_or_default();
+                        let tools_json =
+                            serde_json::to_string(&*tool_definitions).unwrap_or_default();
+                        let bytes = messages_json.len() + tools_json.len();
+                        (bytes, bytes / 4)
+                    };
+
+                    // Get context limit from model profile
+                    let context_limit = model.profile().context_window;
+
+                    // Emit ContextInfo event
+                    let _ = tx
+                        .send(Ok(AgentStreamEvent::ContextInfo {
+                            estimated_tokens,
+                            request_bytes,
+                            context_limit,
+                        }))
+                        .await;
+
+                    // Check if compression is needed
+                    if let Some(ref compression) = compression_config {
+                        if let Some(limit) = context_limit {
+                            let threshold_tokens = (limit as f64 * compression.threshold) as usize;
+
+                            if estimated_tokens > threshold_tokens {
+                                let messages_before = messages.len();
+                                let original_tokens = estimated_tokens;
+
+                                // Apply compression based on strategy
+                                let strategy_name = match compression.strategy {
+                                    CompressionStrategy::Truncate => {
+                                        // Use TruncateByTokens with keep_first_n=2 (system + first user)
+                                        use crate::history::{HistoryProcessor, TruncateByTokens};
+                                        let truncator =
+                                            TruncateByTokens::new(compression.target_tokens as u64)
+                                                .keep_first_n(2);
+
+                                        // Create a minimal context for the processor
+                                        let temp_ctx = RunContext::new((), &model_name);
+                                        messages = truncator.process(&temp_ctx, messages).await;
+                                        "truncate"
+                                    }
+                                    CompressionStrategy::Summarize
+                                    | CompressionStrategy::SummarizeOrTruncate => {
+                                        // Use the same model to summarize the conversation history
+                                        // Keep first 2 messages (system + first user) and last few messages
+                                        // Summarize everything in between
+
+                                        if messages.len() <= 4 {
+                                            // Too few messages to summarize, just truncate
+                                            use crate::history::{
+                                                HistoryProcessor, TruncateByTokens,
+                                            };
+                                            let truncator = TruncateByTokens::new(
+                                                compression.target_tokens as u64,
+                                            )
+                                            .keep_first_n(2);
+                                            let temp_ctx = RunContext::new((), &model_name);
+                                            messages = truncator.process(&temp_ctx, messages).await;
+                                            "truncate (too few messages)"
+                                        } else {
+                                            // Split messages: first 2 (keep), middle (summarize), last 2 (keep)
+                                            let first_two: Vec<_> =
+                                                messages.iter().take(2).cloned().collect();
+                                            let last_two: Vec<_> = messages
+                                                .iter()
+                                                .rev()
+                                                .take(2)
+                                                .cloned()
+                                                .collect::<Vec<_>>()
+                                                .into_iter()
+                                                .rev()
+                                                .collect();
+                                            let middle: Vec<_> = messages
+                                                .iter()
+                                                .skip(2)
+                                                .take(messages.len().saturating_sub(4))
+                                                .cloned()
+                                                .collect();
+
+                                            if middle.is_empty() {
+                                                // Nothing to summarize
+                                                "summarize (nothing to compress)"
+                                            } else {
+                                                // Build summarization prompt
+                                                let middle_json =
+                                                    serde_json::to_string_pretty(&middle)
+                                                        .unwrap_or_default();
+                                                let summary_prompt = format!(
+                                                    "Condense this conversation history into a brief summary while preserving:\n\
+                                                - Key decisions and conclusions\n\
+                                                - Important information discovered\n\
+                                                - Tool calls made and their essential results\n\
+                                                - Any errors or issues encountered\n\n\
+                                                Keep the summary concise but complete enough to continue the conversation.\n\n\
+                                                Conversation to summarize:\n{}\n\n\
+                                                Respond with ONLY the summary, no preamble.",
+                                                    middle_json
+                                                );
+
+                                                // Create a minimal request for summarization
+                                                let mut summary_req = ModelRequest::new();
+                                                summary_req.add_user_prompt(summary_prompt);
+
+                                                // Call the model (non-streaming for simplicity)
+                                                let summary_params = ModelRequestParameters::new();
+                                                match tokio::time::timeout(model_settings.timeout.unwrap_or(std::time::Duration::from_secs(30)), model
+                                                .request(
+                                                    &[summary_req],
+                                                    &model_settings,
+                                                    &summary_params,
+                                                )).await.unwrap_or_else(|_| Err(serdes_ai_models::ModelError::incomplete_stream("summary deadline exceeded")))
+                                            {
+                                                Ok(response) => {
+                                                    if let Some(summary_usage) = &response.usage { usage.add_request(summary_usage.clone()); } else { usage.record_request(); }
+                                                    // Extract text from response
+                                                    let summary_text = response
+                                                        .parts
+                                                        .iter()
+                                                        .filter_map(|p| match p {
+                                                            ModelResponsePart::Text(t) => {
+                                                                Some(t.content.clone())
+                                                            }
+                                                            _ => None,
+                                                        })
+                                                        .collect::<Vec<_>>()
+                                                        .join("\n");
+
+                                                    if !summary_text.is_empty() {
+                                                        // Build new message list: first 2 + summary + last 2
+                                                        let mut new_messages = first_two;
+
+                                                        // Add summary as a "previous context" message
+                                                        let mut summary_msg = ModelRequest::new();
+                                                        summary_msg.add_user_prompt(format!(
+                                                            "[Previous conversation summary]\n{}\n[End of summary - continuing conversation]",
+                                                            summary_text
+                                                        ));
+                                                        new_messages.push(summary_msg);
+
+                                                        new_messages.extend(last_two);
+                                                        messages = new_messages;
+                                                        "summarize"
+                                                    } else {
+                                                        if !matches!(compression.strategy, CompressionStrategy::SummarizeOrTruncate) {
+                                                            checkpoint!(checkpoint_sink, run_id_clone, step, CheckpointBoundary::Failed, messages, responses.last(), usage, tx);
+                                                            let _ = tx.try_send(Err(AgentRunError::ContextPolicy("Summary returned no text".into())));
+                                                            return;
                                                         }
+                                                        // Explicit compatibility fallback
+                                                        use crate::history::{
+                                                            HistoryProcessor, TruncateByTokens,
+                                                        };
+                                                        let truncator = TruncateByTokens::new(
+                                                            compression.target_tokens as u64,
+                                                        )
+                                                        .keep_first_n(2);
+                                                        let temp_ctx =
+                                                            RunContext::new((), &model_name);
+                                                        messages = truncator
+                                                            .process(&temp_ctx, messages)
+                                                            .await;
+                                                        "truncate (summary empty)"
                                                     }
                                                 }
-                                                ModelResponsePart::Thinking(t)
-                                                    if !t.content.is_empty() =>
-                                                {
-                                                    accumulated_thinking.push_str(&t.content);
+                                                Err(_e) => {
+                                                    usage.record_request();
+                                                    if !matches!(compression.strategy, CompressionStrategy::SummarizeOrTruncate) {
+                                                        checkpoint!(checkpoint_sink, run_id_clone, step, CheckpointBoundary::Failed, messages, responses.last(), usage, tx);
+                                                        let _ = tx.try_send(Err(AgentRunError::ContextPolicy("Summary request failed".into())));
+                                                        return;
+                                                    }
+                                                    use crate::history::{
+                                                        HistoryProcessor, TruncateByTokens,
+                                                    };
+                                                    let truncator = TruncateByTokens::new(
+                                                        compression.target_tokens as u64,
+                                                    )
+                                                    .keep_first_n(2);
+                                                    let temp_ctx = RunContext::new((), &model_name);
+                                                    messages = truncator
+                                                        .process(&temp_ctx, messages)
+                                                        .await;
+                                                    "truncate (summary failed)"
+                                                }
+                                            }
+                                            }
+                                        }
+                                    }
+                                };
+
+                                // Calculate new size
+                                let new_bytes = serde_json::to_string(&messages)
+                                    .map(|s| s.len())
+                                    .unwrap_or(0);
+                                let compressed_tokens = new_bytes / 4;
+
+                                // Emit compression event
+                                let _ = tx
+                                    .send(Ok(AgentStreamEvent::ContextCompressed {
+                                        original_tokens,
+                                        compressed_tokens,
+                                        strategy: strategy_name.to_string(),
+                                        messages_before,
+                                        messages_after: messages.len(),
+                                    }))
+                                    .await;
+                            }
+                        }
+                    }
+                    // === End Context Compression ===
+
+                    for limits in [usage_limits.as_ref(), run_usage_limits.as_ref()]
+                        .into_iter()
+                        .flatten()
+                    {
+                        if let Err(error) = limits.check(&usage) {
+                            checkpoint!(
+                                checkpoint_sink,
+                                run_id_clone,
+                                step,
+                                CheckpointBoundary::Failed,
+                                messages,
+                                responses.last(),
+                                usage,
+                                tx
+                            );
+                            let _ = tx.try_send(Err(error.into()));
+                            return;
+                        }
+                    }
+                    // Make streaming request
+                    info!(
+                        step = step,
+                        message_count = messages.len(),
+                        "AgentStream: calling model.request_stream"
+                    );
+                    if let Err(error) = lifecycle::prepare(
+                        &processors,
+                        context_policy.as_ref(),
+                        context_failure,
+                        ContextPolicyInput {
+                            context: &policy_context,
+                            settings: &model_settings,
+                            parameters: &params,
+                            model: model.as_ref(),
+                        },
+                        &mut messages,
+                    )
+                    .await
+                    {
+                        checkpoint!(
+                            checkpoint_sink,
+                            run_id_clone,
+                            step,
+                            CheckpointBoundary::Failed,
+                            messages,
+                            responses.last(),
+                            usage,
+                            tx
+                        );
+                        let _ = tx.send(Err(error)).await;
+                        return;
+                    }
+                    checkpoint!(
+                        checkpoint_sink,
+                        run_id_clone,
+                        step,
+                        CheckpointBoundary::BeforeRequest,
+                        messages,
+                        None,
+                        usage,
+                        tx
+                    );
+                    let stream_result = model
+                        .request_stream(&messages, &model_settings, &params)
+                        .await;
+
+                    let mut partial_timer = lifecycle::partial_timer(checkpoint_sink.as_ref());
+                    let mut partial_response = ModelResponse::with_parts(Vec::new());
+                    let mut model_stream = match stream_result {
+                        Ok(s) => {
+                            debug!("AgentStream: model.request_stream succeeded, got stream");
+                            s
+                        }
+                        Err(e) => {
+                            error!(error = %e, "AgentStream: model.request_stream failed");
+                            let _ = tx
+                                .send(Ok(AgentStreamEvent::Error {
+                                    message: e.to_string(),
+                                }))
+                                .await;
+                            checkpoint!(
+                                checkpoint_sink,
+                                run_id_clone,
+                                step,
+                                CheckpointBoundary::ModelFailed(e.model_failure().kind),
+                                messages,
+                                Some(&partial_response),
+                                usage,
+                                tx
+                            );
+                            let _ = tx.send(Err(AgentRunError::Model(e))).await;
+                            return;
+                        }
+                    };
+
+                    // Collect response parts while streaming
+                    let mut response_parts: Vec<ModelResponsePart> = Vec::new();
+                    // Track stream events (used by tracing when enabled)
+                    let mut stream_event_count = 0u32;
+                    // Provider-reported finish reason (set by StreamComplete event)
+                    let mut stream_finish_reason: Option<FinishReason> = None;
+                    let mut stream_usage: Option<RequestUsage> = None;
+                    let mut terminal_metadata = None;
+
+                    // Process stream events
+                    debug!("AgentStream: starting to process model stream events");
+                    loop {
+                        partial_response.parts = response_parts.clone();
+                        partial_response.usage = stream_usage.clone();
+                        partial_response.finish_reason = stream_finish_reason;
+                        supervisor.update(&messages, Some(&partial_response), step, &usage);
+                        let event_result = tokio::select! {
+                            _ = partial_timer.tick(), if checkpoint_sink.as_ref().is_some_and(|sink| sink.partial_interval().is_some()) => {
+                                checkpoint!(checkpoint_sink, run_id_clone, step, CheckpointBoundary::Partial,
+                                    messages, Some(&partial_response), usage, tx);
+                                continue;
+                            }
+                            event = model_stream.next() => event,
+                        };
+                        let Some(event_result) = event_result else {
+                            break;
+                        };
+                        {
+                            stream_event_count += 1;
+                            let _ = stream_event_count;
+                        }
+                        match event_result {
+                            Ok(event) => {
+                                lifecycle::apply_partial(&mut partial_response, &event);
+                                supervisor.update(&messages, Some(&partial_response), step, &usage);
+                                match event {
+                                    ModelResponseStreamEvent::PartStart(start) => {
+                                        match &start.part {
+                                            ModelResponsePart::Text(t) => {
+                                                if !t.content.is_empty() {
                                                     let _ = tx
-                                                        .send(Ok(AgentStreamEvent::ThinkingDelta {
+                                                        .send(Ok(AgentStreamEvent::TextDelta {
                                                             text: t.content.clone(),
                                                         }))
                                                         .await;
                                                 }
-                                                _ => {}
                                             }
-                                            response_parts.push(start.part.clone());
-                                        }
-                                        ModelResponseStreamEvent::PartDelta(delta) => {
-                                            use serdes_ai_core::messages::ModelResponsePartDelta;
-                                            match &delta.delta {
-                                                ModelResponsePartDelta::Text(t) => {
-                                                    accumulated_text.push_str(&t.content_delta);
-                                                    let _ = tx
-                                                        .send(Ok(AgentStreamEvent::TextDelta {
-                                                            text: t.content_delta.clone(),
-                                                        }))
-                                                        .await;
-                                                    if let Some(ModelResponsePart::Text(text)) =
-                                                        response_parts.get_mut(delta.index)
-                                                    {
-                                                        text.content.push_str(&t.content_delta);
+                                            ModelResponsePart::ToolCall(tc) => {
+                                                let _ = tx
+                                                    .send(Ok(AgentStreamEvent::ToolCallStart {
+                                                        tool_name: tc.tool_name.clone(),
+                                                        tool_call_id: tc.tool_call_id.clone(),
+                                                    }))
+                                                    .await;
+                                                // If args are already present (non-streaming models),
+                                                // send them as a delta immediately
+                                                if let Ok(args_str) = tc.args.to_json_string() {
+                                                    if !args_str.is_empty() && args_str != "{}" {
+                                                        let _ = tx
+                                                            .send(Ok(
+                                                                AgentStreamEvent::ToolCallDelta {
+                                                                    delta: args_str,
+                                                                    tool_call_id: tc
+                                                                        .tool_call_id
+                                                                        .clone(),
+                                                                },
+                                                            ))
+                                                            .await;
                                                     }
                                                 }
-                                                ModelResponsePartDelta::ToolCall(tc) => {
-                                                    let tool_call_id =
-                                                        response_parts.get(delta.index).and_then(|p| {
-                                                            if let ModelResponsePart::ToolCall(tc) = p {
-                                                                tc.tool_call_id.clone()
-                                                            } else {
-                                                                None
-                                                            }
-                                                        });
-                                                    let _ = tx
-                                                        .send(Ok(AgentStreamEvent::ToolCallDelta {
-                                                            delta: tc.args_delta.clone(),
-                                                            tool_call_id,
-                                                        }))
-                                                        .await;
-                                                    if let Some(ModelResponsePart::ToolCall(
-                                                        tool_call,
-                                                    )) = response_parts.get_mut(delta.index)
-                                                    {
-                                                        tc.apply(tool_call);
-                                                    }
-                                                }
-                                                ModelResponsePartDelta::Thinking(t) => {
-                                                    accumulated_thinking.push_str(&t.content_delta);
-                                                    let _ = tx
-                                                        .send(Ok(AgentStreamEvent::ThinkingDelta {
-                                                            text: t.content_delta.clone(),
-                                                        }))
-                                                        .await;
-                                                    if let Some(ModelResponsePart::Thinking(
-                                                        think,
-                                                    )) = response_parts.get_mut(delta.index)
-                                                    {
-                                                        t.apply(think);
-                                                    }
-                                                }
-                                                _ => {}
                                             }
+                                            ModelResponsePart::Thinking(t)
+                                                if !t.content.is_empty() =>
+                                            {
+                                                let _ = tx
+                                                    .send(Ok(AgentStreamEvent::ThinkingDelta {
+                                                        text: t.content.clone(),
+                                                    }))
+                                                    .await;
+                                            }
+                                            _ => {}
                                         }
-                                        ModelResponseStreamEvent::PartEnd(_) => {}
-                                        ModelResponseStreamEvent::StreamComplete(sc) => {
-                                            stream_finish_reason = Some(sc.finish_reason);
-                                            stream_usage = usage_from_stream_complete(&sc);
+                                        response_parts.push(start.part.clone());
+                                    }
+                                    ModelResponseStreamEvent::PartDelta(delta) => {
+                                        use serdes_ai_core::messages::ModelResponsePartDelta;
+                                        match &delta.delta {
+                                            ModelResponsePartDelta::Text(t) => {
+                                                let _ = tx
+                                                    .send(Ok(AgentStreamEvent::TextDelta {
+                                                        text: t.content_delta.clone(),
+                                                    }))
+                                                    .await;
+                                                // Update the part
+                                                if let Some(ModelResponsePart::Text(text)) =
+                                                    response_parts.get_mut(delta.index)
+                                                {
+                                                    text.content.push_str(&t.content_delta);
+                                                }
+                                            }
+                                            ModelResponsePartDelta::ToolCall(tc) => {
+                                                // Get tool_call_id from the existing response part
+                                                let tool_call_id =
+                                                    response_parts.get(delta.index).and_then(|p| {
+                                                        if let ModelResponsePart::ToolCall(tc) = p {
+                                                            tc.tool_call_id.clone()
+                                                        } else {
+                                                            None
+                                                        }
+                                                    });
+                                                let _ = tx
+                                                    .send(Ok(AgentStreamEvent::ToolCallDelta {
+                                                        delta: tc.args_delta.clone(),
+                                                        tool_call_id,
+                                                    }))
+                                                    .await;
+                                                // Update args - accumulate the delta into the tool call
+                                                if let Some(ModelResponsePart::ToolCall(
+                                                    tool_call,
+                                                )) = response_parts.get_mut(delta.index)
+                                                {
+                                                    tc.apply(tool_call);
+                                                }
+                                            }
+                                            ModelResponsePartDelta::Thinking(t) => {
+                                                let _ = tx
+                                                    .send(Ok(AgentStreamEvent::ThinkingDelta {
+                                                        text: t.content_delta.clone(),
+                                                    }))
+                                                    .await;
+                                                if let Some(ModelResponsePart::Thinking(think)) =
+                                                    response_parts.get_mut(delta.index)
+                                                {
+                                                    t.apply(think);
+                                                }
+                                            }
+                                            _ => {}
                                         }
                                     }
-                                }
-                                Some(Err(e)) => {
-                                    let _ = tx
-                                        .send(Ok(AgentStreamEvent::Error {
-                                            message: e.to_string(),
-                                        }))
-                                        .await;
-                                    let _ = tx.send(Err(AgentRunError::Model(e))).await;
-                                    return;
-                                }
-                                None => {
-                                    // Stream ended normally
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // A stream may legitimately end without an explicit terminal StreamComplete
-                // (in-memory/mock streams, and OpenAI/Google/etc. parsers which never emit one).
-                // Anthropic's parser surfaces REAL truncation separately as an explicit Err
-                // (handled above), so a clean end here with content is a successful completion.
-                // Default the finish reason to Stop. (The `response_parts.is_empty()` guard in
-                // the next block still catches a stream that produced nothing.)
-                if stream_finish_reason.is_none() {
-                    debug!(
-                        parts = response_parts.len(),
-                        "stream ended without terminal StreamComplete; defaulting finish_reason=Stop"
-                    );
-                }
-                let stream_finish_reason = stream_finish_reason.unwrap_or(FinishReason::Stop);
-
-                // If the stream produced no parts at all, treat it as an error
-                if response_parts.is_empty() {
-                    let _ = tx
-                        .send(Ok(AgentStreamEvent::Error {
-                            message: "model stream ended without producing any content".to_string(),
-                        }))
-                        .await;
-                    let _ = tx
-                        .send(Err(AgentRunError::Model(
-                            serdes_ai_models::ModelError::incomplete_stream(
-                                "model stream ended without producing any content",
-                            ),
-                        )))
-                        .await;
-                    return;
-                }
-
-                // Build the complete response using the provider-reported finish reason
-                let mut response = ModelResponse {
-                    parts: response_parts.clone(),
-                    model_name: Some(model.name().to_string()),
-                    timestamp: Utc::now(),
-                    finish_reason: Some(stream_finish_reason),
-                    usage: stream_usage,
-                    vendor_id: None,
-                    vendor_details: None,
-                    kind: "response".to_string(),
-                };
-                canonicalize_tool_call_args_in_response(&mut response);
-
-                finish_reason = response.finish_reason;
-                responses.push(response.clone());
-
-                // Accumulate run-wide usage, mirroring the non-streaming run()
-                // path so streaming and non-streaming agree. The request is
-                // counted either way, so max_requests bounds the loop even
-                // against a provider that reports no usage.
-                match &response.usage {
-                    Some(u) => usage.add_request(u.clone()),
-                    None => usage.record_request(),
-                }
-
-                let _ = tx
-                    .send(Ok(AgentStreamEvent::ResponseComplete {
-                        step,
-                        usage: response.usage.clone(),
-                    }))
-                    .await;
-
-                // Check for tool calls
-                let tool_calls: Vec<_> = response
-                    .parts
-                    .iter()
-                    .filter_map(|p| {
-                        if let ModelResponsePart::ToolCall(tc) = p {
-                            Some(tc.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-
-                if !tool_calls.is_empty() {
-                    let mut response_req = ModelRequest::new();
-                    response_req
-                        .parts
-                        .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
-                    messages.push(response_req);
-
-                    let mut tool_req = ModelRequest::new();
-
-                    for tc in tool_calls {
-                        // Check for cancellation before each tool execution
-                        if cancel_token_clone.is_cancelled() {
-                            info!(run_id = %run_id_clone, "AgentStream: cancelled before tool execution");
-                            let _ = tx
-                                .send(Ok(AgentStreamEvent::Cancelled {
-                                    partial_text: if accumulated_text.is_empty() {
-                                        None
-                                    } else {
-                                        Some(accumulated_text)
-                                    },
-                                    partial_thinking: if accumulated_thinking.is_empty() {
-                                        None
-                                    } else {
-                                        Some(accumulated_thinking)
-                                    },
-                                    pending_tools: pending_tool_names,
-                                    usage: usage.clone(),
-                                }))
-                                .await;
-                            let _ = tx.send(Err(AgentRunError::Cancelled)).await;
-                            return;
-                        }
-
-                        let _ = tx
-                            .send(Ok(AgentStreamEvent::ToolCallComplete {
-                                tool_name: tc.tool_name.clone(),
-                                tool_call_id: tc.tool_call_id.clone(),
-                            }))
-                            .await;
-
-                        usage.record_tool_call();
-                        // Remove from pending after completion
-                        pending_tool_names.retain(|n| n != &tc.tool_name);
-
-                        let tool = tools.iter().find(|t| t.definition.name == tc.tool_name);
-
-                        match tool {
-                            Some(tool) => {
-                                let tool_ctx =
-                                    RunContext::with_shared_deps(deps.clone(), model_name.clone())
-                                        .for_tool(&tc.tool_name, tc.tool_call_id.clone());
-
-                                let result =
-                                    tool.executor.execute(tc.args.to_json(), &tool_ctx).await;
-
-                                match result {
-                                    Ok(ret) => {
-                                        let _ = tx
-                                            .send(Ok(AgentStreamEvent::ToolExecuted {
-                                                tool_name: tc.tool_name.clone(),
-                                                tool_call_id: tc.tool_call_id.clone(),
-                                                success: true,
-                                                error: None,
-                                            }))
-                                            .await;
-
-                                        let mut part =
-                                            ToolReturnPart::new(&tc.tool_name, ret.content);
-                                        if let Some(id) = tc.tool_call_id.clone() {
-                                            part = part.with_tool_call_id(id);
-                                        }
-                                        tool_req.parts.push(ModelRequestPart::ToolReturn(part));
+                                    ModelResponseStreamEvent::PartEnd(_) => {
+                                        // Part finished
                                     }
-                                    Err(e) => {
-                                        let error_msg = e.to_string();
-                                        let _ = tx
-                                            .send(Ok(AgentStreamEvent::ToolExecuted {
-                                                tool_name: tc.tool_name.clone(),
-                                                tool_call_id: tc.tool_call_id.clone(),
-                                                success: false,
-                                                error: Some(error_msg.clone()),
-                                            }))
-                                            .await;
-
-                                        let mut part = ToolReturnPart::error(
-                                            &tc.tool_name,
-                                            format!("Tool error: {}", e),
-                                        );
-                                        if let Some(id) = tc.tool_call_id.clone() {
-                                            part = part.with_tool_call_id(id);
-                                        }
-                                        tool_req.parts.push(ModelRequestPart::ToolReturn(part));
+                                    ModelResponseStreamEvent::StreamComplete(sc) => {
+                                        stream_finish_reason = Some(sc.finish_reason);
+                                        stream_usage = usage_from_stream_complete(&sc);
+                                        terminal_metadata = sc.metadata.clone();
                                     }
                                 }
                             }
-                            None => {
-                                let error_msg = format!("Unknown tool: {}", tc.tool_name);
+                            Err(e) => {
                                 let _ = tx
-                                    .send(Ok(AgentStreamEvent::ToolExecuted {
-                                        tool_name: tc.tool_name.clone(),
-                                        tool_call_id: tc.tool_call_id.clone(),
-                                        success: false,
-                                        error: Some(error_msg.clone()),
+                                    .send(Ok(AgentStreamEvent::Error {
+                                        message: e.to_string(),
                                     }))
                                     .await;
-
-                                let mut part = ToolReturnPart::error(
-                                    &tc.tool_name,
-                                    format!("Unknown tool: {}", tc.tool_name),
+                                checkpoint!(
+                                    checkpoint_sink,
+                                    run_id_clone,
+                                    step,
+                                    CheckpointBoundary::ModelFailed(e.model_failure().kind),
+                                    messages,
+                                    Some(&partial_response),
+                                    usage,
+                                    tx
                                 );
-                                if let Some(id) = tc.tool_call_id.clone() {
-                                    part = part.with_tool_call_id(id);
-                                }
-                                tool_req.parts.push(ModelRequestPart::ToolReturn(part));
+                                let _ = tx.send(Err(AgentRunError::Model(e))).await;
+                                return;
                             }
                         }
                     }
 
-                    if !tool_req.parts.is_empty() {
-                        messages.push(tool_req);
+                    info!(
+                        stream_events = stream_event_count,
+                        parts = response_parts.len(),
+                        "AgentStream: finished processing model stream"
+                    );
+
+                    // A stream may legitimately end without an explicit terminal StreamComplete
+                    // (in-memory/mock streams, and OpenAI/Google/etc. parsers which never emit one).
+                    // Anthropic's parser surfaces REAL truncation separately as an explicit Err
+                    // (handled above), so a clean end here with content is a successful completion.
+                    // Default the finish reason to Stop. (The `response_parts.is_empty()` guard in
+                    // the next block still catches a stream that produced nothing.)
+                    if stream_finish_reason.is_none() {
+                        debug!(
+                            parts = response_parts.len(),
+                            "stream ended without terminal StreamComplete; defaulting finish_reason=Stop"
+                        );
+                    }
+                    let stream_finish_reason = stream_finish_reason.unwrap_or(FinishReason::Stop);
+
+                    // If the stream produced no parts at all, treat it as an error
+                    if response_parts.is_empty() && terminal_metadata.is_none() {
+                        checkpoint!(
+                            checkpoint_sink,
+                            run_id_clone,
+                            step,
+                            CheckpointBoundary::ModelFailed(
+                                serdes_ai_core::ModelFailureKind::IncompleteStream
+                            ),
+                            messages,
+                            Some(&partial_response),
+                            usage,
+                            tx
+                        );
+                        let _ = tx
+                            .send(Ok(AgentStreamEvent::Error {
+                                message: "model stream ended without producing any content"
+                                    .to_string(),
+                            }))
+                            .await;
+                        let _ = tx
+                            .send(Err(AgentRunError::Model(
+                                serdes_ai_models::ModelError::incomplete_stream(
+                                    "model stream ended without producing any content",
+                                ),
+                            )))
+                            .await;
+                        return;
                     }
 
-                    continue;
-                }
+                    // Build the complete response using the provider-reported finish reason
+                    let mut response = ModelResponse {
+                        parts: response_parts.clone(),
+                        model_name: Some(model.name().to_string()),
+                        timestamp: Utc::now(),
+                        finish_reason: Some(stream_finish_reason),
+                        usage: stream_usage,
+                        vendor_id: None,
+                        vendor_details: None,
+                        kind: "response".to_string(),
+                    };
+                    if let Some(metadata) = &terminal_metadata {
+                        metadata.apply(&mut response);
+                    }
+                    // Accumulate run-wide usage, mirroring the non-streaming run()
+                    // path so streaming and non-streaming agree. The request is
+                    // counted either way, so max_requests bounds the loop even
+                    // against a provider that reports no usage.
+                    match &response.usage {
+                        Some(u) => usage.add_request(u.clone()),
+                        None => usage.record_request(),
+                    }
 
-                if finish_reason.is_some_and(|r| r.is_complete()) {
-                    // Add final response to messages for complete history
-                    let mut response_req = ModelRequest::new();
-                    response_req
-                        .parts
-                        .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
-                    messages.push(response_req);
-
-                    finished = true;
-                    let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
-                } else if let Some(r) = finish_reason {
-                    // finish_reason is Some but NOT complete, and there were no
-                    // tool calls (the tool-call path `continue`d before reaching
-                    // here). The loop is about to silently re-issue the same
-                    // request - make that observable. NOT a behavior change:
-                    // termination is unchanged; termination-on-Length/etc. is a
-                    // separate P2 follow-up. `let _ = &r` keeps `r` "used" so the
-                    // no-op `warn!` build (tracing-integration off) stays clean.
-                    let _ = &r;
-                    warn!(
-                        finish_reason = ?r,
-                        "stream completed with a non-terminal finish reason and no tool calls; re-issuing request (this can loop - see follow-up for Length/ContentFilter/Error handling)"
+                    checkpoint!(
+                        checkpoint_sink,
+                        run_id_clone,
+                        step,
+                        CheckpointBoundary::AfterResponse,
+                        messages,
+                        Some(&response),
+                        usage,
+                        tx
                     );
-                }
-            }
+                    canonicalize_tool_call_args_in_response(&mut response);
 
-            let _ = tx
-                .send(Ok(AgentStreamEvent::RunComplete {
-                    run_id: run_id_clone,
+                    finish_reason = response.finish_reason;
+                    responses.clear(); // Only the current response is needed by streaming checkpoints.
+                    responses.push(response.clone());
+
+                    // Emit ResponseComplete
+                    let _ = tx
+                        .send(Ok(AgentStreamEvent::ResponseComplete {
+                            step,
+                            usage: response.usage.clone(),
+                        }))
+                        .await;
+
+                    // Check for tool calls that need execution
+                    let tool_calls: Vec<_> = response
+                        .parts
+                        .iter()
+                        .filter_map(|p| {
+                            if let ModelResponsePart::ToolCall(tc) = p {
+                                if output_schema.tool_name() == Some(tc.tool_name.as_str()) {
+                                    return None;
+                                }
+                                Some(tc.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
+                    let explicit_output = response.parts.iter().any(|part| matches!(part,
+                        ModelResponsePart::ToolCall(call) if output_schema.tool_name() == Some(call.tool_name.as_str())));
+                    let mut accepted_mixed = None;
+                    if explicit_output
+                        && !tool_calls.is_empty()
+                        && !matches!(
+                            finish_reason,
+                            Some(FinishReason::Length | FinishReason::ContentFilter)
+                        )
+                    {
+                        policy_context.retry_count = output_retries;
+                        match crate::stream_output::validate(
+                            output_schema.as_ref(),
+                            &output_validators,
+                            &response,
+                            &policy_context,
+                        )
+                        .await
+                        {
+                            Ok(output) => accepted_mixed = Some(output),
+                            Err(_) => {
+                                output_retries += 1;
+                                let mut request = ModelRequest::new();
+                                request.parts.push(ModelRequestPart::ModelResponse(Box::new(
+                                    response.clone(),
+                                )));
+                                messages.push(request);
+                                if output_retries > max_output_retries {
+                                    checkpoint!(
+                                        checkpoint_sink,
+                                        run_id_clone,
+                                        step,
+                                        CheckpointBoundary::ValidationFailed,
+                                        messages,
+                                        Some(&response),
+                                        usage,
+                                        tx
+                                    );
+                                    let _ =
+                                        tx.try_send(Err(AgentRunError::OutputValidationFailed(
+                                            crate::OutputValidationError::failed(
+                                                "Output validation exhausted",
+                                            ),
+                                        )));
+                                    return;
+                                }
+                                let mut results = ModelRequest::new();
+                                for part in &response.parts {
+                                    if let ModelResponsePart::ToolCall(call) = part {
+                                        let mut result = ToolReturnPart::new(
+                                            &call.tool_name,
+                                            "Not executed: final output rejected; retry",
+                                        );
+                                        if let Some(id) = &call.tool_call_id {
+                                            result = result.with_tool_call_id(id);
+                                        }
+                                        results.parts.push(ModelRequestPart::ToolReturn(result));
+                                    }
+                                }
+                                messages.push(results);
+                                continue;
+                            }
+                        }
+                    }
+                    if !tool_calls.is_empty()
+                        && !matches!(
+                            finish_reason,
+                            Some(FinishReason::Length | FinishReason::ContentFilter)
+                        )
+                    {
+                        // Add response to messages for proper alternation
+                        let mut response_req = ModelRequest::new();
+                        response_req
+                            .parts
+                            .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
+                        messages.push(response_req);
+
+                        let mut tool_req = ModelRequest::new();
+
+                        for call in &tool_calls {
+                            if accepted_mixed.is_none()
+                                || _end_strategy == crate::EndStrategy::Exhaustive
+                            {
+                                usage.record_tool_call();
+                            }
+                            let _ = tx
+                                .send(Ok(AgentStreamEvent::ToolCallComplete {
+                                    tool_name: call.tool_name.clone(),
+                                    tool_call_id: call.tool_call_id.clone(),
+                                }))
+                                .await;
+                        }
+                        let results = if accepted_mixed.is_some()
+                            && _end_strategy == crate::EndStrategy::Early
+                        {
+                            tool_calls
+                                .into_iter()
+                                .map(|call| {
+                                    (
+                                        call,
+                                        Ok(serdes_ai_tools::ToolReturn::text(
+                                            "Skipped: final output accepted",
+                                        )),
+                                    )
+                                })
+                                .collect()
+                        } else {
+                            crate::stream_tools::execute(
+                                &tools,
+                                tool_calls,
+                                &policy_context,
+                                parallel_tools,
+                                max_concurrent_tools,
+                            )
+                            .await
+                        };
+                        for (call, result) in results {
+                            let success = result.is_ok();
+                            let error = result.as_ref().err().map(ToString::to_string);
+                            let mut part = match result {
+                                Ok(value) => ToolReturnPart::new(&call.tool_name, value.content),
+                                Err(_) => {
+                                    ToolReturnPart::error(&call.tool_name, "Tool execution failed")
+                                }
+                            };
+                            if let Some(id) = &call.tool_call_id {
+                                part = part.with_tool_call_id(id);
+                            }
+                            tool_req.parts.push(ModelRequestPart::ToolReturn(part));
+                            let _ = tx
+                                .send(Ok(AgentStreamEvent::ToolExecuted {
+                                    tool_name: call.tool_name,
+                                    tool_call_id: call.tool_call_id,
+                                    success,
+                                    error,
+                                }))
+                                .await;
+                        }
+                        // A mixed final-output call is not executed as an application tool.
+                        // Acknowledge it before asking for the next final response.
+                        for part in &response.parts {
+                            if let ModelResponsePart::ToolCall(call) = part {
+                                if output_schema.tool_name() == Some(call.tool_name.as_str()) {
+                                    let mut result = ToolReturnPart::new(
+                                        &call.tool_name,
+                                        "Output deferred until ordinary tools complete",
+                                    );
+                                    if let Some(id) = &call.tool_call_id {
+                                        result = result.with_tool_call_id(id);
+                                    }
+                                    tool_req.parts.push(ModelRequestPart::ToolReturn(result));
+                                }
+                            }
+                        }
+
+                        if !tool_req.parts.is_empty() {
+                            messages.push(tool_req);
+                            checkpoint!(
+                                checkpoint_sink,
+                                run_id_clone,
+                                step,
+                                CheckpointBoundary::AfterTools,
+                                messages,
+                                Some(&response),
+                                usage,
+                                tx
+                            );
+                        }
+
+                        if let Some(output) = accepted_mixed {
+                            validated_output = Some(output);
+                            finished = true;
+                            let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
+                        }
+                        continue;
+                    }
+
+                    // Parse and validate through the actual configured output type before
+                    // any completion event. Partial token/filter output remains partial.
+                    let partial = matches!(
+                        finish_reason,
+                        Some(FinishReason::Length | FinishReason::ContentFilter)
+                    );
+                    if partial {
+                        validated_output = None;
+                    }
+                    if !partial {
+                        policy_context.retry_count = output_retries;
+                        let validation = crate::stream_output::validate(
+                            output_schema.as_ref(),
+                            &output_validators,
+                            &response,
+                            &policy_context,
+                        )
+                        .await;
+                        if let Ok(value) = validation {
+                            validated_output = Some(value);
+                        } else {
+                            output_retries += 1;
+                            let mut rejected = ModelRequest::new();
+                            rejected
+                                .parts
+                                .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
+                            messages.push(rejected);
+                            if output_retries > max_output_retries {
+                                checkpoint!(
+                                    checkpoint_sink,
+                                    run_id_clone,
+                                    step,
+                                    CheckpointBoundary::ValidationFailed,
+                                    messages,
+                                    Some(&response),
+                                    usage,
+                                    tx
+                                );
+                                let _ = tx.try_send(Err(AgentRunError::OutputValidationFailed(
+                                    crate::OutputValidationError::failed(
+                                        "Output validation retry budget exhausted",
+                                    ),
+                                )));
+                                return;
+                            }
+                            let mut retry = ModelRequest::new();
+                            let output_calls: Vec<_> = response
+                                .parts
+                                .iter()
+                                .filter_map(|p| match p {
+                                    ModelResponsePart::ToolCall(call)
+                                        if output_schema.tool_name()
+                                            == Some(call.tool_name.as_str()) =>
+                                    {
+                                        Some(call)
+                                    }
+                                    _ => None,
+                                })
+                                .collect();
+                            if output_calls.is_empty() {
+                                retry.parts.push(ModelRequestPart::RetryPrompt(serdes_ai_core::messages::RetryPromptPart::new("Output did not pass validation; return a valid final output")));
+                            } else {
+                                for call in output_calls {
+                                    let mut part = serdes_ai_core::messages::RetryPromptPart::new("Output did not pass validation; return a valid final output").with_tool_name(&call.tool_name);
+                                    if let Some(id) = &call.tool_call_id {
+                                        part = part.with_tool_call_id(id);
+                                    }
+                                    retry.parts.push(ModelRequestPart::RetryPrompt(part));
+                                }
+                            }
+                            messages.push(retry);
+                            continue;
+                        }
+                    }
+                    // No tool calls - check finish condition
+                    if partial
+                        || _end_strategy == crate::EndStrategy::Early
+                        || finish_reason.is_some_and(|r| r.is_complete())
+                        || output_schema.tool_name().is_some()
+                    {
+                        // Add final response to messages for complete history
+                        let mut response_req = ModelRequest::new();
+                        response_req
+                            .parts
+                            .push(ModelRequestPart::ModelResponse(Box::new(response.clone())));
+                        messages.push(response_req);
+
+                        finished = true;
+                        if !partial {
+                            let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
+                        }
+                    } else if let Some(r) = finish_reason {
+                        // finish_reason is Some but NOT complete, and there were no
+                        // tool calls (the tool-call path `continue`d before reaching
+                        // here). The loop is about to silently re-issue the same
+                        // request - make that observable. NOT a behavior change:
+                        // termination is unchanged; termination-on-Length/etc. is a
+                        // separate P2 follow-up. `let _ = &r` keeps `r` "used" so the
+                        // no-op `warn!` build (tracing-integration off) stays clean.
+                        let _ = &r;
+                        warn!(
+                            finish_reason = ?r,
+                            "stream completed with a non-terminal finish reason and no tool calls; re-issuing request (this can loop - see follow-up for Length/ContentFilter/Error handling)"
+                        );
+                    }
+                }
+
+                checkpoint!(
+                    checkpoint_sink,
+                    run_id_clone,
+                    step,
+                    CheckpointBoundary::Terminal,
                     messages,
+                    responses.last(),
                     usage,
-                }))
+                    tx
+                );
+                if let Some(value) = validated_output {
+                    *output_writer.lock().unwrap() = Some(Box::new(value));
+                }
+                // Emit RunComplete
+                let _ = tx
+                    .send(Ok(AgentStreamEvent::RunComplete {
+                        run_id: run_id_clone,
+                        messages,
+                        usage,
+                    }))
+                    .await;
+            };
+            supervisor
+                .supervise(work, supervisor_tx, supervisor_token)
                 .await;
         });
 
         Ok(AgentStream {
+            output,
             rx,
             cancel_token: Some(cancel_token),
         })
@@ -1543,8 +1366,8 @@ impl AgentStream {
     /// [`AgentStream::new_with_cancel`], this will trigger cancellation.
     /// The stream will emit a `Cancelled` event with any partial results.
     ///
-    /// If this stream was created without cancellation support (via `new`),
-    /// this method does nothing.
+    /// Both constructors support cancellation. Dropping the receiver also stops
+    /// in-flight work and records ConsumerDetached when a sink is configured.
     pub fn cancel(&self) {
         if let Some(ref token) = self.cancel_token {
             token.cancel();

--- a/serdes-ai-agent/src/stream_lifecycle.rs
+++ b/serdes-ai-agent/src/stream_lifecycle.rs
@@ -1,0 +1,175 @@
+//! Owns the lifetime of a streaming task, including receiver detach during idle work.
+use crate::{
+    AgentCheckpoint, AgentRunError, AgentStreamEvent, CheckpointBoundary, CheckpointSink, RunUsage,
+};
+use async_trait::async_trait;
+use std::{
+    future::Future,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+};
+use tokio::sync::{Mutex as AsyncMutex, mpsc};
+use tokio_util::sync::CancellationToken;
+
+pub(crate) struct StreamLifecycle {
+    sink: Option<Arc<dyn CheckpointSink>>,
+    snapshot: Mutex<AgentCheckpoint>,
+    gate: AsyncMutex<()>,
+    terminal: AtomicBool,
+    failed: AtomicBool,
+    interrupted: AtomicBool,
+}
+impl StreamLifecycle {
+    pub fn new(sink: Option<Arc<dyn CheckpointSink>>, id: String) -> Arc<Self> {
+        Arc::new(Self {
+            sink,
+            snapshot: Mutex::new(AgentCheckpoint {
+                version: 1,
+                run_id: id,
+                step: 0,
+                boundary: CheckpointBoundary::BeforeRequest,
+                messages: Vec::new(),
+                response: None,
+                usage: RunUsage::new(),
+            }),
+            gate: AsyncMutex::new(()),
+            terminal: AtomicBool::new(false),
+            failed: AtomicBool::new(false),
+            interrupted: AtomicBool::new(false),
+        })
+    }
+    pub fn update(
+        &self,
+        messages: &[serdes_ai_core::ModelRequest],
+        response: Option<&serdes_ai_core::ModelResponse>,
+        step: u32,
+        usage: &RunUsage,
+    ) {
+        let mut snapshot = self.snapshot.lock().unwrap();
+        snapshot.messages = messages.to_vec();
+        snapshot.response = response.cloned();
+        snapshot.step = step;
+        snapshot.usage = usage.clone();
+    }
+    pub async fn supervise(
+        &self,
+        future: impl Future<Output = ()>,
+        tx: mpsc::Sender<Result<AgentStreamEvent, AgentRunError>>,
+        token: CancellationToken,
+    ) {
+        tokio::pin!(future);
+        let boundary = tokio::select! {
+            biased;
+            _ = tx.closed() => Some(CheckpointBoundary::ConsumerDetached),
+            _ = token.cancelled() => Some(CheckpointBoundary::Cancelled),
+            _ = &mut future => Some(if tx.is_closed() { CheckpointBoundary::ConsumerDetached } else { CheckpointBoundary::Failed }),
+        };
+        if let Some(boundary) = boundary {
+            // A save in progress is part of `future`. Poll it until its bounded
+            // transaction completes; never cancel a persistence operation midway.
+            self.interrupted.store(true, Ordering::SeqCst);
+            if self.gate.try_lock().is_err() {
+                tokio::select! { _ = self.gate.lock() => {}, _ = &mut future => {} }
+            }
+            self.interrupted.store(false, Ordering::SeqCst);
+            if !self.terminal.load(Ordering::SeqCst) && !self.failed.load(Ordering::SeqCst) {
+                let mut snapshot = self.snapshot.lock().unwrap().clone();
+                snapshot.boundary = boundary;
+                let _ = self.save(&snapshot).await;
+            }
+            if matches!(
+                self.snapshot.lock().unwrap().boundary,
+                CheckpointBoundary::Cancelled | CheckpointBoundary::ConsumerDetached
+            ) {
+                let _ = tx.try_send(Err(AgentRunError::Cancelled));
+            }
+        }
+        // Dropping future cancels request/summary/validator/tool futures here.
+    }
+}
+fn terminal(boundary: &CheckpointBoundary) -> bool {
+    matches!(
+        boundary,
+        CheckpointBoundary::Terminal
+            | CheckpointBoundary::Cancelled
+            | CheckpointBoundary::ConsumerDetached
+            | CheckpointBoundary::Failed
+            | CheckpointBoundary::ModelFailed(_)
+            | CheckpointBoundary::ValidationFailed
+    )
+}
+#[async_trait]
+impl CheckpointSink for StreamLifecycle {
+    fn partial_interval(&self) -> Option<std::time::Duration> {
+        self.sink.as_ref().and_then(|sink| sink.partial_interval())
+    }
+    // The inner operation enforces the application's timeout. Allow its timeout
+    // result to propagate before the outer lifecycle helper's own deadline.
+    fn save_timeout(&self) -> std::time::Duration {
+        self.sink
+            .as_ref()
+            .map(|s| s.save_timeout())
+            .unwrap_or_default()
+            .saturating_add(std::time::Duration::from_secs(1))
+    }
+    async fn save(&self, checkpoint: &AgentCheckpoint) -> Result<(), String> {
+        let _guard = self.gate.lock().await;
+        if self.terminal.load(Ordering::SeqCst) || self.failed.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+        *self.snapshot.lock().unwrap() = checkpoint.clone();
+        if let Some(sink) = &self.sink {
+            let result = tokio::time::timeout(sink.save_timeout(), sink.save(checkpoint)).await;
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    self.failed.store(true, Ordering::SeqCst);
+                    return Err(error);
+                }
+                Err(_) => {
+                    self.failed.store(true, Ordering::SeqCst);
+                    return Err("checkpoint deadline exceeded; reconcile storage".into());
+                }
+            }
+        }
+        if terminal(&checkpoint.boundary) {
+            self.terminal.store(true, Ordering::SeqCst);
+        }
+        drop(_guard);
+        if self.interrupted.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[tokio::test]
+    async fn terminal_checkpoint_wins_blocked_final_delivery() {
+        let state = StreamLifecycle::new(None, "test".into());
+        let (tx, _rx) = mpsc::channel(1);
+        let token = CancellationToken::new();
+        let work = async {
+            tx.send(Ok(AgentStreamEvent::OutputReady)).await.unwrap();
+            let mut checkpoint = state.snapshot.lock().unwrap().clone();
+            checkpoint.boundary = CheckpointBoundary::Terminal;
+            state.save(&checkpoint).await.unwrap();
+            token.cancel();
+            let _ = tx.send(Ok(AgentStreamEvent::OutputReady)).await;
+        };
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            state.supervise(work, tx.clone(), token.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            state.snapshot.lock().unwrap().boundary,
+            CheckpointBoundary::Terminal
+        );
+    }
+}

--- a/serdes-ai-agent/src/stream_output.rs
+++ b/serdes-ai-agent/src/stream_output.rs
@@ -1,0 +1,34 @@
+//! Type-aware validation before the type-erased streaming completion notification.
+use crate::output::{OutputSchema, OutputValidator};
+use crate::{OutputValidationError, RunContext};
+use serdes_ai_core::{ModelResponse, ModelResponsePart};
+use std::sync::Arc;
+pub(crate) async fn validate<D: Send + Sync, O: Send + Sync>(
+    schema: &dyn OutputSchema<O>,
+    validators: &[Arc<dyn OutputValidator<O, D>>],
+    response: &ModelResponse,
+    context: &RunContext<D>,
+) -> Result<O, OutputValidationError> {
+    let mut found = None;
+    for part in &response.parts {
+        let parsed = match part {
+            ModelResponsePart::Text(text) => schema.parse_text(&text.content),
+            ModelResponsePart::ToolCall(call)
+                if schema.tool_name() == Some(call.tool_name.as_str()) =>
+            {
+                schema.parse_tool_call(&call.tool_name, &call.args.to_json())
+            }
+            _ => continue,
+        };
+        if let Ok(output) = parsed {
+            found = Some(output);
+        }
+    }
+    let mut output = found.ok_or_else(|| {
+        OutputValidationError::failed("Output did not match the configured schema")
+    })?;
+    for validator in validators {
+        output = validator.validate(output, context).await?;
+    }
+    Ok(output)
+}

--- a/serdes-ai-agent/src/stream_tools.rs
+++ b/serdes-ai-agent/src/stream_tools.rs
@@ -1,0 +1,40 @@
+//! Ordered, bounded tool batches. Dropping the batch drops all in-flight futures.
+use crate::{RunContext, agent::RegisteredTool};
+use futures::{StreamExt, stream};
+use serdes_ai_core::messages::ToolCallPart;
+use serdes_ai_tools::{ToolError, ToolReturn};
+pub(crate) async fn execute<D: Send + Sync>(
+    tools: &[RegisteredTool<D>],
+    calls: Vec<ToolCallPart>,
+    ctx: &RunContext<D>,
+    parallel: bool,
+    limit: Option<usize>,
+) -> Vec<(ToolCallPart, Result<ToolReturn, ToolError>)> {
+    let concurrency = if parallel {
+        limit.unwrap_or(calls.len()).max(1)
+    } else {
+        1
+    };
+    stream::iter(calls.into_iter().map(|call| async move {
+        let context = ctx.for_tool(&call.tool_name, call.tool_call_id.clone());
+        let result = if let Some(tool) = tools.iter().find(|t| t.definition.name == call.tool_name)
+        {
+            let args = call.args.to_json();
+            let mut retries = 0;
+            loop {
+                match tool.executor.execute(args.clone(), &context).await {
+                    Err(error) if error.is_retryable() && retries < tool.max_retries => {
+                        retries += 1;
+                    }
+                    result => break result,
+                }
+            }
+        } else {
+            Err(ToolError::NotFound(call.tool_name.clone()))
+        };
+        (call, result)
+    }))
+    .buffered(concurrency)
+    .collect()
+    .await
+}

--- a/serdes-ai-agent/src/typed_stream.rs
+++ b/serdes-ai-agent/src/typed_stream.rs
@@ -1,0 +1,38 @@
+//! Typed final output without changing existing stream event types.
+use crate::{AgentRunError, AgentStream, AgentStreamEvent};
+use futures::{Stream, StreamExt};
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+/// A compatible event stream with a recoverable validator-transformed result.
+/// Output becomes available only after the successful terminal checkpoint.
+pub struct TypedAgentStream<Output> {
+    pub(crate) stream: AgentStream,
+    pub(crate) marker: PhantomData<fn() -> Output>,
+}
+impl<O: Send + Sync + 'static> TypedAgentStream<O> {
+    /// Take validated output once; None before terminal commit or for partial runs.
+    pub fn take_output(&mut self) -> Option<O> {
+        self.stream.take_typed_output()
+    }
+    /// Drain events with backpressure, returning the exact transformed value.
+    /// A valid token-limit/content-filter partial has no typed final output.
+    pub async fn finish(mut self) -> Result<Option<O>, AgentRunError> {
+        while let Some(event) = self.next().await {
+            event?;
+        }
+        Ok(self.take_output())
+    }
+    /// Cancel this run.
+    pub fn cancel(&self) {
+        self.stream.cancel();
+    }
+}
+impl<O> Stream for TypedAgentStream<O> {
+    type Item = Result<AgentStreamEvent, AgentRunError>;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().stream).poll_next(cx)
+    }
+}

--- a/serdes-ai-agent/tests/checkpoint_interval.rs
+++ b/serdes-ai-agent/tests/checkpoint_interval.rs
@@ -1,0 +1,220 @@
+use async_trait::async_trait;
+use futures::{StreamExt, stream};
+use serdes_ai_agent::*;
+use serdes_ai_core::{ModelRequest, ModelResponsePart, ModelResponseStreamEvent as Event};
+use serdes_ai_models::FunctionModel;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+#[derive(Clone, Default)]
+struct Sink(Arc<Mutex<Vec<AgentCheckpoint>>>);
+#[async_trait]
+impl CheckpointSink for Sink {
+    fn partial_interval(&self) -> Option<Duration> {
+        Some(Duration::from_millis(10))
+    }
+    async fn save(&self, value: &AgentCheckpoint) -> Result<(), String> {
+        self.0.lock().unwrap().push(value.clone());
+        Ok(())
+    }
+}
+#[tokio::test]
+async fn idle_stream_periodic_snapshot_and_full_channel_cancel() {
+    for flood in [false, true] {
+        let sink = Sink::default();
+        let model = FunctionModel::with_stream(move |_, _| {
+            let first = stream::iter(vec![Ok(Event::part_start(
+                0,
+                ModelResponsePart::text("partial"),
+            ))]);
+            if flood {
+                Box::pin(first.chain(stream::repeat_with(|| Ok(Event::text_delta(0, "x")))))
+            } else {
+                Box::pin(first.chain(stream::pending()))
+            }
+        });
+        let agent = AgentBuilder::<(), String>::new(model)
+            .checkpoint_sink(sink.clone())
+            .build();
+        let token = CancellationToken::new();
+        let mut response = AgentStream::new_with_cancel(
+            &agent,
+            "test".into(),
+            (),
+            RunOptions::default(),
+            token.clone(),
+        )
+        .await
+        .unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if !flood {
+            assert!(
+                sink.0
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|c| c.boundary == CheckpointBoundary::Partial)
+            );
+        }
+        token.cancel();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if sink
+                    .0
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .any(|c| c.boundary == CheckpointBoundary::Cancelled)
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .unwrap();
+        while response.next().await.is_some() {}
+    }
+}
+struct PendingPolicy;
+#[async_trait]
+impl ContextPolicy<()> for PendingPolicy {
+    async fn prepare(
+        &self,
+        _: ContextPolicyInput<'_, ()>,
+        _: Vec<ModelRequest>,
+    ) -> Result<Vec<ModelRequest>, String> {
+        std::future::pending().await
+    }
+}
+#[tokio::test]
+async fn cancel_policy_preparation() {
+    let sink = Sink::default();
+    let token = CancellationToken::new();
+    let agent = AgentBuilder::<(), String>::new(FunctionModel::constant_text("unused"))
+        .context_policy(PendingPolicy)
+        .checkpoint_sink(sink.clone())
+        .build();
+    let mut response = AgentStream::new_with_cancel(
+        &agent,
+        "test".into(),
+        (),
+        RunOptions::default(),
+        token.clone(),
+    )
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    token.cancel();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while response.next().await.is_some() {}
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        sink.0.lock().unwrap().last().unwrap().boundary,
+        CheckpointBoundary::Cancelled
+    );
+}
+
+#[derive(Clone)]
+struct StalledSink(Arc<std::sync::atomic::AtomicUsize>);
+#[async_trait]
+impl CheckpointSink for StalledSink {
+    fn save_timeout(&self) -> Duration {
+        Duration::from_millis(20)
+    }
+    async fn save(&self, _: &AgentCheckpoint) -> Result<(), String> {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        std::future::pending().await
+    }
+}
+#[tokio::test]
+async fn sink_deadline_stops_without_recursive_save_or_model_call() {
+    let saves = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let model_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let count = model_calls.clone();
+    let model = FunctionModel::with_stream(move |_, _| {
+        count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Box::pin(stream::empty())
+    });
+    let agent = AgentBuilder::<(), String>::new(model)
+        .checkpoint_sink(StalledSink(saves.clone()))
+        .build();
+    let mut response = agent.run_stream("test", ()).await.unwrap();
+    let mut failed = false;
+    while let Some(event) = response.next().await {
+        failed |= matches!(event, Err(AgentRunError::Checkpoint(_)));
+    }
+    assert!(failed);
+    assert_eq!(saves.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(model_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+}
+
+#[derive(Clone)]
+struct SlowSave {
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+    records: Arc<Mutex<Vec<CheckpointBoundary>>>,
+}
+#[async_trait]
+impl CheckpointSink for SlowSave {
+    fn save_timeout(&self) -> Duration {
+        Duration::from_millis(100)
+    }
+    async fn save(&self, checkpoint: &AgentCheckpoint) -> Result<(), String> {
+        self.records
+            .lock()
+            .unwrap()
+            .push(checkpoint.boundary.clone());
+        if checkpoint.boundary == CheckpointBoundary::BeforeRequest {
+            self.entered.notify_one();
+            self.release.notified().await;
+        }
+        Ok(())
+    }
+}
+#[tokio::test]
+async fn cancel_during_save_waits_without_starting_model() {
+    let sink = SlowSave {
+        entered: Arc::new(tokio::sync::Notify::new()),
+        release: Arc::new(tokio::sync::Notify::new()),
+        records: Arc::new(Mutex::new(Vec::new())),
+    };
+    let count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let calls = count.clone();
+    let agent = AgentBuilder::<(), String>::new(FunctionModel::with_stream(move |_, _| {
+        calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Box::pin(stream::empty())
+    }))
+    .checkpoint_sink(sink.clone())
+    .build();
+    let token = CancellationToken::new();
+    let mut events = AgentStream::new_with_cancel(
+        &agent,
+        "test".into(),
+        (),
+        RunOptions::default(),
+        token.clone(),
+    )
+    .await
+    .unwrap();
+    sink.entered.notified().await;
+    token.cancel();
+    tokio::task::yield_now().await;
+    sink.release.notify_one();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while events.next().await.is_some() {}
+    })
+    .await
+    .unwrap();
+    assert_eq!(count.load(std::sync::atomic::Ordering::SeqCst), 0);
+    assert_eq!(
+        sink.records.lock().unwrap().as_slice(),
+        &[
+            CheckpointBoundary::BeforeRequest,
+            CheckpointBoundary::Cancelled
+        ]
+    );
+}

--- a/serdes-ai-agent/tests/lifecycle_hooks.rs
+++ b/serdes-ai-agent/tests/lifecycle_hooks.rs
@@ -1,0 +1,416 @@
+use async_trait::async_trait;
+use futures::{StreamExt, stream};
+use serdes_ai_agent::*;
+use serdes_ai_core::{
+    FinishReason, ModelRequest, ModelResponse, ModelResponsePart, ModelResponseStreamEvent as Event,
+};
+use serdes_ai_models::FunctionModel;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+#[derive(Clone)]
+struct Sink {
+    records: Arc<Mutex<Vec<AgentCheckpoint>>>,
+    fail: Option<CheckpointBoundary>,
+}
+#[async_trait]
+impl CheckpointSink for Sink {
+    async fn save(&self, checkpoint: &AgentCheckpoint) -> Result<(), String> {
+        self.records.lock().unwrap().push(checkpoint.clone());
+        if self.fail.as_ref() == Some(&checkpoint.boundary) {
+            Err("durability unavailable".into())
+        } else {
+            Ok(())
+        }
+    }
+}
+struct Compact(Arc<AtomicUsize>);
+#[async_trait]
+impl HistoryProcessor<()> for Compact {
+    async fn process(&self, _: &RunContext<()>, messages: Vec<ModelRequest>) -> Vec<ModelRequest> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        // This fixture has no tools; retain only the current user request.
+        messages.into_iter().rev().take(1).collect()
+    }
+}
+struct FailingPolicy;
+#[async_trait]
+impl ContextPolicy<()> for FailingPolicy {
+    async fn prepare(
+        &self,
+        input: ContextPolicyInput<'_, ()>,
+        _: Vec<ModelRequest>,
+    ) -> Result<Vec<ModelRequest>, String> {
+        assert_eq!(input.settings, &input.context.model_settings);
+        Err("summary model unavailable".into())
+    }
+}
+fn sink(fail: Option<CheckpointBoundary>) -> Sink {
+    Sink {
+        records: Default::default(),
+        fail,
+    }
+}
+fn model() -> FunctionModel {
+    FunctionModel::with_both(
+        |_, _| ModelResponse::text("ok"),
+        |_, _| {
+            Box::pin(stream::iter(vec![
+                Ok(Event::part_start(0, ModelResponsePart::text("ok"))),
+                Ok(Event::StreamComplete(
+                    serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::Stop),
+                )),
+            ]))
+        },
+    )
+}
+#[tokio::test]
+async fn canonical_processor_and_checkpoint_parity() {
+    for streaming in [false, true] {
+        let sink = sink(None);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let agent = AgentBuilder::<(), String>::new(model())
+            .system_prompt("discard me")
+            .history_processor(Compact(calls.clone()))
+            .checkpoint_sink(sink.clone())
+            .build();
+        if streaming {
+            let mut stream = agent.run_stream("test", ()).await.unwrap();
+            while let Some(event) = stream.next().await {
+                event.unwrap();
+            }
+        } else {
+            agent.run("test", ()).await.unwrap();
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        let records = sink.records.lock().unwrap();
+        assert_eq!(records[0].boundary, CheckpointBoundary::BeforeRequest);
+        assert_eq!(records[0].messages.len(), 1);
+        assert_eq!(
+            records.last().unwrap().boundary,
+            CheckpointBoundary::Terminal
+        );
+        let json = serde_json::to_string(records.last().unwrap()).unwrap();
+        let restored = AgentCheckpoint::from_json(&json).unwrap();
+        assert!(restored.response.is_some());
+        assert!(!format!("{restored:?}").contains("discard me"));
+    }
+}
+#[tokio::test]
+async fn summary_failure_is_not_silent_truncation() {
+    for failure in [
+        ContextFailurePolicy::Stop,
+        ContextFailurePolicy::KeepHistory,
+    ] {
+        let sink = sink(None);
+        let agent = AgentBuilder::<(), String>::new(model())
+            .context_policy(FailingPolicy)
+            .context_failure_policy(failure)
+            .checkpoint_sink(sink.clone())
+            .build();
+        let mut stream = agent.run_stream("test", ()).await.unwrap();
+        let mut failed = false;
+        while let Some(event) = stream.next().await {
+            failed |= matches!(event, Err(AgentRunError::ContextPolicy(_)));
+        }
+        assert_eq!(failed, matches!(failure, ContextFailurePolicy::Stop));
+        assert_eq!(
+            sink.records.lock().unwrap().last().unwrap().boundary == CheckpointBoundary::Failed,
+            failed
+        );
+    }
+}
+#[tokio::test]
+async fn sink_failure_before_tool_dispatch_stops_side_effects() {
+    let sink = sink(Some(CheckpointBoundary::AfterResponse));
+    let calls = Arc::new(AtomicUsize::new(0));
+    let count = calls.clone();
+    let model = FunctionModel::with_stream(|_, _| {
+        Box::pin(stream::iter(vec![
+            Ok(Event::part_start(
+                0,
+                ModelResponsePart::tool_call("danger", serde_json::json!({})),
+            )),
+            Ok(Event::StreamComplete(
+                serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::ToolCall),
+            )),
+        ]))
+    });
+    let agent = AgentBuilder::<(), String>::new(model)
+        .checkpoint_sink(sink.clone())
+        .tool_fn("danger", "danger", move |_, _: serde_json::Value| {
+            count.fetch_add(1, Ordering::SeqCst);
+            Ok(serdes_ai_tools::ToolReturn::text("done"))
+        })
+        .build();
+    let mut stream = agent.run_stream("test", ()).await.unwrap();
+    let mut failed = false;
+    while let Some(event) = stream.next().await {
+        failed |= matches!(event, Err(AgentRunError::Checkpoint(_)));
+    }
+    assert!(failed);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+#[tokio::test]
+async fn cancellation_during_stream_saves_partial_native_parts() {
+    let sink = sink(None);
+    let model = FunctionModel::with_stream(|_, _| {
+        Box::pin(
+            stream::iter(vec![Ok(Event::part_start(
+                0,
+                ModelResponsePart::Thinking(
+                    serdes_ai_core::ThinkingPart::new("private").with_signature("secret"),
+                ),
+            ))])
+            .chain(stream::pending()),
+        )
+    });
+    let agent = AgentBuilder::<(), String>::new(model)
+        .checkpoint_sink(sink.clone())
+        .build();
+    let token = CancellationToken::new();
+    let mut stream = AgentStream::new_with_cancel(
+        &agent,
+        "test".into(),
+        (),
+        RunOptions::default(),
+        token.clone(),
+    )
+    .await
+    .unwrap();
+    while let Some(event) = stream.next().await {
+        if matches!(event, Ok(AgentStreamEvent::ThinkingDelta { .. })) {
+            token.cancel();
+            break;
+        }
+    }
+    while let Some(event) = stream.next().await {
+        if event.is_err() {
+            break;
+        }
+    }
+    let records = sink.records.lock().unwrap();
+    let last = records.last().unwrap();
+    assert_eq!(last.boundary, CheckpointBoundary::Cancelled);
+    assert!(serde_json::to_string(last).unwrap().contains("secret"));
+    assert!(!format!("{last:?}").contains("secret"));
+    assert!(last.response.as_ref().unwrap().usage.is_none());
+}
+
+struct KeepRecent(Arc<AtomicUsize>);
+#[async_trait]
+impl HistoryProcessor<()> for KeepRecent {
+    async fn process(
+        &self,
+        _: &RunContext<()>,
+        mut messages: Vec<ModelRequest>,
+    ) -> Vec<ModelRequest> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        if messages.len() > 3 {
+            messages.drain(..messages.len() - 2);
+        }
+        messages
+    }
+}
+#[tokio::test]
+async fn processors_run_for_each_tool_iteration_and_active_history_shrinks() {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let count = requests.clone();
+    let model = FunctionModel::with_stream(move |_, _| {
+        let step = count.fetch_add(1, Ordering::SeqCst);
+        let (part, reason) = if step < 4 {
+            (
+                ModelResponsePart::ToolCall(
+                    serdes_ai_core::ToolCallPart::new(
+                        "next",
+                        serdes_ai_core::messages::ToolCallArgs::string("{}"),
+                    )
+                    .with_tool_call_id(format!("call_{step}")),
+                ),
+                FinishReason::ToolCall,
+            )
+        } else {
+            (ModelResponsePart::text("done"), FinishReason::Stop)
+        };
+        Box::pin(stream::iter(vec![
+            Ok(Event::part_start(0, part)),
+            Ok(Event::StreamComplete(
+                serdes_ai_core::messages::StreamCompleteEvent::new(reason),
+            )),
+        ]))
+    });
+    let calls = Arc::new(AtomicUsize::new(0));
+    let sink = sink(None);
+    let agent = AgentBuilder::<(), String>::new(model)
+        .history_processor(KeepRecent(calls.clone()))
+        .checkpoint_sink(sink.clone())
+        .tool_fn("next", "next", |_, _: serde_json::Value| {
+            Ok(serdes_ai_tools::ToolReturn::text("ok"))
+        })
+        .build();
+    let mut stream = agent.run_stream("start", ()).await.unwrap();
+    while let Some(event) = stream.next().await {
+        event.unwrap();
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 5);
+    let records = sink.records.lock().unwrap();
+    assert!(
+        records
+            .iter()
+            .filter(|r| r.boundary == CheckpointBoundary::BeforeRequest)
+            .all(|r| r.messages.len() <= 3)
+    );
+    assert_eq!(
+        records
+            .iter()
+            .filter(|r| r.boundary == CheckpointBoundary::AfterTools)
+            .count(),
+        4
+    );
+}
+
+#[tokio::test]
+async fn provider_failure_snapshot_preserves_partial_arguments() {
+    let sink = sink(None);
+    let model = FunctionModel::with_stream(|_, _| {
+        Box::pin(stream::iter(vec![
+            Ok(Event::part_start(
+                0,
+                ModelResponsePart::ToolCall(serdes_ai_core::ToolCallPart::new(
+                    "unfinished",
+                    serdes_ai_core::messages::ToolCallArgs::string("{\"partial\":"),
+                )),
+            )),
+            Err(serdes_ai_models::ModelError::incomplete_stream(
+                "fixture EOF",
+            )),
+        ]))
+    });
+    let agent = AgentBuilder::<(), String>::new(model)
+        .checkpoint_sink(sink.clone())
+        .build();
+    let mut stream = agent.run_stream("test", ()).await.unwrap();
+    while let Some(event) = stream.next().await {
+        if event.is_err() {
+            break;
+        }
+    }
+    let records = sink.records.lock().unwrap();
+    let last = records.last().unwrap();
+    assert_eq!(
+        last.boundary,
+        CheckpointBoundary::ModelFailed(serdes_ai_core::ModelFailureKind::IncompleteStream)
+    );
+    assert!(serde_json::to_string(last).unwrap().contains("partial"));
+}
+
+#[tokio::test]
+async fn cancellation_interrupts_request_establishment() {
+    use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_delay(std::time::Duration::from_secs(30)))
+        .mount(&server)
+        .await;
+    let sink = sink(None);
+    let agent = AgentBuilder::<(), String>::new(
+        serdes_ai_models::openai::OpenAIChatModel::new("local", "test").with_base_url(server.uri()),
+    )
+    .checkpoint_sink(sink.clone())
+    .build();
+    let token = CancellationToken::new();
+    let mut stream = AgentStream::new_with_cancel(
+        &agent,
+        "test".into(),
+        (),
+        RunOptions::default(),
+        token.clone(),
+    )
+    .await
+    .unwrap();
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        token.cancel();
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while let Some(event) = stream.next().await {
+            if event.is_err() {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        sink.records.lock().unwrap().last().unwrap().boundary,
+        CheckpointBoundary::Cancelled
+    );
+}
+
+#[tokio::test]
+async fn cancellation_drops_pending_tool_and_never_records_success() {
+    let token = CancellationToken::new();
+    let cancel = token.clone();
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let cleanup = dropped.clone();
+    struct Guard(Arc<AtomicUsize>);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+    let sink = sink(None);
+    let model = FunctionModel::with_stream(|_, _| {
+        Box::pin(stream::iter(vec![
+            Ok(Event::part_start(
+                0,
+                ModelResponsePart::tool_call("wait", serde_json::json!({})),
+            )),
+            Ok(Event::StreamComplete(
+                serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::ToolCall),
+            )),
+        ]))
+    });
+    let agent = AgentBuilder::<(), String>::new(model)
+        .checkpoint_sink(sink.clone())
+        .tool_fn_async("wait", "wait", move |_, _: serde_json::Value| {
+            let cleanup = cleanup.clone();
+            let cancel = cancel.clone();
+            async move {
+                let _guard = Guard(cleanup);
+                cancel.cancel();
+                std::future::pending().await
+            }
+        })
+        .build();
+    let mut stream =
+        AgentStream::new_with_cancel(&agent, "test".into(), (), RunOptions::default(), token)
+            .await
+            .unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while let Some(event) = stream.next().await {
+            assert!(!matches!(
+                event,
+                Ok(AgentStreamEvent::ToolExecuted { success: true, .. })
+            ));
+            if event.is_err() {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    let records = sink.records.lock().unwrap();
+    assert_eq!(
+        records.last().unwrap().boundary,
+        CheckpointBoundary::Cancelled
+    );
+    assert!(
+        !records
+            .iter()
+            .any(|r| r.boundary == CheckpointBoundary::AfterTools)
+    );
+}

--- a/serdes-ai-agent/tests/native_stream_interruption.rs
+++ b/serdes-ai-agent/tests/native_stream_interruption.rs
@@ -1,0 +1,83 @@
+use futures::StreamExt;
+use serdes_ai_agent::AgentBuilder;
+use serdes_ai_models::openai::OpenAIChatModel;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+#[tokio::test]
+async fn interrupted_native_tool_call_is_never_dispatched() {
+    let server = MockServer::start().await;
+    // Even valid JSON arguments must not run before terminal evidence.
+    let body = format!(
+        "data: {}\n\n",
+        serde_json::json!({"id":"test","object":"chat.completion.chunk",
+        "created":1,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{
+            "index":0,"id":"call_1","type":"function","function":{"name":"danger","arguments":"{}"}
+        }]}}]})
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counter = calls.clone();
+    let agent = AgentBuilder::<(), String>::new(
+        OpenAIChatModel::new("gpt-4o", "local").with_base_url(server.uri()),
+    )
+    .tool_fn("danger", "must not run", move |_, _: serde_json::Value| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Ok(serdes_ai_tools::ToolReturn::text("oops"))
+    })
+    .build();
+    let mut stream = agent.run_stream("test", ()).await.unwrap();
+    let mut failed = false;
+    while let Some(event) = stream.next().await {
+        failed |= event.is_err();
+    }
+    assert!(failed);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn token_limit_is_terminal_and_does_not_dispatch_partial_tools() {
+    let server = MockServer::start().await;
+    let body = format!(
+        "data: {}\n\ndata: [DONE]\n\n",
+        serde_json::json!({"id":"test","object":"chat.completion.chunk",
+        "created":1,"model":"gpt-4o","choices":[{"index":0,"finish_reason":"length","delta":{
+            "content":"valid partial", "tool_calls":[{"index":0,"id":"call_1","type":"function",
+                "function":{"name":"danger","arguments":"{\"unfinished\":"}}]}}]})
+    );
+    Mock::given(method("POST"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let counter = calls.clone();
+    let agent = AgentBuilder::<(), String>::new(
+        OpenAIChatModel::new("gpt-4o", "local").with_base_url(server.uri()),
+    )
+    .tool_fn("danger", "must not run", move |_, _: serde_json::Value| {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Ok(serdes_ai_tools::ToolReturn::text("oops"))
+    })
+    .build();
+    let mut stream = agent.run_stream("test", ()).await.unwrap();
+    while let Some(event) = stream.next().await {
+        assert!(event.is_ok());
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}

--- a/serdes-ai-agent/tests/nonstream_save_races.rs
+++ b/serdes-ai-agent/tests/nonstream_save_races.rs
@@ -1,0 +1,104 @@
+use async_trait::async_trait;
+use serdes_ai_agent::*;
+use serdes_ai_models::FunctionModel;
+use std::{
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+#[derive(Clone)]
+struct Sink {
+    boundary: CheckpointBoundary,
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+    attempts: Arc<Mutex<Vec<CheckpointBoundary>>>,
+    outcome: u8,
+}
+#[async_trait]
+impl CheckpointSink for Sink {
+    fn save_timeout(&self) -> Duration {
+        Duration::from_millis(50)
+    }
+    async fn save(&self, checkpoint: &AgentCheckpoint) -> Result<(), String> {
+        self.attempts
+            .lock()
+            .unwrap()
+            .push(checkpoint.boundary.clone());
+        if checkpoint.boundary == self.boundary {
+            self.entered.notify_one();
+            self.release.notified().await;
+            if self.outcome == 1 {
+                return Err("rejected".into());
+            }
+        }
+        Ok(())
+    }
+}
+#[tokio::test]
+async fn cooperative_nonstream_saves_have_one_outcome() {
+    for boundary in [
+        CheckpointBoundary::BeforeRequest,
+        CheckpointBoundary::Terminal,
+    ] {
+        for outcome in 0..3 {
+            let sink = Sink {
+                boundary: boundary.clone(),
+                entered: Arc::new(tokio::sync::Notify::new()),
+                release: Arc::new(tokio::sync::Notify::new()),
+                attempts: Arc::new(Mutex::new(Vec::new())),
+                outcome,
+            };
+            let calls = Arc::new(AtomicUsize::new(0));
+            let counter = calls.clone();
+            let agent = AgentBuilder::<(), String>::new(FunctionModel::new(move |_, _| {
+                counter.fetch_add(1, Ordering::SeqCst);
+                serdes_ai_core::ModelResponse::text("done")
+            }))
+            .checkpoint_sink(sink.clone())
+            .build();
+            let token = CancellationToken::new();
+            let mut run = AgentRun::new_with_cancel(
+                &agent,
+                "test".into(),
+                (),
+                RunOptions::default(),
+                token.clone(),
+            )
+            .await
+            .unwrap();
+            let controller = async {
+                sink.entered.notified().await;
+                token.cancel();
+                tokio::task::yield_now().await;
+                if outcome != 2 {
+                    sink.release.notify_one();
+                }
+            };
+            let (result, ()) = tokio::join!(run.step(), controller);
+            if outcome != 0 {
+                assert!(matches!(result, Err(AgentRunError::Checkpoint(_))));
+            } else if boundary == CheckpointBoundary::Terminal {
+                assert!(result.is_ok());
+            } else {
+                assert!(matches!(result, Err(AgentRunError::Cancelled)));
+            }
+            let attempts = sink.attempts.lock().unwrap().clone();
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                usize::from(boundary == CheckpointBoundary::Terminal)
+            );
+            assert_eq!(attempts.iter().filter(|b| **b == boundary).count(), 1);
+            assert_eq!(
+                attempts
+                    .iter()
+                    .filter(|b| **b == CheckpointBoundary::Cancelled)
+                    .count(),
+                usize::from(outcome == 0 && boundary == CheckpointBoundary::BeforeRequest)
+            );
+            let _ = run.step().await;
+            assert_eq!(*sink.attempts.lock().unwrap(), attempts);
+        }
+    }
+}

--- a/serdes-ai-agent/tests/responses_native_agent.rs
+++ b/serdes-ai-agent/tests/responses_native_agent.rs
@@ -1,0 +1,103 @@
+use futures::StreamExt;
+use serde_json::json;
+use serdes_ai_agent::AgentBuilder;
+use serdes_ai_models::openai::OpenAIResponsesModel;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+#[tokio::test]
+async fn native_responses_only_dispatch_completed_tools() {
+    for completed in [false, true] {
+        let server = MockServer::start().await;
+        let item = json!({"type":"function_call","id":"fc_1","call_id":"call_1","name":"next","arguments":"{}"});
+        let mut body = format!(
+            "data: {}\n\n",
+            json!({"type":"response.output_item.added","output_index":0,"item":item})
+        );
+        if completed {
+            body += &format!(
+                "data: {}\n\n",
+                json!({"type":"response.completed","response":{"id":"r1","status":"completed","output":[item]}})
+            );
+        }
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST")).respond_with(ResponseTemplate::new(200).set_body_string(format!("data: {}\n\n", json!({"type":"response.completed","response":{"id":"r2","status":"completed","output":[{"type":"message","id":"m2","content":[{"type":"output_text","text":"done"}]}]}})))).with_priority(2).mount(&server).await;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let count = calls.clone();
+        let agent = AgentBuilder::<(), String>::new(
+            OpenAIResponsesModel::new("local", "test").with_base_url(server.uri()),
+        )
+        .tool_fn("next", "next", move |_, _: serde_json::Value| {
+            count.fetch_add(1, Ordering::SeqCst);
+            Ok(serdes_ai_tools::ToolReturn::text("ok"))
+        })
+        .build();
+        let mut stream = agent.run_stream("test", ()).await.unwrap();
+        let mut failed = false;
+        while let Some(event) = stream.next().await {
+            failed |= event.is_err();
+        }
+        assert_eq!(failed, !completed);
+        assert_eq!(calls.load(Ordering::SeqCst), usize::from(completed));
+    }
+}
+
+#[derive(Clone, Default)]
+struct MetadataSink(Arc<std::sync::Mutex<Vec<serdes_ai_agent::AgentCheckpoint>>>);
+#[async_trait::async_trait]
+impl serdes_ai_agent::CheckpointSink for MetadataSink {
+    async fn save(&self, checkpoint: &serdes_ai_agent::AgentCheckpoint) -> Result<(), String> {
+        self.0.lock().unwrap().push(checkpoint.clone());
+        Ok(())
+    }
+}
+#[tokio::test]
+async fn native_metadata_reaches_checkpoint_and_serde() {
+    for output in [
+        json!([]),
+        json!([{"type":"message","id":"m","content":[{"type":"refusal","refusal":"private refusal"}]}]),
+        json!([{"type":"reasoning","id":"rs","summary":[],"encrypted_content":"secret cipher"},{"type":"message","id":"m","content":[{"type":"output_text","text":"done","annotations":[]}]}]),
+    ] {
+        let server = MockServer::start().await;
+        let sink = MetadataSink::default();
+        let body = json!({"type":"response.completed","response":{"id":"metadata-id","model":"actual","status":"completed","output":output,"usage":{"input_tokens":10,"output_tokens":3,"output_tokens_details":{"reasoning_tokens":2}}}});
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(format!("data: {body}\n\n")))
+            .mount(&server)
+            .await;
+        let agent = AgentBuilder::<(), String>::new(
+            OpenAIResponsesModel::new("alias", "test").with_base_url(server.uri()),
+        )
+        .max_output_retries(0)
+        .checkpoint_sink(sink.clone())
+        .build();
+        let mut stream = agent.run_stream("test", ()).await.unwrap();
+        while stream.next().await.is_some() {}
+        let records = sink.0.lock().unwrap();
+        let checkpoint = records
+            .iter()
+            .find(|c| c.boundary == serdes_ai_agent::CheckpointBoundary::AfterResponse)
+            .unwrap();
+        let response = checkpoint.response.as_ref().unwrap();
+        assert_eq!(response.vendor_id.as_deref(), Some("metadata-id"));
+        assert_eq!(response.model_name.as_deref(), Some("actual"));
+        assert_eq!(
+            response.vendor_details.as_ref().unwrap()["output_records"]
+                .as_array()
+                .unwrap()
+                .len(),
+            output.as_array().unwrap().len()
+        );
+        assert!(!format!("{checkpoint:?}").contains("secret cipher"));
+        let encoded = serde_json::to_string(checkpoint).unwrap();
+        let restored: serdes_ai_agent::AgentCheckpoint = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(restored.response, checkpoint.response);
+    }
+}

--- a/serdes-ai-agent/tests/stream_parity.rs
+++ b/serdes-ai-agent/tests/stream_parity.rs
@@ -1,0 +1,358 @@
+use async_trait::async_trait;
+use futures::{StreamExt, stream};
+use serdes_ai_agent::*;
+use serdes_ai_core::{FinishReason, ModelResponsePart, ModelResponseStreamEvent as Event};
+use serdes_ai_models::FunctionModel;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+use tokio::sync::Notify;
+#[derive(Clone, Default)]
+struct Sink {
+    records: Arc<Mutex<Vec<AgentCheckpoint>>>,
+    notify: Arc<Notify>,
+}
+#[async_trait]
+impl CheckpointSink for Sink {
+    async fn save(&self, cp: &AgentCheckpoint) -> Result<(), String> {
+        self.records.lock().unwrap().push(cp.clone());
+        self.notify.notify_one();
+        Ok(())
+    }
+}
+impl Sink {
+    async fn terminal(&self) -> CheckpointBoundary {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let waiting = self.notify.notified();
+                if let Some(cp) = self.records.lock().unwrap().iter().find(|c| {
+                    matches!(
+                        c.boundary,
+                        CheckpointBoundary::Terminal
+                            | CheckpointBoundary::Cancelled
+                            | CheckpointBoundary::ConsumerDetached
+                            | CheckpointBoundary::ValidationFailed
+                    )
+                }) {
+                    return cp.boundary.clone();
+                }
+                waiting.await;
+            }
+        })
+        .await
+        .unwrap()
+    }
+}
+fn text(value: &str) -> Vec<Result<Event, serdes_ai_models::ModelError>> {
+    vec![
+        Ok(Event::part_start(0, ModelResponsePart::text(value))),
+        Ok(Event::StreamComplete(
+            serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::Stop),
+        )),
+    ]
+}
+struct Validator(Arc<AtomicUsize>);
+#[async_trait]
+impl OutputValidator<String, String> for Validator {
+    async fn validate(
+        &self,
+        output: String,
+        ctx: &RunContext<String>,
+    ) -> Result<String, OutputValidationError> {
+        tokio::task::yield_now().await;
+        assert_eq!(ctx.deps.as_str(), "dependency");
+        self.0.fetch_add(1, Ordering::SeqCst);
+        if output == "valid" {
+            Ok(output)
+        } else {
+            Err(OutputValidationError::failed("private validation reason"))
+        }
+    }
+}
+#[tokio::test]
+async fn async_validation_retries_and_dynamic_prompts() {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let count = requests.clone();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let sink = Sink::default();
+    let model = FunctionModel::with_stream(move |messages, _| {
+        let request = count.fetch_add(1, Ordering::SeqCst);
+        let encoded = serde_json::to_string(messages).unwrap();
+        assert!(encoded.contains("dynamic-dependency"));
+        if request > 0 {
+            assert!(encoded.contains("retry-prompt") || encoded.contains("retry_prompt"));
+        }
+        Box::pin(stream::iter(text(if request == 0 {
+            "invalid"
+        } else {
+            "valid"
+        })))
+    });
+    let agent = AgentBuilder::<String, String>::new(model)
+        .system_prompt_fn(|ctx| {
+            let text = format!("dynamic-{}", ctx.deps);
+            async move { Some(text) }
+        })
+        .output_validator(Validator(calls.clone()))
+        .checkpoint_sink(sink.clone())
+        .build();
+    let mut events = agent.run_stream("test", "dependency".into()).await.unwrap();
+    let mut ready = 0;
+    while let Some(event) = events.next().await {
+        let event = event.unwrap();
+        if matches!(event, AgentStreamEvent::OutputReady) {
+            ready += 1;
+        }
+    }
+    assert_eq!(ready, 1);
+    assert_eq!(requests.load(Ordering::SeqCst), 2);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(sink.terminal().await, CheckpointBoundary::Terminal);
+}
+#[tokio::test]
+async fn structured_schema_exhaustion_never_signals_output_ready() {
+    let sink = Sink::default();
+    let agent = AgentBuilder::<(), String>::new(FunctionModel::with_stream(|_, _| {
+        Box::pin(stream::iter(text("not json")))
+    }))
+    .output_type::<serde_json::Value>()
+    .max_output_retries(1)
+    .checkpoint_sink(sink.clone())
+    .build();
+    let mut events = agent.run_stream("test", ()).await.unwrap();
+    let mut failed = false;
+    while let Some(event) = events.next().await {
+        assert!(!matches!(
+            event,
+            Ok(AgentStreamEvent::OutputReady | AgentStreamEvent::RunComplete { .. })
+        ));
+        failed |= matches!(event, Err(AgentRunError::OutputValidationFailed(_)));
+    }
+    assert!(failed);
+    assert_eq!(sink.terminal().await, CheckpointBoundary::ValidationFailed);
+}
+#[tokio::test]
+async fn detach_idle_native_partial_and_cancel_before_start() {
+    for before_start in [true, false] {
+        let sink = Sink::default();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let count = calls.clone();
+        let model = FunctionModel::with_stream(move |_, _| {
+            count.fetch_add(1, Ordering::SeqCst);
+            Box::pin(
+                stream::iter(vec![Ok(Event::part_start(
+                    0,
+                    ModelResponsePart::text("retained"),
+                ))])
+                .chain(stream::pending()),
+            )
+        });
+        let agent = AgentBuilder::<(), String>::new(model)
+            .checkpoint_sink(sink.clone())
+            .build();
+        let token = CancellationToken::new();
+        if before_start {
+            token.cancel();
+        }
+        let mut response =
+            AgentStream::new_with_cancel(&agent, "test".into(), (), RunOptions::default(), token)
+                .await
+                .unwrap();
+        if !before_start {
+            while let Some(event) = response.next().await {
+                if matches!(event, Ok(AgentStreamEvent::TextDelta { .. })) {
+                    break;
+                }
+            }
+        }
+        drop(response);
+        assert_eq!(sink.terminal().await, CheckpointBoundary::ConsumerDetached);
+        if before_start {
+            assert_eq!(calls.load(Ordering::SeqCst), 0);
+        } else {
+            assert_eq!(
+                sink.records
+                    .lock()
+                    .unwrap()
+                    .last()
+                    .unwrap()
+                    .response
+                    .as_ref()
+                    .unwrap()
+                    .parts
+                    .len(),
+                1
+            );
+        }
+    }
+}
+#[tokio::test]
+async fn committed_terminal_wins_receiver_detach() {
+    let sink = Sink::default();
+    let agent = AgentBuilder::<(), String>::new(FunctionModel::with_stream(|_, _| {
+        Box::pin(stream::iter(text("valid")))
+    }))
+    .checkpoint_sink(sink.clone())
+    .build();
+    let response = agent.run_stream("test", ()).await.unwrap();
+    assert_eq!(sink.terminal().await, CheckpointBoundary::Terminal);
+    drop(response);
+    tokio::task::yield_now().await;
+    assert_eq!(
+        sink.records
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|c| matches!(
+                c.boundary,
+                CheckpointBoundary::Terminal
+                    | CheckpointBoundary::ConsumerDetached
+                    | CheckpointBoundary::Cancelled
+            ))
+            .count(),
+        1
+    );
+}
+
+struct PendingModel {
+    entered: Arc<Notify>,
+    dropped: Arc<Notify>,
+    summary: bool,
+}
+struct Cleanup(Arc<Notify>);
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        self.0.notify_one();
+    }
+}
+#[async_trait]
+impl serdes_ai_models::Model for PendingModel {
+    fn name(&self) -> &str {
+        "pending"
+    }
+    fn system(&self) -> &str {
+        "test"
+    }
+    fn profile(&self) -> &serdes_ai_models::ModelProfile {
+        static PROFILE: std::sync::OnceLock<serdes_ai_models::ModelProfile> =
+            std::sync::OnceLock::new();
+        PROFILE.get_or_init(|| serdes_ai_models::ModelProfile {
+            context_window: Some(1000),
+            ..Default::default()
+        })
+    }
+    async fn request(
+        &self,
+        _: &[serdes_ai_core::ModelRequest],
+        _: &serdes_ai_core::ModelSettings,
+        _: &serdes_ai_models::ModelRequestParameters,
+    ) -> Result<serdes_ai_core::ModelResponse, serdes_ai_models::ModelError> {
+        assert!(self.summary);
+        let _cleanup = Cleanup(self.dropped.clone());
+        self.entered.notify_one();
+        std::future::pending().await
+    }
+    async fn request_stream(
+        &self,
+        _: &[serdes_ai_core::ModelRequest],
+        _: &serdes_ai_core::ModelSettings,
+        _: &serdes_ai_models::ModelRequestParameters,
+    ) -> Result<serdes_ai_models::StreamedResponse, serdes_ai_models::ModelError> {
+        assert!(!self.summary);
+        let _cleanup = Cleanup(self.dropped.clone());
+        self.entered.notify_one();
+        std::future::pending().await
+    }
+}
+#[tokio::test]
+async fn detach_request_and_legacy_summary_drops_inflight_future() {
+    for summary in [false, true] {
+        let entered = Arc::new(Notify::new());
+        let dropped = Arc::new(Notify::new());
+        let sink = Sink::default();
+        let agent = AgentBuilder::<(), String>::new(PendingModel {
+            entered: entered.clone(),
+            dropped: dropped.clone(),
+            summary,
+        })
+        .checkpoint_sink(sink.clone())
+        .build();
+        let mut options = RunOptions::default();
+        if summary {
+            options.compression = Some(serdes_ai_agent::run::ContextCompression {
+                strategy: serdes_ai_agent::run::CompressionStrategy::Summarize,
+                threshold: 0.0,
+                target_tokens: 10,
+            });
+            options.message_history = Some(
+                (0..8)
+                    .map(|_| {
+                        let mut message = serdes_ai_core::ModelRequest::new();
+                        message.add_user_prompt("history".repeat(100));
+                        message
+                    })
+                    .collect(),
+            );
+        }
+        let response = AgentStream::new(&agent, "test".into(), (), options)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), entered.notified())
+            .await
+            .unwrap();
+        drop(response);
+        assert_eq!(sink.terminal().await, CheckpointBoundary::ConsumerDetached);
+        tokio::time::timeout(Duration::from_secs(2), dropped.notified())
+            .await
+            .unwrap();
+    }
+}
+#[tokio::test]
+async fn detach_async_tool_cancels_without_followup_request() {
+    let entered = Arc::new(Notify::new());
+    let dropped = Arc::new(Notify::new());
+    let sink = Sink::default();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let count = calls.clone();
+    let model = FunctionModel::with_stream(move |_, _| {
+        count.fetch_add(1, Ordering::SeqCst);
+        Box::pin(stream::iter(vec![
+            Ok(Event::part_start(
+                0,
+                ModelResponsePart::tool_call("wait", serde_json::json!({})),
+            )),
+            Ok(Event::StreamComplete(
+                serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::ToolCall),
+            )),
+        ]))
+    });
+    let start = entered.clone();
+    let cleanup = dropped.clone();
+    let agent = AgentBuilder::<(), String>::new(model)
+        .checkpoint_sink(sink.clone())
+        .tool_fn_async("wait", "wait", move |_, _: serde_json::Value| {
+            let start = start.clone();
+            let cleanup = cleanup.clone();
+            async move {
+                let _cleanup = Cleanup(cleanup);
+                start.notify_one();
+                std::future::pending::<
+                    Result<serdes_ai_tools::ToolReturn, serdes_ai_tools::ToolError>,
+                >()
+                .await
+            }
+        })
+        .build();
+    let response = agent.run_stream("test", ()).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(2), entered.notified())
+        .await
+        .unwrap();
+    drop(response);
+    assert_eq!(sink.terminal().await, CheckpointBoundary::ConsumerDetached);
+    tokio::time::timeout(Duration::from_secs(2), dropped.notified())
+        .await
+        .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}

--- a/serdes-ai-agent/tests/typed_output.rs
+++ b/serdes-ai-agent/tests/typed_output.rs
@@ -1,0 +1,328 @@
+use futures::stream;
+use serdes_ai_agent::{AgentBuilder, RunOptions};
+use serdes_ai_core::{
+    FinishReason, ModelResponse, ModelResponsePart, ModelResponseStreamEvent as Event,
+};
+use serdes_ai_models::FunctionModel;
+#[tokio::test]
+async fn transformed_output_matches_nonstream() {
+    let model = FunctionModel::with_both(
+        |_, _| ModelResponse::text("original"),
+        |_, _| {
+            Box::pin(stream::iter(vec![
+                Ok(Event::part_start(0, ModelResponsePart::text("original"))),
+                Ok(Event::StreamComplete(
+                    serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::Stop),
+                )),
+            ]))
+        },
+    );
+    let agent = AgentBuilder::<(), String>::new(model)
+        .output_validator_fn(|value, _| Ok(format!("transformed:{value}")))
+        .build();
+    let expected = agent.run("test", ()).await.unwrap().output;
+    let actual = agent
+        .run_stream_typed("test", (), RunOptions::default())
+        .await
+        .unwrap()
+        .finish()
+        .await
+        .unwrap();
+    assert_eq!(actual, Some(expected));
+}
+#[tokio::test]
+async fn partial_output_is_not_a_typed_result() {
+    let model = FunctionModel::with_stream(|_, _| {
+        Box::pin(stream::iter(vec![
+            Ok(Event::part_start(0, ModelResponsePart::text("partial"))),
+            Ok(Event::StreamComplete(
+                serdes_ai_core::messages::StreamCompleteEvent::new(FinishReason::Length),
+            )),
+        ]))
+    });
+    let agent = AgentBuilder::<(), String>::new(model).build();
+    assert_eq!(
+        agent
+            .run_stream_typed("test", (), RunOptions::default())
+            .await
+            .unwrap()
+            .finish()
+            .await
+            .unwrap(),
+        None
+    );
+}
+
+struct FinalSchema;
+impl serdes_ai_agent::OutputSchema<String> for FinalSchema {
+    fn tool_name(&self) -> Option<&str> {
+        Some("final")
+    }
+    fn parse_text(&self, _: &str) -> Result<String, serdes_ai_agent::OutputParseError> {
+        Err(serdes_ai_agent::OutputParseError::NotFound)
+    }
+    fn parse_tool_call(
+        &self,
+        _: &str,
+        value: &serde_json::Value,
+    ) -> Result<String, serdes_ai_agent::OutputParseError> {
+        value["answer"]
+            .as_str()
+            .map(str::to_owned)
+            .ok_or(serdes_ai_agent::OutputParseError::NotFound)
+    }
+}
+#[tokio::test]
+async fn mixed_output_tool_end_strategy_parity() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    for strategy in [
+        serdes_ai_agent::EndStrategy::Early,
+        serdes_ai_agent::EndStrategy::Exhaustive,
+    ] {
+        for streaming in [false, true] {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let count = calls.clone();
+            let response = || {
+                ModelResponse::with_parts(vec![
+                    ModelResponsePart::tool_call("work", serde_json::json!({})),
+                    ModelResponsePart::tool_call("final", serde_json::json!({"answer":"done"})),
+                ])
+            };
+            let model = FunctionModel::with_both(
+                move |_, _| response(),
+                move |_, _| {
+                    let events = response()
+                        .parts
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, part)| Ok(Event::part_start(index, part)))
+                        .chain(std::iter::once(Ok(Event::StreamComplete(
+                            serdes_ai_core::messages::StreamCompleteEvent::new(
+                                FinishReason::ToolCall,
+                            ),
+                        ))))
+                        .collect::<Vec<_>>();
+                    Box::pin(stream::iter(events))
+                },
+            );
+            let agent = AgentBuilder::<(), String>::new(model)
+                .output_schema(FinalSchema)
+                .end_strategy(strategy)
+                .tool_fn("work", "work", move |_, _: serde_json::Value| {
+                    count.fetch_add(1, Ordering::SeqCst);
+                    Ok(serdes_ai_tools::ToolReturn::text("ok"))
+                })
+                .build();
+            let result = if streaming {
+                agent
+                    .run_stream_typed("test", (), RunOptions::default())
+                    .await
+                    .unwrap()
+                    .finish()
+                    .await
+                    .unwrap()
+                    .unwrap()
+            } else {
+                agent.run("test", ()).await.unwrap().output
+            };
+            assert_eq!(result, "done");
+            assert_eq!(
+                calls.load(Ordering::SeqCst),
+                usize::from(strategy == serdes_ai_agent::EndStrategy::Exhaustive)
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn bounded_parallel_batch_matches_nonstream() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    for streaming in [false, true] {
+        for limit in [1, 2] {
+            let current = Arc::new(AtomicUsize::new(0));
+            let peak = Arc::new(AtomicUsize::new(0));
+            let requests = Arc::new(AtomicUsize::new(0));
+            let normal = requests.clone();
+            let streamed = requests.clone();
+            let response = |step| {
+                if step == 0 {
+                    ModelResponse::with_parts(
+                        (0..4)
+                            .map(|_| ModelResponsePart::tool_call("work", serde_json::json!({})))
+                            .collect(),
+                    )
+                } else {
+                    ModelResponse::text("done")
+                }
+            };
+            let model = FunctionModel::with_both(
+                move |_, _| response(normal.fetch_add(1, Ordering::SeqCst)),
+                move |_, _| {
+                    let step = streamed.fetch_add(1, Ordering::SeqCst);
+                    Box::pin(stream::iter(
+                        response(step)
+                            .parts
+                            .into_iter()
+                            .enumerate()
+                            .map(|(index, part)| Ok(Event::part_start(index, part)))
+                            .chain(std::iter::once(Ok(Event::StreamComplete(
+                                serdes_ai_core::messages::StreamCompleteEvent::new(if step == 0 {
+                                    FinishReason::ToolCall
+                                } else {
+                                    FinishReason::Stop
+                                }),
+                            ))))
+                            .collect::<Vec<_>>(),
+                    ))
+                },
+            );
+            let active = current.clone();
+            let maximum = peak.clone();
+            let agent = AgentBuilder::<(), String>::new(model)
+                .parallel_tool_calls(true)
+                .max_concurrent_tools(limit)
+                .tool_fn_async("work", "work", move |_, _: serde_json::Value| {
+                    let active = active.clone();
+                    let maximum = maximum.clone();
+                    async move {
+                        let value = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        maximum.fetch_max(value, Ordering::SeqCst);
+                        tokio::task::yield_now().await;
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(serdes_ai_tools::ToolReturn::text("ok"))
+                    }
+                })
+                .build();
+            let output = if streaming {
+                agent
+                    .run_stream_typed("test", (), RunOptions::default())
+                    .await
+                    .unwrap()
+                    .finish()
+                    .await
+                    .unwrap()
+                    .unwrap()
+            } else {
+                agent.run("test", ()).await.unwrap().output
+            };
+            assert_eq!(output, "done");
+            assert_eq!(peak.load(Ordering::SeqCst), limit);
+            assert_eq!(current.load(Ordering::SeqCst), 0);
+        }
+    }
+}
+
+#[tokio::test]
+async fn malformed_mixed_output_retries_with_paired_ordered_history() {
+    use serdes_ai_core::{ModelRequest, ModelRequestPart};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    fn check(messages: &[ModelRequest]) {
+        let mut pending = Vec::new();
+        let mut seen = Vec::new();
+        for request in messages {
+            for part in &request.parts {
+                match part {
+                    ModelRequestPart::ModelResponse(response) => {
+                        for part in &response.parts {
+                            if let ModelResponsePart::ToolCall(call) = part {
+                                pending.push(call.tool_call_id.clone().unwrap());
+                            }
+                        }
+                    }
+                    ModelRequestPart::ToolReturn(result) => {
+                        let id = result.tool_call_id.clone().unwrap();
+                        assert!(pending.contains(&id));
+                        seen.push(id);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        assert_eq!(pending, vec!["work-id", "output-id"]);
+        assert_eq!(seen, pending);
+    }
+    for streaming in [false, true] {
+        let step = Arc::new(AtomicUsize::new(0));
+        let normal = step.clone();
+        let streamed = step.clone();
+        let response = |step| {
+            if step == 0 {
+                ModelResponse::with_parts(vec![
+                    ModelResponsePart::ToolCall(
+                        serdes_ai_core::messages::ToolCallPart::new("work", serde_json::json!({}))
+                            .with_tool_call_id("work-id"),
+                    ),
+                    ModelResponsePart::ToolCall(
+                        serdes_ai_core::messages::ToolCallPart::new(
+                            "final",
+                            serde_json::json!({"invalid":true}),
+                        )
+                        .with_tool_call_id("output-id"),
+                    ),
+                ])
+            } else {
+                ModelResponse::with_parts(vec![ModelResponsePart::tool_call(
+                    "final",
+                    serde_json::json!({"answer":"done"}),
+                )])
+            }
+        };
+        let model = FunctionModel::with_both(
+            move |messages, _| {
+                let step = normal.fetch_add(1, Ordering::SeqCst);
+                if step > 0 {
+                    check(messages);
+                }
+                response(step)
+            },
+            move |messages, _| {
+                let step = streamed.fetch_add(1, Ordering::SeqCst);
+                if step > 0 {
+                    check(messages);
+                }
+                Box::pin(stream::iter(
+                    response(step)
+                        .parts
+                        .into_iter()
+                        .enumerate()
+                        .map(|(index, part)| Ok(Event::part_start(index, part)))
+                        .chain(std::iter::once(Ok(Event::StreamComplete(
+                            serdes_ai_core::messages::StreamCompleteEvent::new(
+                                FinishReason::ToolCall,
+                            ),
+                        ))))
+                        .collect::<Vec<_>>(),
+                ))
+            },
+        );
+        let agent = AgentBuilder::<(), String>::new(model)
+            .output_schema(FinalSchema)
+            .tool_fn("work", "must not execute", |_, _: serde_json::Value| {
+                panic!("malformed output dispatched a tool")
+            })
+            .build();
+        let result = if streaming {
+            agent
+                .run_stream_typed("test", (), RunOptions::default())
+                .await
+                .unwrap()
+                .finish()
+                .await
+                .unwrap()
+                .unwrap()
+        } else {
+            agent.run("test", ()).await.unwrap().output
+        };
+        assert_eq!(result, "done");
+        assert_eq!(step.load(Ordering::SeqCst), 2);
+    }
+}

--- a/serdes-ai-core/src/messages/events.rs
+++ b/serdes-ai-core/src/messages/events.rs
@@ -330,7 +330,7 @@ impl ModelResponsePartDelta {
 }
 
 /// Delta for text content.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct TextPartDelta {
     /// The text content delta.
     pub content_delta: String,
@@ -339,6 +339,11 @@ pub struct TextPartDelta {
     pub provider_details: Option<Map<String, Value>>,
 }
 
+impl std::fmt::Debug for TextPartDelta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TextPartDelta(<redacted>)")
+    }
+}
 impl TextPartDelta {
     /// Create a new text delta.
     #[must_use]
@@ -473,7 +478,7 @@ impl Default for ToolCallPartDelta {
 }
 
 /// Delta for thinking content.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct ThinkingPartDelta {
     /// The thinking content delta.
     pub content_delta: String,
@@ -486,6 +491,12 @@ pub struct ThinkingPartDelta {
     /// Provider-specific details/metadata delta.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_details: Option<Map<String, Value>>,
+}
+
+impl std::fmt::Debug for ThinkingPartDelta {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ThinkingPartDelta(<redacted>)")
+    }
 }
 
 impl ThinkingPartDelta {
@@ -667,11 +678,41 @@ impl PartEndEvent {
     }
 }
 
+/// Optional provider-native terminal metadata. Opaque output records are archival,
+/// never authorization to execute tools or replay arbitrary provider payloads.
+#[derive(Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct TerminalMetadata {
+    /// Provider response identifier, including for empty output.
+    pub response_id: Option<String>,
+    /// Actual provider model identifier.
+    pub model: Option<String>,
+    /// Provider-native metadata, including status, usage details and output records.
+    pub details: Option<serde_json::Value>,
+}
+impl std::fmt::Debug for TerminalMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("TerminalMetadata(<redacted>)")
+    }
+}
+impl TerminalMetadata {
+    /// Apply metadata to existing response fields without changing message schema.
+    pub fn apply(&self, response: &mut super::response::ModelResponse) {
+        response.vendor_id = self.response_id.clone();
+        if self.model.is_some() {
+            response.model_name = self.model.clone();
+        }
+        response.vendor_details = self.details.clone();
+    }
+}
+
 /// Event indicating the stream completed successfully with provider terminal metadata.
 ///
 /// Only emitted when the provider confirms successful completion.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StreamCompleteEvent {
+    /// Optional native terminal metadata, absent for older producers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<TerminalMetadata>,
     /// Provider-reported finish reason (mapped to [`FinishReason`]).
     pub finish_reason: FinishReason,
     /// Input tokens reported by the provider (if any).
@@ -692,11 +733,41 @@ impl StreamCompleteEvent {
     pub fn new(finish_reason: FinishReason) -> Self {
         Self {
             finish_reason,
+            metadata: None,
             input_tokens: None,
             output_tokens: None,
             cache_creation_tokens: None,
             cache_read_tokens: None,
         }
+    }
+
+    /// Provider usage with optional detailed native counters, without fabricating
+    /// zeroes when a provider omitted counts.
+    pub fn request_usage(&self) -> Option<crate::RequestUsage> {
+        if self.input_tokens.is_none()
+            && self.output_tokens.is_none()
+            && self.cache_read_tokens.is_none()
+            && self.cache_creation_tokens.is_none()
+        {
+            return None;
+        }
+        let mut usage = crate::RequestUsage::new();
+        usage.request_tokens = self.input_tokens;
+        usage.response_tokens = self.output_tokens;
+        usage.total_tokens = self
+            .input_tokens
+            .zip(self.output_tokens)
+            .map(|(a, b)| a.saturating_add(b));
+        usage.cache_read_tokens = self.cache_read_tokens;
+        usage.cache_creation_tokens = self.cache_creation_tokens;
+        usage.details = self
+            .metadata
+            .as_ref()
+            .and_then(|m| m.details.as_ref())
+            .and_then(|d| d.get("usage"))
+            .filter(|u| !u.is_null())
+            .cloned();
+        Some(usage)
     }
 
     /// Set input tokens.

--- a/serdes-ai-core/src/messages/mod.rs
+++ b/serdes-ai-core/src/messages/mod.rs
@@ -45,8 +45,8 @@ pub use content::{
 };
 pub use events::{
     BuiltinToolCallPartDelta, ModelResponsePartDelta, ModelResponseStreamEvent, PartDeltaEvent,
-    PartEndEvent, PartStartEvent, StreamCompleteEvent, TextPartDelta, ThinkingPartDelta,
-    ToolCallPartDelta,
+    PartEndEvent, PartStartEvent, StreamCompleteEvent, TerminalMetadata, TextPartDelta,
+    ThinkingPartDelta, ToolCallPartDelta,
 };
 pub use media::{AudioMediaType, DocumentMediaType, ImageMediaType, VideoMediaType};
 pub use parts::{

--- a/serdes-ai-core/src/messages/parts.rs
+++ b/serdes-ai-core/src/messages/parts.rs
@@ -474,7 +474,7 @@ impl ToolCallPart {
 ///
 /// Used for models that support "thinking" or chain-of-thought reasoning,
 /// like Claude's extended thinking feature.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct ThinkingPart {
     /// The thinking content.
     pub content: String,
@@ -490,6 +490,21 @@ pub struct ThinkingPart {
     /// Provider-specific details/metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub provider_details: Option<serde_json::Map<String, serde_json::Value>>,
+}
+
+impl std::fmt::Debug for ThinkingPart {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ThinkingPart")
+            .field("id", &self.id)
+            .field("provider_name", &self.provider_name)
+            .field("content", &"<redacted>")
+            .field("signature", &self.signature.as_ref().map(|_| "<redacted>"))
+            .field(
+                "provider_details",
+                &self.provider_details.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl ThinkingPart {

--- a/serdes-ai-core/src/messages/response.rs
+++ b/serdes-ai-core/src/messages/response.rs
@@ -10,7 +10,7 @@ use super::parts::{BuiltinToolCallPart, FilePart, TextPart, ThinkingPart, ToolCa
 use crate::usage::RequestUsage;
 
 /// A complete model response containing multiple parts.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct ModelResponse {
     /// The response parts.
     pub parts: Vec<ModelResponsePart>,
@@ -40,6 +40,14 @@ fn default_response_kind() -> String {
     "response".to_string()
 }
 
+impl std::fmt::Debug for ModelResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ModelResponse")
+            .field("part_count", &self.parts.len())
+            .field("finish_reason", &self.finish_reason)
+            .finish_non_exhaustive()
+    }
+}
 impl ModelResponse {
     /// Create a new empty response.
     #[must_use]

--- a/serdes-ai-models/src/openai/chat.rs
+++ b/serdes-ai-models/src/openai/chat.rs
@@ -31,6 +31,8 @@ pub struct OpenAIChatModel {
     project: Option<String>,
     profile: ModelProfile,
     default_timeout: Duration,
+    completion_token_limit: Option<bool>,
+    finish_is_terminal: bool,
 }
 
 impl OpenAIChatModel {
@@ -48,6 +50,8 @@ impl OpenAIChatModel {
             project: None,
             profile,
             default_timeout: Duration::from_secs(120),
+            completion_token_limit: None,
+            finish_is_terminal: false,
         }
     }
 
@@ -63,6 +67,22 @@ impl OpenAIChatModel {
     #[must_use]
     pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
         self.base_url = url.into();
+        self
+    }
+
+    /// Override token-limit wire key selection for custom model aliases/endpoints.
+    /// `true` selects `max_completion_tokens`; `false` selects legacy `max_tokens`.
+    #[must_use]
+    pub fn with_max_completion_tokens(mut self, enabled: bool) -> Self {
+        self.completion_token_limit = Some(enabled);
+        self
+    }
+
+    /// Opt into compatible endpoints that terminate with a finish frame and clean EOF.
+    /// OpenAI's default contract still requires `[DONE]` and consumes usage-only frames.
+    #[must_use]
+    pub fn with_finish_reason_terminal(mut self, enabled: bool) -> Self {
+        self.finish_is_terminal = enabled;
         self
     }
 
@@ -338,13 +358,26 @@ impl OpenAIChatModel {
             ResponseFormat::json_schema("output", schema_value, true)
         });
 
+        let completion_limit = self.completion_token_limit.unwrap_or(
+            self.profile.supports_reasoning
+                || self.model_name.starts_with("o4")
+                || self.model_name.starts_with("gpt-5"),
+        );
         ChatCompletionRequest {
             model: self.model_name.clone(),
             messages,
             temperature: settings.temperature,
             top_p: settings.top_p,
-            max_tokens: settings.max_tokens,
-            max_completion_tokens: None,
+            max_tokens: if completion_limit {
+                None
+            } else {
+                settings.max_tokens
+            },
+            max_completion_tokens: if completion_limit {
+                settings.max_tokens
+            } else {
+                None
+            },
             stop: settings.stop.clone(),
             presence_penalty: settings.presence_penalty,
             frequency_penalty: settings.frequency_penalty,
@@ -357,7 +390,7 @@ impl OpenAIChatModel {
             stream: if stream { Some(true) } else { None },
             stream_options: if stream {
                 Some(StreamOptions {
-                    include_usage: true,
+                    include_usage: params.stream_usage,
                 })
             } else {
                 None
@@ -565,7 +598,8 @@ impl Model for OpenAIChatModel {
 
         // Create stream parser
         let byte_stream = response.bytes_stream();
-        let parser = OpenAIStreamParser::new(byte_stream);
+        let parser = OpenAIStreamParser::new(byte_stream)
+            .with_finish_reason_terminal(self.finish_is_terminal);
 
         Ok(Box::pin(parser))
     }

--- a/serdes-ai-models/src/openai/mod.rs
+++ b/serdes-ai-models/src/openai/mod.rs
@@ -32,6 +32,7 @@
 
 pub mod chat;
 pub mod responses;
+pub mod responses_stream;
 pub mod stream;
 pub mod types;
 
@@ -114,3 +115,5 @@ pub mod models {
     /// gpt-5 (future) - use Responses API
     pub const GPT_5: &str = "gpt-5";
 }
+
+mod responses_metadata;

--- a/serdes-ai-models/src/openai/responses.rs
+++ b/serdes-ai-models/src/openai/responses.rs
@@ -18,9 +18,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use serdes_ai_core::messages::{
-    ImageContent, ModelResponseStreamEvent, PartStartEvent, RetryPromptPart, StreamCompleteEvent,
-    TextPart, ThinkingPart, ToolCallArgs, ToolCallPart, ToolReturnPart, UserContent,
-    UserContentPart, UserPromptPart,
+    ImageContent, RetryPromptPart, TextPart, ThinkingPart, ToolCallArgs, ToolCallPart,
+    ToolReturnPart, UserContent, UserContentPart, UserPromptPart,
 };
 use serdes_ai_core::{
     FinishReason, ModelRequest, ModelRequestPart, ModelResponse, ModelResponsePart, ModelSettings,
@@ -234,6 +233,8 @@ impl Serialize for TruncationMode {
 pub struct ResponsesApiRequest {
     /// Model to use.
     pub model: String,
+    /// Request encrypted reasoning for stateless replay.
+    pub include: Vec<String>,
     /// Input messages/content.
     pub input: Vec<ResponseInput>,
     /// System instructions (replaces system message).
@@ -296,7 +297,7 @@ pub struct TruncationConfig {
 }
 
 /// Input item for the Responses API.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 #[serde(tag = "role")]
 #[allow(missing_docs)]
 pub enum ResponseInput {
@@ -316,6 +317,15 @@ pub enum ResponseInput {
         tool_call_id: String,
         content: String,
     },
+    /// Native Responses item (reasoning, function call, or function output).
+    #[serde(untagged)]
+    Item(JsonValue),
+}
+
+impl std::fmt::Debug for ResponseInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ResponseInput(<redacted>)")
+    }
 }
 
 /// Content for response input.
@@ -494,6 +504,8 @@ pub struct ResponsesApiResponse {
     pub usage: Option<ResponseUsage>,
     /// Response status.
     pub status: ResponseStatus,
+    /// Provider reason for a partial response.
+    pub incomplete_details: Option<JsonValue>,
     /// Error if any.
     pub error: Option<ResponseError>,
     /// Metadata.
@@ -527,7 +539,7 @@ pub struct ResponseError {
 }
 
 /// Output item from the Responses API.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Clone, Deserialize)]
 #[serde(tag = "type")]
 #[allow(missing_docs)]
 pub enum ResponseOutputItem {
@@ -535,6 +547,7 @@ pub enum ResponseOutputItem {
     #[serde(rename = "reasoning")]
     Reasoning {
         id: String,
+        encrypted_content: Option<String>,
         #[serde(default)]
         summary: Vec<ReasoningSummaryItem>,
         status: Option<String>,
@@ -600,12 +613,18 @@ pub enum ResponseOutputItem {
 }
 
 /// Reasoning summary item.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[allow(missing_docs)]
 pub enum ReasoningSummaryItem {
     #[serde(rename = "summary_text")]
     Text { text: String },
+}
+
+impl std::fmt::Debug for ResponseOutputItem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ResponseOutputItem(<redacted>)")
+    }
 }
 
 /// Message content item.
@@ -851,7 +870,7 @@ impl OpenAIResponsesModel {
                     }
                     ModelRequestPart::ModelResponse(response) => {
                         // Add the assistant response to inputs for proper alternation
-                        inputs.push(self.convert_response_to_input(response));
+                        inputs.extend(self.convert_response_to_inputs(response));
                     }
                 }
             }
@@ -907,10 +926,10 @@ impl OpenAIResponsesModel {
     }
 
     fn convert_tool_return(&self, tool_ret: &ToolReturnPart) -> ResponseInput {
-        ResponseInput::Tool {
-            tool_call_id: tool_ret.tool_call_id.clone().unwrap_or_default(),
-            content: tool_ret.content.to_string_content(),
-        }
+        ResponseInput::Item(serde_json::json!({
+            "type":"function_call_output", "call_id":tool_ret.tool_call_id,
+            "output":tool_ret.content.to_string_content(),
+        }))
     }
 
     fn convert_retry_prompt(&self, retry: &RetryPromptPart) -> ResponseInput {
@@ -919,40 +938,46 @@ impl OpenAIResponsesModel {
         }
     }
 
-    /// Convert a ModelResponse to an assistant input for multi-turn conversations.
-    fn convert_response_to_input(&self, response: &ModelResponse) -> ResponseInput {
-        let mut content_parts = Vec::new();
-
-        for part in &response.parts {
-            match part {
-                ModelResponsePart::Text(text) => {
-                    content_parts.push(text.content.clone());
-                }
-                ModelResponsePart::ToolCall(_) => {
-                    // Tool calls are handled by the model, not included in assistant input
-                }
-                ModelResponsePart::Thinking(_) => {
-                    // Thinking parts are not sent back
-                }
-                ModelResponsePart::File(_) => {
-                    // Files are not sent back
-                }
-                ModelResponsePart::BuiltinToolCall(_) => {
-                    // Builtin tool calls are not sent back
-                }
-            }
+    /// Replay native items in their original order, not as invented Chat fields.
+    fn convert_response_to_inputs(&self, response: &ModelResponse) -> Vec<ResponseInput> {
+        if let Some(items) = super::responses_metadata::passive_replay(response) {
+            return items.into_iter().map(ResponseInput::Item).collect();
         }
-
-        let content = if content_parts.is_empty() {
-            ResponseInputContent::Text(String::new())
-        } else {
-            ResponseInputContent::Text(content_parts.join(""))
-        };
-
-        ResponseInput::Assistant {
-            content,
-            reasoning_id: None,
-        }
+        response
+            .parts
+            .iter()
+            .filter_map(|part| match part {
+                ModelResponsePart::Text(text) => Some(ResponseInput::Assistant {
+                    content: ResponseInputContent::Text(text.content.clone()),
+                    reasoning_id: None,
+                }),
+                ModelResponsePart::Thinking(thinking)
+                    if thinking.provider_name.as_deref() == Some("openai") =>
+                {
+                    let mut item = serde_json::json!({"type":"reasoning", "summary": []});
+                    if let Some(id) = &thinking.id {
+                        item["id"] = id.clone().into();
+                    }
+                    if let Some(details) = &thinking.provider_details {
+                        if let Some(summary) = details.get("summary") {
+                            item["summary"] = summary.clone();
+                        }
+                    }
+                    if let Some(encrypted) = &thinking.signature {
+                        item["encrypted_content"] = encrypted.clone().into();
+                    }
+                    Some(ResponseInput::Item(item))
+                }
+                ModelResponsePart::ToolCall(tool) => Some(ResponseInput::Item(serde_json::json!({
+                    "type":"function_call", "call_id":tool.tool_call_id, "name":tool.tool_name,
+                    "arguments": match &tool.args {
+                        ToolCallArgs::String(value) => value.clone(),
+                        ToolCallArgs::Json(value) => value.to_string(),
+                    }
+                }))),
+                _ => None,
+            })
+            .collect()
     }
 
     /// Convert tool definitions to Responses API format.
@@ -1007,6 +1032,7 @@ impl OpenAIResponsesModel {
 
         ResponsesApiRequest {
             model: self.model_name.clone(),
+            include: vec!["reasoning.encrypted_content".to_owned()],
             input,
             instructions,
             tools,
@@ -1037,11 +1063,26 @@ impl OpenAIResponsesModel {
             return Err(ModelError::api("Response failed with unknown error"));
         }
 
+        match resp.status {
+            ResponseStatus::Cancelled => return Err(ModelError::Cancelled),
+            ResponseStatus::InProgress => {
+                return Err(ModelError::incomplete_stream(
+                    "Responses endpoint returned a non-terminal response",
+                ));
+            }
+            _ => {}
+        }
         let mut parts = Vec::new();
+        let mut refused = false;
 
         for output in resp.output {
             match output {
-                ResponseOutputItem::Reasoning { id, summary, .. } => {
+                ResponseOutputItem::Reasoning {
+                    id,
+                    summary,
+                    encrypted_content,
+                    ..
+                } => {
                     // Convert reasoning to ThinkingPart
                     let content: String = summary
                         .iter()
@@ -1051,10 +1092,15 @@ impl OpenAIResponsesModel {
                         .collect::<Vec<_>>()
                         .join("\n");
 
-                    if !content.is_empty() {
-                        let thinking = ThinkingPart::new(content)
+                    {
+                        let mut thinking = ThinkingPart::new(content)
                             .with_id(&id)
                             .with_provider_name("openai");
+                        thinking.signature = encrypted_content;
+                        thinking.provider_details = Some(serde_json::Map::from_iter([(
+                            "summary".to_owned(),
+                            serde_json::to_value(&summary).unwrap_or_default(),
+                        )]));
                         parts.push(ModelResponsePart::Thinking(thinking));
                     }
                 }
@@ -1066,8 +1112,8 @@ impl OpenAIResponsesModel {
                                     parts.push(ModelResponsePart::Text(TextPart::new(text)));
                                 }
                             }
-                            MessageContentItem::Refusal { refusal } => {
-                                return Err(ModelError::ContentFiltered(refusal));
+                            MessageContentItem::Refusal { .. } => {
+                                refused = true;
                             }
                         }
                     }
@@ -1078,8 +1124,9 @@ impl OpenAIResponsesModel {
                     arguments,
                     ..
                 } => {
-                    let args: JsonValue =
-                        serde_json::from_str(&arguments).unwrap_or(serde_json::json!({}));
+                    let args: JsonValue = serde_json::from_str(&arguments).map_err(|_| {
+                        ModelError::invalid_response("Invalid Responses function-call arguments")
+                    })?;
                     parts.push(ModelResponsePart::ToolCall(
                         ToolCallPart::new(name, ToolCallArgs::Json(args))
                             .with_tool_call_id(call_id),
@@ -1097,11 +1144,29 @@ impl OpenAIResponsesModel {
             }
         }
 
-        let finish_reason = match resp.status {
-            ResponseStatus::Completed => Some(FinishReason::Stop),
-            ResponseStatus::Incomplete => Some(FinishReason::Length),
-            ResponseStatus::Cancelled => Some(FinishReason::Stop),
-            _ => None,
+        let finish_reason = if refused {
+            Some(FinishReason::ContentFilter)
+        } else {
+            match resp.status {
+                ResponseStatus::Completed => Some(FinishReason::Stop),
+                ResponseStatus::Incomplete => Some(
+                    match resp
+                        .incomplete_details
+                        .as_ref()
+                        .and_then(|v| v["reason"].as_str())
+                    {
+                        Some("max_output_tokens") => FinishReason::Length,
+                        Some("content_filter") => FinishReason::ContentFilter,
+                        _ => {
+                            return Err(ModelError::invalid_response(
+                                "Unknown Responses incomplete reason",
+                            ));
+                        }
+                    },
+                ),
+                ResponseStatus::Cancelled => Some(FinishReason::Stop),
+                _ => None,
+            }
         };
 
         let usage = resp.usage.map(|u| RequestUsage {
@@ -1203,83 +1268,66 @@ impl Model for OpenAIResponsesModel {
             return Err(self.handle_error_response(status, &body));
         }
 
-        let resp: ResponsesApiResponse = response
+        let raw: JsonValue = response
             .json()
             .await
-            .map_err(|e| ModelError::invalid_response(e.to_string()))?;
-
-        self.process_response(resp)
+            .map_err(|_| ModelError::invalid_response("Invalid Responses JSON"))?;
+        let metadata = super::responses_metadata::terminal(&raw)?;
+        // Only native parts enter replay conversion. All other output records are
+        // retained in bounded archival metadata, including future provider types.
+        let mut parsed = raw.clone();
+        if let Some(items) = parsed["output"].as_array_mut() {
+            items.retain(|item| {
+                matches!(
+                    item["type"].as_str(),
+                    Some("message" | "reasoning" | "function_call")
+                )
+            });
+        }
+        let resp: ResponsesApiResponse = serde_json::from_value(parsed)
+            .map_err(|_| ModelError::invalid_response("Unsupported Responses JSON shape"))?;
+        let mut response = self.process_response(resp)?;
+        metadata.apply(&mut response);
+        Ok(response)
     }
 
-    /// Stream a response through the non-streaming request fallback.
+    /// Stream native Responses SSE incrementally.
     async fn request_stream(
         &self,
         messages: &[ModelRequest],
         settings: &ModelSettings,
         params: &ModelRequestParameters,
     ) -> Result<StreamedResponse, ModelError> {
-        // For now, fall back to non-streaming
-        // TODO: Implement proper streaming with ResponsesStreamParser
-        let response = self.request(messages, settings, params).await?;
-
-        let ModelResponse {
-            parts,
-            finish_reason,
-            usage,
-            ..
-        } = response;
-
-        // Part events first, terminal event last; the request error above
-        // short-circuits failures before any event is emitted.
-        let mut events: Vec<Result<ModelResponseStreamEvent, ModelError>> = parts
-            .into_iter()
-            .enumerate()
-            .map(|(idx, part)| {
-                Ok(ModelResponseStreamEvent::PartStart(PartStartEvent::new(
-                    idx, part,
-                )))
-            })
-            .collect();
-
-        events.push(Ok(stream_complete_event(finish_reason, usage.as_ref())));
-
-        Ok(Box::pin(futures::stream::iter(events)))
+        let body = self.build_request(messages, settings, params, true);
+        let mut request = self
+            .client
+            .post(format!("{}/responses", self.base_url))
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Accept", "text/event-stream")
+            .timeout(settings.timeout.unwrap_or(self.default_timeout));
+        if let Some(org) = &self.organization {
+            request = request.header("OpenAI-Organization", org);
+        }
+        if let Some(project) = &self.project {
+            request = request.header("OpenAI-Project", project);
+        }
+        let response = request.json(&body).send().await?;
+        if !response.status().is_success() {
+            return Err(self.handle_error_response(
+                response.status().as_u16(),
+                &response.text().await.unwrap_or_default(),
+            ));
+        }
+        Ok(Box::pin(super::responses_stream::ResponsesStream::new(
+            response.bytes_stream(),
+        )))
     }
-}
-
-/// Build the terminal event from the finish reason and usage the
-/// non-streaming path mapped from the completed response.
-///
-/// Usage fields absent from the response stay `None`; a status the
-/// non-streaming mapping leaves unmapped defaults to [`FinishReason::Stop`],
-/// matching the chat stream parser's terminal default.
-fn stream_complete_event(
-    finish_reason: Option<FinishReason>,
-    usage: Option<&RequestUsage>,
-) -> ModelResponseStreamEvent {
-    let mut event = StreamCompleteEvent::new(finish_reason.unwrap_or(FinishReason::Stop));
-
-    if let Some(u) = usage {
-        if let Some(tokens) = u.request_tokens {
-            event = event.with_input_tokens(tokens);
-        }
-        if let Some(tokens) = u.response_tokens {
-            event = event.with_output_tokens(tokens);
-        }
-        if let Some(tokens) = u.cache_creation_tokens {
-            event = event.with_cache_creation_tokens(tokens);
-        }
-        if let Some(tokens) = u.cache_read_tokens {
-            event = event.with_cache_read_tokens(tokens);
-        }
-    }
-
-    ModelResponseStreamEvent::StreamComplete(event)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serdes_ai_core::messages::ModelResponseStreamEvent;
 
     /// Every effort variant serializes as its API string; custom values
     /// pass through verbatim.
@@ -1500,7 +1548,14 @@ mod tests {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("POST"))
             .and(wiremock::matchers::path("/responses"))
-            .respond_with(wiremock::ResponseTemplate::new(200).set_body_json(body))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(format!(
+                        "data: {}\n\n",
+                        serde_json::json!({"type":"response.completed", "response":body})
+                    )),
+            )
             .mount(&server)
             .await;
 
@@ -1543,8 +1598,8 @@ mod tests {
             Some(ModelResponseStreamEvent::PartStart(start)) => {
                 assert_eq!(start.index, 0);
                 assert!(
-                    matches!(&start.part, ModelResponsePart::Text(t) if t.content == "Hello"),
-                    "expected the buffered text part first, got {:?}",
+                    matches!(&start.part, ModelResponsePart::Text(t) if t.content.is_empty()),
+                    "expected the incremental text part start, got {:?}",
                     start.part
                 );
             }

--- a/serdes-ai-models/src/openai/responses_metadata.rs
+++ b/serdes-ai-models/src/openai/responses_metadata.rs
@@ -1,0 +1,93 @@
+//! Native archival metadata, not arbitrary replay or application tool execution.
+use crate::ModelError;
+use serde_json::{Value, json};
+use serdes_ai_core::messages::TerminalMetadata;
+
+/// Bound retained native output and usage metadata to avoid unbounded archives.
+pub(super) fn terminal(response: &Value) -> Result<TerminalMetadata, ModelError> {
+    let details = json!({
+        "provider": "openai", "api": "responses", "status": response.get("status"),
+        "usage": response.get("usage"), "metadata": response.get("metadata"),
+        "service_tier": response.get("service_tier"), "created_at": response.get("created_at"),
+        "incomplete_details": response.get("incomplete_details"),
+        "output_records": response.get("output").and_then(Value::as_array).map(|items| items.iter().enumerate().map(|(index,item)| {
+            json!({"output_index":index, "type":item.get("type"), "item":item,
+                "representation": if matches!(item["type"].as_str(), Some("message"|"reasoning"|"function_call")) { "native_parts" } else { "opaque_not_replayed" }})
+        }).collect::<Vec<_>>()),
+        "usage_complete": response["usage"]["input_tokens"].as_u64().is_some() && response["usage"]["output_tokens"].as_u64().is_some()
+    });
+    if serde_json::to_vec(&details)
+        .map_err(|_| ModelError::invalid_response("Invalid metadata"))?
+        .len()
+        > 2 * 1024 * 1024
+    {
+        return Err(ModelError::invalid_response(
+            "Responses terminal metadata exceeds 2 MiB",
+        ));
+    }
+    Ok(TerminalMetadata {
+        response_id: response["id"].as_str().map(str::to_owned),
+        model: response["model"].as_str().map(str::to_owned),
+        details: Some(details),
+    })
+}
+
+/// Replay only supported passive native items. Archival built-in tools never
+/// become requests or executable application calls. Function calls use parts.
+pub(super) fn passive_replay(response: &serdes_ai_core::ModelResponse) -> Option<Vec<Value>> {
+    let details = response.vendor_details.as_ref()?;
+    if details["provider"] != "openai" || details["api"] != "responses" {
+        return None;
+    }
+    let records = details["output_records"].as_array()?;
+    let mut result = Vec::new();
+    for (index, record) in records.iter().enumerate() {
+        if record["output_index"].as_u64()? != index as u64 {
+            return None;
+        }
+        let item = &record["item"];
+        let keys: &[&str] =
+            match item["type"].as_str()? {
+                "message" => {
+                    if !item["content"].as_array()?.iter().all(|part| {
+                        matches!(part["type"].as_str(), Some("output_text" | "refusal"))
+                    }) {
+                        return None;
+                    }
+                    &["type", "id", "role", "status", "content"]
+                }
+                "reasoning" => &["type", "id", "summary", "encrypted_content", "status"],
+                "function_call" => {
+                    // Only canonical typed calls authorize replay; the archive cannot
+                    // introduce a new callable item or override repaired arguments.
+                    let call = response.parts.iter().find_map(|part| match part {
+                        serdes_ai_core::ModelResponsePart::ToolCall(call)
+                            if call.tool_call_id.as_deref() == item["call_id"].as_str()
+                                && call.tool_name == item["name"].as_str().unwrap_or_default() =>
+                        {
+                            Some(call)
+                        }
+                        _ => None,
+                    })?;
+                    result.push(json!({"type":"function_call", "call_id":call.tool_call_id,
+                    "name":call.tool_name, "arguments":match &call.args {
+                        serdes_ai_core::messages::ToolCallArgs::String(value) => value.clone(),
+                        serdes_ai_core::messages::ToolCallArgs::Json(value) => value.to_string(),
+                    }}));
+                    continue;
+                }
+                _ => continue,
+            };
+        let mut replay = serde_json::Map::new();
+        for key in keys {
+            if let Some(value) = item.get(*key) {
+                replay.insert((*key).into(), value.clone());
+            }
+        }
+        if item["type"] == "message" {
+            replay.insert("role".into(), "assistant".into());
+        }
+        result.push(Value::Object(replay));
+    }
+    Some(result)
+}

--- a/serdes-ai-models/src/openai/responses_stream.rs
+++ b/serdes-ai-models/src/openai/responses_stream.rs
@@ -1,0 +1,543 @@
+//! Incremental Responses SSE. Item completion is not response completion.
+use crate::ModelError;
+use bytes::Bytes;
+use futures::Stream;
+use serde_json::Value;
+use serdes_ai_core::messages::*;
+use serdes_ai_core::{FinishReason, ModelResponsePart};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+#[derive(Default)]
+struct Item {
+    part: Option<usize>,
+    kind: String,
+    text: String,
+    encrypted: String,
+    closed: bool,
+    slots: BTreeMap<u64, (usize, String)>,
+    summaries: BTreeMap<u64, String>,
+}
+/// Byte-buffered native Responses event parser. No payloads are logged.
+pub struct ResponsesStream<S> {
+    inner: Pin<Box<S>>,
+    buffer: Vec<u8>,
+    data: String,
+    queue: VecDeque<Result<ModelResponseStreamEvent, ModelError>>,
+    items: BTreeMap<u64, Item>,
+    next: usize,
+    response_id: Option<String>,
+    done: bool,
+}
+impl<S> ResponsesStream<S> {
+    /// Parse a native Responses HTTP byte stream.
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner: Box::pin(inner),
+            buffer: Vec::new(),
+            data: String::new(),
+            queue: VecDeque::new(),
+            items: BTreeMap::new(),
+            next: 0,
+            response_id: None,
+            done: false,
+        }
+    }
+    fn emit(&mut self, event: ModelResponseStreamEvent) {
+        self.queue.push_back(Ok(event));
+    }
+    fn fail(&mut self, error: ModelError) {
+        self.done = true;
+        self.queue.push_back(Err(error));
+    }
+    fn metadata(&self, item: &Value) -> serde_json::Map<String, Value> {
+        let mut map = serde_json::Map::new();
+        if let Some(id) = &self.response_id {
+            map.insert("response_id".into(), id.clone().into());
+        }
+        if let Some(id) = item.get("id") {
+            map.insert("item_id".into(), id.clone());
+        }
+        map
+    }
+    fn item(&mut self, index: u64, value: &Value, completed: bool) -> Result<(), ModelError> {
+        if serde_json::to_vec(value)
+            .map_err(|_| ModelError::invalid_response("Invalid item"))?
+            .len()
+            > 2 * 1024 * 1024
+        {
+            return Err(ModelError::invalid_response("Responses item exceeds 2 MiB"));
+        }
+        let kind = value["type"]
+            .as_str()
+            .ok_or_else(|| ModelError::invalid_response("Responses item lacks type"))?;
+        if let Some(state) = self.items.get(&index) {
+            if state.kind != kind {
+                return Err(ModelError::invalid_response("Responses item type changed"));
+            }
+        }
+        if !self.items.contains_key(&index) {
+            if self
+                .items
+                .keys()
+                .next_back()
+                .is_some_and(|last| index <= *last)
+            {
+                return Err(ModelError::invalid_response(
+                    "Responses output items out of order",
+                ));
+            }
+            let mut metadata = self.metadata(value);
+            metadata.insert("output_index".into(), index.into());
+            let part = match kind {
+                "message" => Some(ModelResponsePart::Text(
+                    TextPart::new("").with_provider_details(metadata),
+                )),
+                "reasoning" => Some(ModelResponsePart::Thinking(
+                    ThinkingPart::new("")
+                        .with_id(value["id"].as_str().unwrap_or_default())
+                        .with_provider_name("openai")
+                        .with_provider_details(metadata),
+                )),
+                "function_call" => Some(ModelResponsePart::ToolCall(
+                    ToolCallPart::new(
+                        value["name"].as_str().ok_or_else(|| {
+                            ModelError::invalid_response("Function item lacks name")
+                        })?,
+                        ToolCallArgs::String(String::new()),
+                    )
+                    .with_tool_call_id(value["call_id"].as_str().ok_or_else(|| {
+                        ModelError::invalid_response("Function item lacks call_id")
+                    })?)
+                    .with_provider_details(metadata),
+                )),
+                _ => None, // Native built-in tool events are not executable function calls.
+            };
+            let part_index = part.map(|part| {
+                let index = self.next;
+                self.next += 1;
+                self.emit(ModelResponseStreamEvent::part_start(index, part));
+                index
+            });
+            self.items.insert(
+                index,
+                Item {
+                    part: part_index,
+                    kind: kind.into(),
+                    slots: if kind == "message" {
+                        part_index
+                            .map(|p| BTreeMap::from([(0, (p, String::new()))]))
+                            .unwrap_or_default()
+                    } else {
+                        BTreeMap::new()
+                    },
+                    ..Default::default()
+                },
+            );
+        }
+        if value["content"].as_array().is_some_and(|items| {
+            items
+                .iter()
+                .any(|item| !matches!(item["type"].as_str(), Some("output_text" | "refusal")))
+        }) {
+            return Err(ModelError::invalid_response(
+                "Unsupported Responses message content shape",
+            ));
+        }
+        if kind == "message" && !self.items[&index].closed {
+            if let Some(content) = value["content"].as_array() {
+                for (slot, item) in content.iter().enumerate() {
+                    self.slot(index, slot as u64)?;
+                    let text = item["text"].as_str().unwrap_or_default();
+                    let previous = self.items[&index].slots[&(slot as u64)].1.clone();
+                    if !text.starts_with(&previous) {
+                        return Err(ModelError::invalid_response(
+                            "Content slot contradicts streamed text",
+                        ));
+                    }
+                    self.slot_delta(index, slot as u64, &text[previous.len()..])?;
+                    let part = self.items[&index].slots[&(slot as u64)].0;
+                    let details = serde_json::Map::from_iter([
+                        ("content_index".into(), slot.into()),
+                        ("native_content".into(), item.clone()),
+                    ]);
+                    self.emit(ModelResponseStreamEvent::PartDelta(PartDeltaEvent {
+                        index: part,
+                        delta: ModelResponsePartDelta::Text(
+                            TextPartDelta::new("").with_provider_details(details),
+                        ),
+                    }));
+                }
+            }
+        }
+        if kind == "reasoning" {
+            if let Some(summary) = value["summary"].as_array() {
+                for (slot, text) in &self.items[&index].summaries {
+                    if !summary
+                        .get(*slot as usize)
+                        .and_then(|v| v["text"].as_str())
+                        .is_some_and(|final_text| final_text.starts_with(text))
+                    {
+                        return Err(ModelError::invalid_response(
+                            "Summary snapshot contradicts delta",
+                        ));
+                    }
+                }
+            }
+        }
+        let final_text = match kind {
+            "function_call" => value["arguments"].as_str().map(str::to_owned),
+            "reasoning" => value["summary"].as_array().map(|items| {
+                items
+                    .iter()
+                    .filter_map(|v| v["text"].as_str())
+                    .collect::<String>()
+            }),
+            _ => None,
+        };
+        if let Some(text) = final_text {
+            let previous = &self.items[&index].text;
+            if !text.starts_with(previous) {
+                return Err(ModelError::invalid_response(
+                    "Responses item contradicts emitted content",
+                ));
+            }
+            let suffix = text[previous.len()..].to_owned();
+            if !suffix.is_empty() {
+                self.delta(index, &suffix)?;
+            }
+        }
+        if kind == "reasoning" && !self.items[&index].closed {
+            let state = self.items.get_mut(&index).unwrap();
+            let mut delta = ThinkingPartDelta::new("");
+            if let Some(encrypted) = value["encrypted_content"].as_str() {
+                if !encrypted.starts_with(&state.encrypted) {
+                    return Err(ModelError::invalid_response(
+                        "Conflicting encrypted reasoning",
+                    ));
+                }
+                delta.signature_delta = Some(encrypted[state.encrypted.len()..].to_owned());
+                state.encrypted = encrypted.into();
+            }
+            if let Some(summary) = value.get("summary") {
+                delta.provider_details = Some(serde_json::Map::from_iter([(
+                    "summary".into(),
+                    summary.clone(),
+                )]));
+            }
+            if let Some(part) = state.part {
+                self.emit(ModelResponseStreamEvent::PartDelta(PartDeltaEvent {
+                    index: part,
+                    delta: ModelResponsePartDelta::Thinking(delta),
+                }));
+            }
+        }
+        if completed {
+            let state = self.items.get_mut(&index).unwrap();
+            if !state.closed {
+                state.closed = true;
+                let parts: Vec<_> = if state.kind == "message" {
+                    state.slots.values().map(|(p, _)| *p).collect()
+                } else {
+                    state.part.into_iter().collect()
+                };
+                for part in parts {
+                    self.emit(ModelResponseStreamEvent::part_end(part));
+                }
+            }
+        }
+        Ok(())
+    }
+    fn slot(&mut self, index: u64, slot: u64) -> Result<usize, ModelError> {
+        let state = self
+            .items
+            .get(&index)
+            .ok_or_else(|| ModelError::invalid_response("Content before item"))?;
+        if state.kind != "message" || slot > 1024 {
+            return Err(ModelError::invalid_response("Invalid content slot"));
+        }
+        if let Some((part, _)) = state.slots.get(&slot) {
+            return Ok(*part);
+        }
+        if slot != state.slots.len() as u64 {
+            return Err(ModelError::invalid_response(
+                "Noncontiguous content slot declaration",
+            ));
+        }
+        let part = self.next;
+        self.next += 1;
+        self.items
+            .get_mut(&index)
+            .unwrap()
+            .slots
+            .insert(slot, (part, String::new()));
+        let metadata = serde_json::Map::from_iter([
+            ("output_index".into(), index.into()),
+            ("content_index".into(), slot.into()),
+        ]);
+        self.emit(ModelResponseStreamEvent::part_start(
+            part,
+            ModelResponsePart::Text(TextPart::new("").with_provider_details(metadata)),
+        ));
+        Ok(part)
+    }
+    fn slot_delta(&mut self, index: u64, slot: u64, text: &str) -> Result<(), ModelError> {
+        let part = self.slot(index, slot)?;
+        if self.items[&index].closed && !text.is_empty() {
+            return Err(ModelError::invalid_response("Content after item end"));
+        }
+        self.items
+            .get_mut(&index)
+            .unwrap()
+            .slots
+            .get_mut(&slot)
+            .unwrap()
+            .1
+            .push_str(text);
+        if !text.is_empty() {
+            self.emit(ModelResponseStreamEvent::text_delta(part, text));
+        }
+        Ok(())
+    }
+    fn delta(&mut self, index: u64, text: &str) -> Result<(), ModelError> {
+        let state = self
+            .items
+            .get_mut(&index)
+            .ok_or_else(|| ModelError::invalid_response("Delta before item"))?;
+        if state.closed {
+            return Err(ModelError::invalid_response("Delta after item completion"));
+        }
+        state.text.push_str(text);
+        if let Some(part) = state.part {
+            let event = match state.kind.as_str() {
+                "function_call" => PartDeltaEvent::tool_call_args(part, text),
+                "reasoning" => PartDeltaEvent {
+                    index: part,
+                    delta: ModelResponsePartDelta::Thinking(ThinkingPartDelta::new(text)),
+                },
+                _ => PartDeltaEvent::text(part, text),
+            };
+            self.emit(ModelResponseStreamEvent::PartDelta(event));
+        }
+        Ok(())
+    }
+    fn event(&mut self, value: Value) -> Result<(), ModelError> {
+        let kind = value["type"]
+            .as_str()
+            .ok_or_else(|| ModelError::invalid_response("Responses event lacks type"))?;
+        if let Some(id) = value["response"]["id"].as_str() {
+            if self.response_id.as_deref().is_some_and(|old| old != id) {
+                return Err(ModelError::invalid_response("Response ID changed"));
+            }
+            self.response_id = Some(id.into());
+        }
+        match kind {
+            "response.output_item.added" | "response.output_item.done" => {
+                let index = value["output_index"]
+                    .as_u64()
+                    .ok_or_else(|| ModelError::invalid_response("Missing output index"))?;
+                self.item(index, &value["item"], kind.ends_with("done"))?;
+            }
+            "response.output_text.delta"
+            | "response.reasoning_summary_text.delta"
+            | "response.function_call_arguments.delta" => {
+                if kind == "response.output_text.delta" {
+                    let index = value["output_index"]
+                        .as_u64()
+                        .ok_or_else(|| ModelError::invalid_response("Missing output index"))?;
+                    let slot = value["content_index"]
+                        .as_u64()
+                        .ok_or_else(|| ModelError::invalid_response("Missing content index"))?;
+                    self.slot_delta(
+                        index,
+                        slot,
+                        value["delta"]
+                            .as_str()
+                            .ok_or_else(|| ModelError::invalid_response("Missing delta"))?,
+                    )?;
+                    return Ok(());
+                }
+                if kind == "response.reasoning_summary_text.delta" {
+                    let index = value["output_index"]
+                        .as_u64()
+                        .ok_or_else(|| ModelError::invalid_response("Missing output index"))?;
+                    let slot = value["summary_index"].as_u64().unwrap_or(0);
+                    if slot > 1024 {
+                        return Err(ModelError::invalid_response("Invalid summary index"));
+                    }
+                    let text = value["delta"]
+                        .as_str()
+                        .ok_or_else(|| ModelError::invalid_response("Missing summary delta"))?;
+                    let item = self
+                        .items
+                        .get_mut(&index)
+                        .ok_or_else(|| ModelError::invalid_response("Summary before item"))?;
+                    if item.kind != "reasoning" || item.closed {
+                        return Err(ModelError::invalid_response("Invalid reasoning delta"));
+                    }
+                    item.summaries.entry(slot).or_default().push_str(text);
+                    if slot == 0 {
+                        self.delta(index, text)?;
+                    }
+                    return Ok(());
+                }
+                self.delta(
+                    value["output_index"]
+                        .as_u64()
+                        .ok_or_else(|| ModelError::invalid_response("Missing output index"))?,
+                    value["delta"]
+                        .as_str()
+                        .ok_or_else(|| ModelError::invalid_response("Missing delta"))?,
+                )?;
+            }
+            "response.content_part.added" => {
+                let index = value["output_index"]
+                    .as_u64()
+                    .ok_or_else(|| ModelError::invalid_response("Missing output index"))?;
+                let slot = value["content_index"]
+                    .as_u64()
+                    .ok_or_else(|| ModelError::invalid_response("Missing content index"))?;
+                self.slot(index, slot)?;
+            }
+            "response.failed" | "error" => {
+                return Err(ModelError::Api {
+                    message: "Responses provider reported failure".into(),
+                    code: value["response"]["error"]["code"]
+                        .as_str()
+                        .or(value["code"].as_str())
+                        .map(str::to_owned),
+                });
+            }
+            "response.refusal.delta" | "response.refusal.done" => {} // Retained in terminal output_records; never dispatched.
+            "response.cancelled" => return Err(ModelError::Cancelled),
+            "response.completed" | "response.incomplete" => {
+                let response = &value["response"];
+                let expected = if kind == "response.completed" {
+                    "completed"
+                } else {
+                    "incomplete"
+                };
+                if response["status"].as_str() != Some(expected) {
+                    return Err(ModelError::invalid_response(
+                        "Terminal event/status mismatch",
+                    ));
+                }
+                let reason = if expected == "completed" {
+                    FinishReason::Stop
+                } else {
+                    match response["incomplete_details"]["reason"].as_str() {
+                        Some("max_output_tokens") => FinishReason::Length,
+                        Some("content_filter") => FinishReason::ContentFilter,
+                        _ => {
+                            return Err(ModelError::invalid_response(
+                                "Unknown Responses incomplete reason",
+                            ));
+                        }
+                    }
+                };
+                let output = response["output"].as_array().ok_or_else(|| {
+                    ModelError::invalid_response("Terminal response lacks output")
+                })?;
+                for (index, item) in output.iter().enumerate() {
+                    self.item(index as u64, item, true)?;
+                }
+                if reason == FinishReason::Stop
+                    && self.items.values().any(|item| {
+                        !item.closed
+                            || (item.kind == "function_call"
+                                && serde_json::from_str::<Value>(&item.text).is_err())
+                    })
+                {
+                    return Err(ModelError::invalid_response(
+                        "Incomplete function call in completed response",
+                    ));
+                }
+                let mut complete = StreamCompleteEvent::new(
+                    if reason == FinishReason::Stop
+                        && self.items.values().any(|i| i.kind == "function_call")
+                    {
+                        FinishReason::ToolCall
+                    } else {
+                        reason
+                    },
+                );
+                complete.metadata = Some(super::responses_metadata::terminal(response)?);
+                if output.iter().any(|item| {
+                    item["content"]
+                        .as_array()
+                        .is_some_and(|parts| parts.iter().any(|p| p["type"] == "refusal"))
+                }) {
+                    complete.finish_reason = FinishReason::ContentFilter;
+                }
+                if let Some(usage) = response.get("usage").filter(|v| !v.is_null()) {
+                    complete.input_tokens = usage["input_tokens"].as_u64();
+                    complete.output_tokens = usage["output_tokens"].as_u64();
+                    complete.cache_read_tokens =
+                        usage["input_tokens_details"]["cached_tokens"].as_u64();
+                }
+                self.emit(ModelResponseStreamEvent::StreamComplete(complete));
+                self.done = true;
+            }
+            _ => {} // Lifecycle/content-part/done and built-in tool telemetry.
+        }
+        Ok(())
+    }
+    fn line(&mut self, bytes: &[u8]) -> Result<(), ModelError> {
+        let line = std::str::from_utf8(bytes)
+            .map_err(|_| ModelError::invalid_response("Invalid Responses SSE UTF-8"))?
+            .trim_end_matches(['\r', '\n']);
+        if line.is_empty() {
+            if !self.data.is_empty() {
+                let data = std::mem::take(&mut self.data);
+                let value = serde_json::from_str(&data)
+                    .map_err(|_| ModelError::invalid_response("Malformed Responses SSE JSON"))?;
+                self.event(value)?;
+            }
+        } else if let Some(data) = line.strip_prefix("data:") {
+            if !self.data.is_empty() {
+                self.data.push('\n');
+            }
+            self.data.push_str(data.strip_prefix(' ').unwrap_or(data));
+        }
+        Ok(())
+    }
+}
+impl<S: Stream<Item = Result<Bytes, reqwest::Error>>> Stream for ResponsesStream<S> {
+    type Item = Result<ModelResponseStreamEvent, ModelError>;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Some(event) = this.queue.pop_front() {
+                return Poll::Ready(Some(event));
+            }
+            if this.done {
+                return Poll::Ready(None);
+            }
+            if let Some(end) = this.buffer.iter().position(|byte| *byte == b'\n') {
+                let line: Vec<_> = this.buffer.drain(..=end).collect();
+                if let Err(error) = this.line(&line) {
+                    this.fail(error);
+                }
+                continue;
+            }
+            match this.inner.as_mut().poll_next(cx) {
+                Poll::Ready(Some(Ok(bytes))) => {
+                    this.buffer.extend_from_slice(&bytes);
+                    if this.buffer.len() + this.data.len() > 16 * 1024 * 1024 {
+                        this.fail(ModelError::invalid_response(
+                            "Responses SSE record exceeds 16 MiB",
+                        ));
+                    }
+                }
+                Poll::Ready(Some(Err(error))) => this.fail(error.into()),
+                Poll::Ready(None) => this.fail(ModelError::incomplete_stream(
+                    "Responses EOF before terminal event",
+                )),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}

--- a/serdes-ai-models/src/openai/stream.rs
+++ b/serdes-ai-models/src/openai/stream.rs
@@ -1,54 +1,21 @@
-//! OpenAI SSE stream parser.
-//!
-//! This module provides streaming support for OpenAI chat completions.
-
-pin_project! {
-    /// OpenAI SSE stream parser.
-    pub struct OpenAIStreamParser<S> {
-        #[pin]
-        inner: S,
-        buffer: String,
-        // Track tool calls in progress (index -> accumulated data)
-        tool_calls: HashMap<u32, ToolCallState>,
-        // Track text part state
-        text_started: bool,
-        // Track if we've emitted a part start for text
-        current_text_index: Option<usize>,
-        // Track thinking/reasoning part state
-        thinking_started: bool,
-        // Track if we've emitted a part start for thinking
-        current_thinking_index: Option<usize>,
-        // Next part index to use
-        next_part_index: usize,
-        // Finished: terminal event emitted or stream failed; no further events
-        done: bool,
-        // data: [DONE] marker observed; terminal event still pending
-        done_seen: bool,
-        // Last seen non-None finish reason across chunks
-        last_finish_reason: Option<FinishReason>,
-        // Buffered usage from the include_usage chunk
-        usage: Option<Usage>,
-        // Pending PartEnd events to emit (queued when multiple parts close at once)
-        pending_part_ends: Vec<usize>,
-    }
-}
-
+//! OpenAI-compatible Chat SSE parser. `[DONE]` is the transport terminal marker.
+//! Finish frames alone are not terminal: a usage-only frame may follow them.
 use super::types::{ChatCompletionChunk, Usage};
 use crate::error::ModelError;
 use bytes::Bytes;
 use futures::Stream;
-use pin_project_lite::pin_project;
 use serdes_ai_core::ModelResponsePart;
 use serdes_ai_core::messages::{
     FinishReason, ModelResponseStreamEvent, PartDeltaEvent, PartEndEvent, PartStartEvent,
     StreamCompleteEvent, TextPart, ThinkingPart, ThinkingPartDelta, ToolCallArgs, ToolCallPart,
 };
-use std::collections::HashMap;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    pin::Pin,
+    task::{Context, Poll},
+};
 
-/// State for an in-progress tool call.
-#[derive(Debug, Clone, Default)]
+#[derive(Default)]
 struct ToolCallState {
     id: String,
     name: String,
@@ -57,324 +24,273 @@ struct ToolCallState {
     started: bool,
 }
 
-impl<S> OpenAIStreamParser<S>
-where
-    S: Stream<Item = Result<Bytes, reqwest::Error>>,
-{
-    /// Create a new stream parser.
+/// Incremental parser with byte buffering (HTTP chunks need not be UTF-8 boundaries).
+pub struct OpenAIStreamParser<S> {
+    inner: Pin<Box<S>>,
+    buffer: Vec<u8>,
+    pending: VecDeque<Result<ModelResponseStreamEvent, ModelError>>,
+    tools: BTreeMap<u32, ToolCallState>,
+    text: Option<usize>,
+    thinking: Option<usize>,
+    next_index: usize,
+    finish: Option<FinishReason>,
+    usage: Option<Usage>,
+    done: bool,
+    finish_is_terminal: bool,
+}
+
+impl<S> OpenAIStreamParser<S> {
+    /// Create a parser for a Chat Completions endpoint using the `[DONE]` contract.
     pub fn new(inner: S) -> Self {
         Self {
-            inner,
-            buffer: String::new(),
-            tool_calls: HashMap::new(),
-            text_started: false,
-            current_text_index: None,
-            thinking_started: false,
-            current_thinking_index: None,
-            next_part_index: 0,
-            done: false,
-            done_seen: false,
-            last_finish_reason: None,
+            inner: Box::pin(inner),
+            buffer: Vec::new(),
+            pending: VecDeque::new(),
+            tools: BTreeMap::new(),
+            text: None,
+            thinking: None,
+            next_index: 0,
+            finish: None,
             usage: None,
-            pending_part_ends: Vec::new(),
+            done: false,
+            finish_is_terminal: false,
+        }
+    }
+
+    /// Allow clean EOF after a finish frame for compatible endpoints without `[DONE]`.
+    /// Disabled by default. Usage frames are still consumed until EOF.
+    pub fn with_finish_reason_terminal(mut self, enabled: bool) -> Self {
+        self.finish_is_terminal = enabled;
+        self
+    }
+
+    fn fail(&mut self, error: ModelError) {
+        self.done = true;
+        self.pending.push_back(Err(error));
+    }
+
+    fn emit(&mut self, event: ModelResponseStreamEvent) {
+        self.pending.push_back(Ok(event));
+    }
+
+    fn validate_tools(&mut self) -> bool {
+        if self.finish == Some(FinishReason::Length) {
+            return true;
+        }
+        if self.tools.values().any(|tool| {
+            !tool.started || serde_json::from_str::<serde_json::Value>(&tool.arguments).is_err()
+        }) {
+            self.fail(ModelError::invalid_response(
+                "Incomplete Chat tool call at terminal frame",
+            ));
+            return false;
+        }
+        true
+    }
+
+    fn close_parts(&mut self) {
+        let mut indices: Vec<_> = self
+            .text
+            .take()
+            .into_iter()
+            .chain(self.thinking.take())
+            .collect();
+        indices.extend(
+            std::mem::take(&mut self.tools)
+                .into_values()
+                .filter(|tool| tool.started)
+                .map(|tool| tool.part_index),
+        );
+        indices.sort_unstable();
+        for index in indices {
+            self.emit(ModelResponseStreamEvent::PartEnd(PartEndEvent { index }));
+        }
+    }
+
+    fn line(&mut self, bytes: &[u8]) {
+        let Ok(line) = std::str::from_utf8(bytes) else {
+            self.fail(ModelError::invalid_response("Invalid UTF-8 in Chat SSE"));
+            return;
+        };
+        let Some(data) = line.trim().strip_prefix("data:") else {
+            return;
+        };
+        let data = data.trim_start();
+        if data == "[DONE]" {
+            if !self.validate_tools() {
+                return;
+            }
+            self.close_parts();
+            self.emit(stream_complete_event(self.finish, self.usage.as_ref()));
+            self.done = true;
+            return;
+        }
+        let value: serde_json::Value = match serde_json::from_str(data) {
+            Ok(value) => value,
+            Err(_) => {
+                self.fail(ModelError::invalid_response("Malformed Chat SSE JSON"));
+                return;
+            }
+        };
+        if let Some(error) = value.get("error") {
+            self.fail(ModelError::Api {
+                message: error
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Chat provider stream error")
+                    .to_owned(),
+                code: error
+                    .get("code")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_owned),
+            });
+            return;
+        }
+        let chunk: ChatCompletionChunk = match serde_json::from_value(value) {
+            Ok(chunk) => chunk,
+            Err(_) => {
+                self.fail(ModelError::invalid_response(
+                    "Invalid Chat SSE chunk schema",
+                ));
+                return;
+            }
+        };
+        if let Some(usage) = chunk.usage {
+            self.usage = Some(usage);
+        }
+        // This API returns one ModelResponse; alternative choices must not be concatenated.
+        for choice in chunk.choices.into_iter().filter(|choice| choice.index == 0) {
+            if self.finish.is_some() {
+                self.fail(ModelError::invalid_response(
+                    "Chat choice after finish frame",
+                ));
+                return;
+            }
+            let delta = choice.delta;
+            if let Some(content) = delta.content.filter(|s| !s.is_empty()) {
+                if let Some(index) = self.text {
+                    self.emit(ModelResponseStreamEvent::PartDelta(PartDeltaEvent::text(
+                        index, content,
+                    )));
+                } else {
+                    let index = self.next_index;
+                    self.next_index += 1;
+                    self.text = Some(index);
+                    self.emit(ModelResponseStreamEvent::PartStart(PartStartEvent::new(
+                        index,
+                        ModelResponsePart::Text(TextPart::new(content)),
+                    )));
+                }
+            }
+            // Compatibility extension only; OpenAI Responses reasoning uses a different schema.
+            if let Some(content) = delta.reasoning_content.filter(|s| !s.is_empty()) {
+                if let Some(index) = self.thinking {
+                    self.emit(ModelResponseStreamEvent::PartDelta(PartDeltaEvent {
+                        index,
+                        delta: serdes_ai_core::ModelResponsePartDelta::Thinking(
+                            ThinkingPartDelta::new(content),
+                        ),
+                    }));
+                } else {
+                    let index = self.next_index;
+                    self.next_index += 1;
+                    self.thinking = Some(index);
+                    self.emit(ModelResponseStreamEvent::PartStart(PartStartEvent::new(
+                        index,
+                        ModelResponsePart::Thinking(ThinkingPart::new(content)),
+                    )));
+                }
+            }
+            for tool in delta.tool_calls.unwrap_or_default() {
+                let state = self.tools.entry(tool.index).or_insert_with(|| {
+                    let part_index = self.next_index;
+                    self.next_index += 1;
+                    ToolCallState {
+                        part_index,
+                        ..Default::default()
+                    }
+                });
+                if let Some(id) = tool.id {
+                    state.id = id;
+                }
+                if let Some(function) = tool.function {
+                    if let Some(name) = function.name {
+                        state.name.push_str(&name);
+                    }
+                    if let Some(args) = function.arguments {
+                        state.arguments.push_str(&args);
+                        if state.started {
+                            let event = PartDeltaEvent::tool_call_args(state.part_index, args);
+                            self.pending
+                                .push_back(Ok(ModelResponseStreamEvent::PartDelta(event)));
+                        }
+                    }
+                }
+                if !state.started && !state.id.is_empty() && !state.name.is_empty() {
+                    state.started = true;
+                    let part = ToolCallPart::new(
+                        &state.name,
+                        ToolCallArgs::String(state.arguments.clone()),
+                    )
+                    .with_tool_call_id(&state.id);
+                    self.pending
+                        .push_back(Ok(ModelResponseStreamEvent::PartStart(
+                            PartStartEvent::new(
+                                state.part_index,
+                                ModelResponsePart::ToolCall(part),
+                            ),
+                        )));
+                }
+            }
+            if let Some(reason) = choice.finish_reason {
+                self.finish = Some(map_finish_reason(&reason));
+                if !self.validate_tools() {
+                    return;
+                }
+                self.close_parts();
+            }
         }
     }
 }
 
-impl<S> Stream for OpenAIStreamParser<S>
-where
-    S: Stream<Item = Result<Bytes, reqwest::Error>>,
-{
+impl<S: Stream<Item = Result<Bytes, reqwest::Error>>> Stream for OpenAIStreamParser<S> {
     type Item = Result<ModelResponseStreamEvent, ModelError>;
-
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut this = self.project();
-
-        if *this.done {
-            return Poll::Ready(None);
-        }
-
-        // First, emit any pending PartEnd events
-        if let Some(idx) = this.pending_part_ends.pop() {
-            return Poll::Ready(Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
-                index: idx,
-            }))));
-        }
-
+        let this = self.get_mut();
         loop {
-            // Check if we have complete lines in the buffer
-            while let Some(newline_pos) = this.buffer.find('\n') {
-                let line = this.buffer.drain(..=newline_pos).collect::<String>();
-                if let Some(event) = parse_sse_line(
-                    &line,
-                    this.tool_calls,
-                    this.text_started,
-                    this.current_text_index,
-                    this.thinking_started,
-                    this.current_thinking_index,
-                    this.next_part_index,
-                    this.done_seen,
-                    this.last_finish_reason,
-                    this.usage,
-                    this.pending_part_ends,
-                ) {
-                    return Poll::Ready(Some(event));
-                }
+            if let Some(event) = this.pending.pop_front() {
+                return Poll::Ready(Some(event));
             }
-
-            // [DONE] observed and all buffered lines consumed: emit the
-            // terminal event. Queued part ends were already drained above.
-            if *this.done_seen {
-                *this.done = true;
-                return Poll::Ready(Some(Ok(stream_complete_event(
-                    *this.last_finish_reason,
-                    this.usage.as_ref(),
-                ))));
+            if this.done {
+                return Poll::Ready(None);
             }
-
-            // Need more data
+            if let Some(end) = this.buffer.iter().position(|byte| *byte == b'\n') {
+                let line: Vec<_> = this.buffer.drain(..=end).collect();
+                this.line(&line);
+                continue;
+            }
             match this.inner.as_mut().poll_next(cx) {
-                Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        this.buffer.push_str(text);
-                    }
-                    // Continue to process buffer
-                }
-                Poll::Ready(Some(Err(e))) => {
-                    // Mark done so no event (including the terminal event) is
-                    // emitted after an error.
-                    *this.done = true;
-                    return Poll::Ready(Some(Err(ModelError::Other(e.into()))));
-                }
+                Poll::Ready(Some(Ok(bytes))) => this.buffer.extend_from_slice(&bytes),
+                Poll::Ready(Some(Err(error))) => this.fail(ModelError::Other(error.into())),
                 Poll::Ready(None) => {
-                    // Stream ended, process any remaining buffer
                     if !this.buffer.is_empty() {
-                        let remaining = std::mem::take(this.buffer);
-                        for line in remaining.lines() {
-                            if let Some(event) = parse_sse_line(
-                                line,
-                                this.tool_calls,
-                                this.text_started,
-                                this.current_text_index,
-                                this.thinking_started,
-                                this.current_thinking_index,
-                                this.next_part_index,
-                                this.done_seen,
-                                this.last_finish_reason,
-                                this.usage,
-                                this.pending_part_ends,
-                            ) {
-                                return Poll::Ready(Some(event));
-                            }
-                        }
+                        let line = std::mem::take(&mut this.buffer);
+                        this.line(&line);
                     }
-
-                    // A [DONE] in the final (newline-less) line still emits
-                    // the terminal event before the stream ends.
-                    if *this.done_seen {
-                        *this.done = true;
-                        return Poll::Ready(Some(Ok(stream_complete_event(
-                            *this.last_finish_reason,
-                            this.usage.as_ref(),
-                        ))));
+                    if !this.done && this.finish_is_terminal && this.finish.is_some() {
+                        this.emit(stream_complete_event(this.finish, this.usage.as_ref()));
+                        this.done = true;
                     }
-
-                    return Poll::Ready(None);
+                    if !this.done {
+                        this.fail(ModelError::incomplete_stream(
+                            "Chat SSE ended before [DONE]",
+                        ));
+                    }
                 }
                 Poll::Pending => return Poll::Pending,
             }
         }
     }
-}
-
-/// Parse a single SSE line into an event.
-#[allow(clippy::too_many_arguments)]
-fn parse_sse_line(
-    line: &str,
-    tool_calls: &mut HashMap<u32, ToolCallState>,
-    text_started: &mut bool,
-    current_text_index: &mut Option<usize>,
-    thinking_started: &mut bool,
-    current_thinking_index: &mut Option<usize>,
-    next_part_index: &mut usize,
-    done_seen: &mut bool,
-    last_finish_reason: &mut Option<FinishReason>,
-    usage: &mut Option<Usage>,
-    pending_part_ends: &mut Vec<usize>,
-) -> Option<Result<ModelResponseStreamEvent, ModelError>> {
-    let line = line.trim();
-
-    // Skip empty lines and comments
-    if line.is_empty() || line.starts_with(':') {
-        return None;
-    }
-
-    // Handle data lines
-    if let Some(data) = line.strip_prefix("data: ") {
-        // Check for stream end
-        if data == "[DONE]" {
-            *done_seen = true;
-            return None;
-        }
-
-        // Parse the JSON chunk
-        match serde_json::from_str::<ChatCompletionChunk>(data) {
-            Ok(chunk) => {
-                // Buffer usage for the terminal event; the usage chunk has
-                // empty choices and produces no part events.
-                if let Some(chunk_usage) = chunk.usage {
-                    *usage = Some(chunk_usage);
-                }
-
-                // Process each choice
-                for choice in chunk.choices {
-                    let delta = choice.delta;
-
-                    // Handle text content
-                    if let Some(content) = delta.content {
-                        if !content.is_empty() {
-                            // Start text part if not started
-                            if !*text_started {
-                                *text_started = true;
-                                *current_text_index = Some(*next_part_index);
-                                *next_part_index += 1;
-
-                                // Include the first content in the PartStart
-                                let start = PartStartEvent::new(
-                                    current_text_index.unwrap(),
-                                    ModelResponsePart::Text(TextPart::new(&content)),
-                                );
-                                return Some(Ok(ModelResponseStreamEvent::PartStart(start)));
-                            }
-
-                            // Emit text delta for subsequent content
-                            let delta = PartDeltaEvent::text(current_text_index.unwrap(), content);
-                            return Some(Ok(ModelResponseStreamEvent::PartDelta(delta)));
-                        }
-                    }
-
-                    // Handle reasoning/thinking content (for models like GLM-4)
-                    if let Some(reasoning) = delta.reasoning_content {
-                        if !reasoning.is_empty() {
-                            // Start thinking part if not started
-                            if !*thinking_started {
-                                *thinking_started = true;
-                                *current_thinking_index = Some(*next_part_index);
-                                *next_part_index += 1;
-
-                                // Include the first content in the PartStart
-                                let start = PartStartEvent::new(
-                                    current_thinking_index.unwrap(),
-                                    ModelResponsePart::Thinking(ThinkingPart::new(&reasoning)),
-                                );
-                                return Some(Ok(ModelResponseStreamEvent::PartStart(start)));
-                            }
-
-                            // Emit thinking delta for subsequent content
-                            let delta_event = PartDeltaEvent {
-                                index: current_thinking_index.unwrap(),
-                                delta: serdes_ai_core::messages::ModelResponsePartDelta::Thinking(
-                                    ThinkingPartDelta::new(reasoning),
-                                ),
-                            };
-                            return Some(Ok(ModelResponseStreamEvent::PartDelta(delta_event)));
-                        }
-                    }
-
-                    // Handle tool calls
-                    if let Some(tcs) = delta.tool_calls {
-                        for tc in tcs {
-                            let state = tool_calls.entry(tc.index).or_insert_with(|| {
-                                let part_index = *next_part_index;
-                                *next_part_index += 1;
-                                ToolCallState {
-                                    part_index,
-                                    ..Default::default()
-                                }
-                            });
-
-                            // Update state
-                            if let Some(id) = tc.id {
-                                state.id = id;
-                            }
-                            if let Some(func) = tc.function {
-                                if let Some(name) = func.name {
-                                    state.name = name;
-                                }
-                                if let Some(args) = func.arguments {
-                                    state.arguments.push_str(&args);
-
-                                    // Start part if not started
-                                    if !state.started {
-                                        state.started = true;
-                                        // Include the accumulated args in PartStart (some providers
-                                        // like Cerebras send all tool call data in one chunk)
-                                        let tool_part = ToolCallPart::new(
-                                            &state.name,
-                                            ToolCallArgs::String(state.arguments.clone()),
-                                        )
-                                        .with_tool_call_id(&state.id);
-
-                                        let start = PartStartEvent::new(
-                                            state.part_index,
-                                            ModelResponsePart::ToolCall(tool_part),
-                                        );
-                                        return Some(Ok(ModelResponseStreamEvent::PartStart(
-                                            start,
-                                        )));
-                                    }
-
-                                    // Emit args delta
-                                    let delta =
-                                        PartDeltaEvent::tool_call_args(state.part_index, args);
-                                    return Some(Ok(ModelResponseStreamEvent::PartDelta(delta)));
-                                }
-                            }
-                        }
-                    }
-
-                    // Handle finish reason - remember it for the terminal
-                    // event and emit part end events
-                    if let Some(reason) = choice.finish_reason.as_deref() {
-                        *last_finish_reason = Some(map_finish_reason(reason));
-
-                        // Collect all part indices that need to be closed
-                        let mut parts_to_close = Vec::new();
-
-                        // End text part if open
-                        if let Some(idx) = current_text_index.take() {
-                            parts_to_close.push(idx);
-                        }
-
-                        // End tool call parts
-                        for (_, state) in tool_calls.drain() {
-                            if state.started {
-                                parts_to_close.push(state.part_index);
-                            }
-                        }
-
-                        // If we have parts to close, return the first one and queue the rest
-                        if !parts_to_close.is_empty() {
-                            // Queue all but the first for later emission
-                            if parts_to_close.len() > 1 {
-                                pending_part_ends.extend(parts_to_close.iter().skip(1).copied());
-                            }
-                            // Return the first one now
-                            let first_idx = parts_to_close[0];
-                            return Some(Ok(ModelResponseStreamEvent::PartEnd(PartEndEvent {
-                                index: first_idx,
-                            })));
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!("Failed to parse SSE chunk: {} - data: {}", e, data);
-            }
-        }
-    }
-
-    None
 }
 
 /// Build the terminal event from the last seen finish reason and the buffered
@@ -419,378 +335,5 @@ fn map_finish_reason(reason: &str) -> FinishReason {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::StreamExt;
-    use futures::stream;
-    use serdes_ai_core::ModelResponsePartDelta;
-
-    fn make_chunk_bytes(data: &str) -> Bytes {
-        Bytes::from(format!("data: {}\n\n", data))
-    }
-
-    #[tokio::test]
-    async fn test_parse_text_chunk() {
-        // Test multi-chunk text streaming
-        let chunk1 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant"}}]}"#;
-        let chunk2 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
-        let chunk3 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":" World"}}]}"#;
-        let bytes = vec![
-            Ok(make_chunk_bytes(chunk1)),
-            Ok(make_chunk_bytes(chunk2)),
-            Ok(make_chunk_bytes(chunk3)),
-        ];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        // Collect all events
-        let mut events = Vec::new();
-        while let Some(result) = parser.next().await {
-            events.push(result.unwrap());
-        }
-
-        // Should have: PartStart(Hello), PartDelta( World)
-        assert!(
-            events.len() >= 2,
-            "Expected at least 2 events, got {}: {:?}",
-            events.len(),
-            events
-        );
-
-        // First should be PartStart with "Hello" content
-        if let ModelResponseStreamEvent::PartStart(start) = &events[0] {
-            if let ModelResponsePart::Text(text) = &start.part {
-                assert_eq!(text.content, "Hello", "PartStart should contain 'Hello'");
-            } else {
-                panic!("Expected Text part in PartStart, got {:?}", start.part);
-            }
-        } else {
-            panic!("First event should be PartStart, got {:?}", events[0]);
-        }
-
-        // Second should be PartDelta with " World"
-        if let ModelResponseStreamEvent::PartDelta(delta) = &events[1] {
-            if let ModelResponsePartDelta::Text(text) = &delta.delta {
-                assert_eq!(
-                    text.content_delta, " World",
-                    "Delta should contain ' World'"
-                );
-            } else {
-                panic!("Expected Text delta, got {:?}", delta.delta);
-            }
-        } else {
-            panic!("Second event should be PartDelta, got {:?}", events[1]);
-        }
-    }
-
-    /// [DONE] without a usage chunk emits exactly one terminal event with the
-    /// default finish reason and all token fields None; nothing follows it.
-    #[tokio::test]
-    async fn test_parse_done() {
-        let bytes = vec![Ok(Bytes::from("data: [DONE]\n\n"))];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        let event = parser.next().await.unwrap().unwrap();
-        match event {
-            ModelResponseStreamEvent::StreamComplete(complete) => {
-                assert_eq!(complete.finish_reason, FinishReason::Stop);
-                assert_eq!(complete.input_tokens, None);
-                assert_eq!(complete.output_tokens, None);
-                assert_eq!(complete.cache_creation_tokens, None);
-                assert_eq!(complete.cache_read_tokens, None);
-            }
-            other => panic!("expected StreamComplete, got {:?}", other),
-        }
-
-        // The terminal event is the final event of the stream.
-        assert!(parser.next().await.is_none());
-    }
-
-    /// EOF without [DONE] emits no terminal event (truncated streams stay
-    /// detectable by the agent loop).
-    #[tokio::test]
-    async fn test_eof_without_done_emits_no_terminal_event() {
-        let chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
-        let bytes = vec![Ok(make_chunk_bytes(chunk))];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        let mut events = Vec::new();
-        while let Some(result) = parser.next().await {
-            events.push(result.unwrap());
-        }
-
-        assert_eq!(
-            events.len(),
-            1,
-            "expected only the part event: {:?}",
-            events
-        );
-        assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
-    }
-
-    /// A transport error mid-stream ends the stream with the error and never
-    /// emits the terminal event afterwards.
-    #[tokio::test]
-    async fn stream_error_suppresses_terminal_event() {
-        // reqwest::Error has no public constructor; a refused connection to a
-        // closed loopback port is the cheapest real one to obtain.
-        let client = reqwest::Client::builder().no_proxy().build().unwrap();
-        let err = client
-            .get("http://127.0.0.1:1")
-            .send()
-            .await
-            .expect_err("connection to closed loopback port must fail");
-
-        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
-        let bytes = vec![Ok(make_chunk_bytes(text_chunk)), Err(err)];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        let mut events = Vec::new();
-        while let Some(result) = parser.next().await {
-            events.push(result);
-        }
-
-        assert_eq!(
-            events.len(),
-            2,
-            "expected only the part event and the error: {:?}",
-            events
-        );
-        assert!(matches!(
-            events[0],
-            Ok(ModelResponseStreamEvent::PartStart(_))
-        ));
-        assert!(events[1].is_err());
-    }
-
-    #[tokio::test]
-    async fn test_parse_finish_reason() {
-        let chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
-        let bytes = vec![Ok(make_chunk_bytes(chunk))];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        // Should return None since no parts are open and no [DONE] arrived
-        let event = parser.next().await;
-        assert!(event.is_none());
-    }
-
-    /// The include_usage chunk is buffered and produces no part events; its
-    /// counts are carried on the terminal event at [DONE].
-    #[tokio::test]
-    async fn usage_chunk_then_done_populates_terminal_event() {
-        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
-        let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
-        let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
-
-        let bytes = vec![
-            Ok(make_chunk_bytes(text_chunk)),
-            Ok(make_chunk_bytes(finish_chunk)),
-            Ok(make_chunk_bytes(usage_chunk)),
-            Ok(Bytes::from("data: [DONE]\n\n")),
-        ];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        let mut events = Vec::new();
-        while let Some(result) = parser.next().await {
-            events.push(result.unwrap());
-        }
-
-        // The usage chunk is ignored for part events: only PartStart and
-        // PartEnd precede the terminal event.
-        assert_eq!(
-            events.len(),
-            3,
-            "expected PartStart, PartEnd, StreamComplete: {:?}",
-            events
-        );
-        assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
-        assert!(matches!(events[1], ModelResponseStreamEvent::PartEnd(_)));
-
-        match events.last() {
-            Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
-                assert_eq!(complete.finish_reason, FinishReason::Stop);
-                assert_eq!(complete.input_tokens, Some(10));
-                assert_eq!(complete.output_tokens, Some(5));
-                assert_eq!(complete.cache_creation_tokens, None);
-                assert_eq!(complete.cache_read_tokens, Some(7));
-            }
-            other => panic!("expected terminal StreamComplete, got {:?}", other),
-        }
-    }
-
-    /// Finish reason strings map onto the terminal event; unknown reasons
-    /// default to Stop.
-    #[tokio::test]
-    async fn finish_reason_maps_onto_terminal_event() {
-        let cases = [
-            ("stop", FinishReason::Stop),
-            ("length", FinishReason::Length),
-            ("content_filter", FinishReason::ContentFilter),
-            ("tool_calls", FinishReason::ToolCall),
-            ("function_call", FinishReason::Stop),
-            ("unknown_reason", FinishReason::Stop),
-        ];
-
-        for (wire_reason, expected) in cases {
-            let finish_chunk = format!(
-                r#"{{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{{"index":0,"delta":{{}},"finish_reason":"{wire_reason}"}}]}}"#
-            );
-            let bytes = vec![
-                Ok(make_chunk_bytes(&finish_chunk)),
-                Ok(Bytes::from("data: [DONE]\n\n")),
-            ];
-            let stream = stream::iter(bytes);
-            let mut parser = OpenAIStreamParser::new(stream);
-
-            let mut terminals = 0;
-            let mut finish_reason = None;
-            while let Some(result) = parser.next().await {
-                if let ModelResponseStreamEvent::StreamComplete(complete) = result.unwrap() {
-                    terminals += 1;
-                    finish_reason = Some(complete.finish_reason);
-                }
-            }
-
-            assert_eq!(
-                terminals, 1,
-                "expected one terminal event for {wire_reason}"
-            );
-            assert_eq!(
-                finish_reason,
-                Some(expected),
-                "finish reason mapping for {wire_reason}"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_parse_tool_call() {
-        let chunk1 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":""}}]}}]}"#;
-        let chunk2 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":"}}]}}]}"#;
-        let chunk3 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"test\"}"}}]}}]}"#;
-
-        let bytes = vec![
-            Ok(make_chunk_bytes(chunk1)),
-            Ok(make_chunk_bytes(chunk2)),
-            Ok(make_chunk_bytes(chunk3)),
-        ];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        // First event should be PartStart for tool call
-        let event = parser.next().await.unwrap().unwrap();
-        assert!(matches!(event, ModelResponseStreamEvent::PartStart(_)));
-
-        // Subsequent events should be deltas
-        let event = parser.next().await.unwrap().unwrap();
-        assert!(matches!(event, ModelResponseStreamEvent::PartDelta(_)));
-    }
-
-    /// Regression test: when finish_reason is received with multiple open parts
-    /// (text + tool calls), ALL PartEnd events must be emitted, not just the
-    /// first. The terminal event follows the queued part ends and is emitted
-    /// exactly once, last.
-    #[tokio::test]
-    async fn test_multiple_part_ends_on_finish() {
-        // Scenario: text part starts, then 2 tool calls start, then finish_reason
-        // We should get 3 PartEnd events (one for text, two for tool calls)
-        let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
-        let tool1_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{\"q\":\"test\"}"}}]}}]}"#;
-        let tool2_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"lookup","arguments":"{\"id\":1}"}}]}}]}"#;
-        let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
-        let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
-
-        let bytes = vec![
-            Ok(make_chunk_bytes(text_chunk)),
-            Ok(make_chunk_bytes(tool1_chunk)),
-            Ok(make_chunk_bytes(tool2_chunk)),
-            Ok(make_chunk_bytes(finish_chunk)),
-            Ok(make_chunk_bytes(usage_chunk)),
-            Ok(Bytes::from("data: [DONE]\n\n")),
-        ];
-        let stream = stream::iter(bytes);
-        let mut parser = OpenAIStreamParser::new(stream);
-
-        // Collect all events
-        let mut events = Vec::new();
-        while let Some(result) = parser.next().await {
-            events.push(result.unwrap());
-        }
-
-        // Should have:
-        // - 1 PartStart for text (index 0)
-        // - 1 PartStart for tool call 1 (index 1)
-        // - 1 PartStart for tool call 2 (index 2)
-        // - 3 PartEnd events (for indices 0, 1, 2)
-        // - 1 StreamComplete terminal event
-        let part_starts: Vec<_> = events
-            .iter()
-            .filter(|e| matches!(e, ModelResponseStreamEvent::PartStart(_)))
-            .collect();
-        let part_ends: Vec<_> = events
-            .iter()
-            .filter(|e| matches!(e, ModelResponseStreamEvent::PartEnd(_)))
-            .collect();
-
-        assert_eq!(
-            part_starts.len(),
-            3,
-            "Expected 3 PartStart events, got {}: {:?}",
-            part_starts.len(),
-            part_starts
-        );
-        assert_eq!(
-            part_ends.len(),
-            3,
-            "Expected 3 PartEnd events (regression: bug caused only 1 to be emitted), got {}: {:?}",
-            part_ends.len(),
-            part_ends
-        );
-
-        // Verify all part indices are closed
-        let mut closed_indices: Vec<usize> = part_ends
-            .iter()
-            .filter_map(|e| {
-                if let ModelResponseStreamEvent::PartEnd(end) = e {
-                    Some(end.index)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        closed_indices.sort();
-        assert_eq!(
-            closed_indices,
-            vec![0, 1, 2],
-            "All part indices should be closed"
-        );
-
-        // Exactly one terminal event, carrying the buffered usage, emitted
-        // after every queued part end.
-        let terminals: Vec<_> = events
-            .iter()
-            .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
-            .collect();
-        assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
-        assert!(
-            matches!(
-                events.last(),
-                Some(ModelResponseStreamEvent::StreamComplete(_))
-            ),
-            "terminal event must be emitted last, got {:?}",
-            events.last()
-        );
-        if let Some(ModelResponseStreamEvent::StreamComplete(complete)) = events.last() {
-            assert_eq!(complete.finish_reason, FinishReason::ToolCall);
-            assert_eq!(complete.input_tokens, Some(10));
-            assert_eq!(complete.output_tokens, Some(5));
-            assert_eq!(complete.cache_creation_tokens, None);
-            assert_eq!(complete.cache_read_tokens, Some(7));
-        }
-    }
-}
+#[path = "stream_tests.rs"]
+mod tests;

--- a/serdes-ai-models/src/openai/stream_tests.rs
+++ b/serdes-ai-models/src/openai/stream_tests.rs
@@ -1,0 +1,400 @@
+use super::*;
+use futures::StreamExt;
+use futures::stream;
+use serdes_ai_core::ModelResponsePartDelta;
+
+fn make_chunk_bytes(data: &str) -> Bytes {
+    Bytes::from(format!("data: {}\n\n", data))
+}
+
+#[tokio::test]
+async fn test_parse_text_chunk() {
+    // Test multi-chunk text streaming
+    let chunk1 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant"}}]}"#;
+    let chunk2 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+    let chunk3 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":" World"}}]}"#;
+    let bytes = vec![
+        Ok(make_chunk_bytes(chunk1)),
+        Ok(make_chunk_bytes(chunk2)),
+        Ok(make_chunk_bytes(chunk3)),
+    ];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    // Collect all events
+    let mut events = Vec::new();
+    while let Some(result) = parser.next().await {
+        events.push(result.unwrap());
+    }
+
+    // Should have: PartStart(Hello), PartDelta( World)
+    assert!(
+        events.len() >= 2,
+        "Expected at least 2 events, got {}: {:?}",
+        events.len(),
+        events
+    );
+
+    // First should be PartStart with "Hello" content
+    if let ModelResponseStreamEvent::PartStart(start) = &events[0] {
+        if let ModelResponsePart::Text(text) = &start.part {
+            assert_eq!(text.content, "Hello", "PartStart should contain 'Hello'");
+        } else {
+            panic!("Expected Text part in PartStart, got {:?}", start.part);
+        }
+    } else {
+        panic!("First event should be PartStart, got {:?}", events[0]);
+    }
+
+    // Second should be PartDelta with " World"
+    if let ModelResponseStreamEvent::PartDelta(delta) = &events[1] {
+        if let ModelResponsePartDelta::Text(text) = &delta.delta {
+            assert_eq!(
+                text.content_delta, " World",
+                "Delta should contain ' World'"
+            );
+        } else {
+            panic!("Expected Text delta, got {:?}", delta.delta);
+        }
+    } else {
+        panic!("Second event should be PartDelta, got {:?}", events[1]);
+    }
+}
+
+/// [DONE] without a usage chunk emits exactly one terminal event with the
+/// default finish reason and all token fields None; nothing follows it.
+#[tokio::test]
+async fn test_parse_done() {
+    let bytes = vec![Ok(Bytes::from("data: [DONE]\n\n"))];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    let event = parser.next().await.unwrap().unwrap();
+    match event {
+        ModelResponseStreamEvent::StreamComplete(complete) => {
+            assert_eq!(complete.finish_reason, FinishReason::Stop);
+            assert_eq!(complete.input_tokens, None);
+            assert_eq!(complete.output_tokens, None);
+            assert_eq!(complete.cache_creation_tokens, None);
+            assert_eq!(complete.cache_read_tokens, None);
+        }
+        other => panic!("expected StreamComplete, got {:?}", other),
+    }
+
+    // The terminal event is the final event of the stream.
+    assert!(parser.next().await.is_none());
+}
+
+#[tokio::test]
+async fn test_eof_without_done_emits_no_terminal_event() {
+    let chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+    let mut parser = OpenAIStreamParser::new(stream::iter(vec![Ok(make_chunk_bytes(chunk))]));
+    assert!(matches!(
+        parser.next().await,
+        Some(Ok(ModelResponseStreamEvent::PartStart(_)))
+    ));
+    assert!(matches!(
+        parser.next().await,
+        Some(Err(ModelError::IncompleteStream(_)))
+    ));
+    assert!(parser.next().await.is_none());
+}
+
+/// A transport error mid-stream ends the stream with the error and never
+/// emits the terminal event afterwards.
+#[tokio::test]
+async fn stream_error_suppresses_terminal_event() {
+    // reqwest::Error has no public constructor; a refused connection to a
+    // closed loopback port is the cheapest real one to obtain.
+    let client = reqwest::Client::builder().no_proxy().build().unwrap();
+    let err = client
+        .get("http://127.0.0.1:1")
+        .send()
+        .await
+        .expect_err("connection to closed loopback port must fail");
+
+    let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+    let bytes = vec![Ok(make_chunk_bytes(text_chunk)), Err(err)];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    let mut events = Vec::new();
+    while let Some(result) = parser.next().await {
+        events.push(result);
+    }
+
+    assert_eq!(
+        events.len(),
+        2,
+        "expected only the part event and the error: {:?}",
+        events
+    );
+    assert!(matches!(
+        events[0],
+        Ok(ModelResponseStreamEvent::PartStart(_))
+    ));
+    assert!(events[1].is_err());
+}
+
+#[tokio::test]
+async fn test_parse_finish_reason() {
+    let chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+    let bytes = vec![Ok(make_chunk_bytes(chunk))];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    // A finish frame plus [DONE] emits exactly one terminal event.
+    let event = parser.next().await;
+    assert!(matches!(
+        event,
+        Some(Ok(ModelResponseStreamEvent::StreamComplete(_)))
+    ));
+}
+
+/// The include_usage chunk is buffered and produces no part events; its
+/// counts are carried on the terminal event at [DONE].
+#[tokio::test]
+async fn usage_chunk_then_done_populates_terminal_event() {
+    let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+    let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#;
+    let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
+
+    let bytes = vec![
+        Ok(make_chunk_bytes(text_chunk)),
+        Ok(make_chunk_bytes(finish_chunk)),
+        Ok(make_chunk_bytes(usage_chunk)),
+        Ok(Bytes::from("data: [DONE]\n\n")),
+    ];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    let mut events = Vec::new();
+    while let Some(result) = parser.next().await {
+        events.push(result.unwrap());
+    }
+
+    // The usage chunk is ignored for part events: only PartStart and
+    // PartEnd precede the terminal event.
+    assert_eq!(
+        events.len(),
+        3,
+        "expected PartStart, PartEnd, StreamComplete: {:?}",
+        events
+    );
+    assert!(matches!(events[0], ModelResponseStreamEvent::PartStart(_)));
+    assert!(matches!(events[1], ModelResponseStreamEvent::PartEnd(_)));
+
+    match events.last() {
+        Some(ModelResponseStreamEvent::StreamComplete(complete)) => {
+            assert_eq!(complete.finish_reason, FinishReason::Stop);
+            assert_eq!(complete.input_tokens, Some(10));
+            assert_eq!(complete.output_tokens, Some(5));
+            assert_eq!(complete.cache_creation_tokens, None);
+            assert_eq!(complete.cache_read_tokens, Some(7));
+        }
+        other => panic!("expected terminal StreamComplete, got {:?}", other),
+    }
+}
+
+/// Finish reason strings map onto the terminal event; unknown reasons
+/// default to Stop.
+#[tokio::test]
+async fn finish_reason_maps_onto_terminal_event() {
+    let cases = [
+        ("stop", FinishReason::Stop),
+        ("length", FinishReason::Length),
+        ("content_filter", FinishReason::ContentFilter),
+        ("tool_calls", FinishReason::ToolCall),
+        ("function_call", FinishReason::Stop),
+        ("unknown_reason", FinishReason::Stop),
+    ];
+
+    for (wire_reason, expected) in cases {
+        let finish_chunk = format!(
+            r#"{{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{{"index":0,"delta":{{}},"finish_reason":"{wire_reason}"}}]}}"#
+        );
+        let bytes = vec![
+            Ok(make_chunk_bytes(&finish_chunk)),
+            Ok(Bytes::from("data: [DONE]\n\n")),
+        ];
+        let stream = stream::iter(
+            bytes
+                .into_iter()
+                .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+        );
+        let mut parser = OpenAIStreamParser::new(stream);
+
+        let mut terminals = 0;
+        let mut finish_reason = None;
+        while let Some(result) = parser.next().await {
+            if let ModelResponseStreamEvent::StreamComplete(complete) = result.unwrap() {
+                terminals += 1;
+                finish_reason = Some(complete.finish_reason);
+            }
+        }
+
+        assert_eq!(
+            terminals, 1,
+            "expected one terminal event for {wire_reason}"
+        );
+        assert_eq!(
+            finish_reason,
+            Some(expected),
+            "finish reason mapping for {wire_reason}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_parse_tool_call() {
+    let chunk1 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":""}}]}}]}"#;
+    let chunk2 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":"}}]}}]}"#;
+    let chunk3 = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"test\"}"}}]}}]}"#;
+
+    let bytes = vec![
+        Ok(make_chunk_bytes(chunk1)),
+        Ok(make_chunk_bytes(chunk2)),
+        Ok(make_chunk_bytes(chunk3)),
+    ];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    // First event should be PartStart for tool call
+    let event = parser.next().await.unwrap().unwrap();
+    assert!(matches!(event, ModelResponseStreamEvent::PartStart(_)));
+
+    // Subsequent events should be deltas
+    let event = parser.next().await.unwrap().unwrap();
+    assert!(matches!(event, ModelResponseStreamEvent::PartDelta(_)));
+}
+
+/// Regression test: when finish_reason is received with multiple open parts
+/// (text + tool calls), ALL PartEnd events must be emitted, not just the
+/// first. The terminal event follows the queued part ends and is emitted
+/// exactly once, last.
+#[tokio::test]
+async fn test_multiple_part_ends_on_finish() {
+    // Scenario: text part starts, then 2 tool calls start, then finish_reason
+    // We should get 3 PartEnd events (one for text, two for tool calls)
+    let text_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}"#;
+    let tool1_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":"{\"q\":\"test\"}"}}]}}]}"#;
+    let tool2_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"lookup","arguments":"{\"id\":1}"}}]}}]}"#;
+    let finish_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}"#;
+    let usage_chunk = r#"{"id":"123","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4o","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15,"prompt_tokens_details":{"cached_tokens":7}}}"#;
+
+    let bytes = vec![
+        Ok(make_chunk_bytes(text_chunk)),
+        Ok(make_chunk_bytes(tool1_chunk)),
+        Ok(make_chunk_bytes(tool2_chunk)),
+        Ok(make_chunk_bytes(finish_chunk)),
+        Ok(make_chunk_bytes(usage_chunk)),
+        Ok(Bytes::from("data: [DONE]\n\n")),
+    ];
+    let stream = stream::iter(
+        bytes
+            .into_iter()
+            .chain(std::iter::once(Ok(make_chunk_bytes("[DONE]")))),
+    );
+    let mut parser = OpenAIStreamParser::new(stream);
+
+    // Collect all events
+    let mut events = Vec::new();
+    while let Some(result) = parser.next().await {
+        events.push(result.unwrap());
+    }
+
+    // Should have:
+    // - 1 PartStart for text (index 0)
+    // - 1 PartStart for tool call 1 (index 1)
+    // - 1 PartStart for tool call 2 (index 2)
+    // - 3 PartEnd events (for indices 0, 1, 2)
+    // - 1 StreamComplete terminal event
+    let part_starts: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, ModelResponseStreamEvent::PartStart(_)))
+        .collect();
+    let part_ends: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, ModelResponseStreamEvent::PartEnd(_)))
+        .collect();
+
+    assert_eq!(
+        part_starts.len(),
+        3,
+        "Expected 3 PartStart events, got {}: {:?}",
+        part_starts.len(),
+        part_starts
+    );
+    assert_eq!(
+        part_ends.len(),
+        3,
+        "Expected 3 PartEnd events (regression: bug caused only 1 to be emitted), got {}: {:?}",
+        part_ends.len(),
+        part_ends
+    );
+
+    // Verify all part indices are closed
+    let mut closed_indices: Vec<usize> = part_ends
+        .iter()
+        .filter_map(|e| {
+            if let ModelResponseStreamEvent::PartEnd(end) = e {
+                Some(end.index)
+            } else {
+                None
+            }
+        })
+        .collect();
+    closed_indices.sort();
+    assert_eq!(
+        closed_indices,
+        vec![0, 1, 2],
+        "All part indices should be closed"
+    );
+
+    // Exactly one terminal event, carrying the buffered usage, emitted
+    // after every queued part end.
+    let terminals: Vec<_> = events
+        .iter()
+        .filter(|e| matches!(e, ModelResponseStreamEvent::StreamComplete(_)))
+        .collect();
+    assert_eq!(terminals.len(), 1, "expected exactly one terminal event");
+    assert!(
+        matches!(
+            events.last(),
+            Some(ModelResponseStreamEvent::StreamComplete(_))
+        ),
+        "terminal event must be emitted last, got {:?}",
+        events.last()
+    );
+    if let Some(ModelResponseStreamEvent::StreamComplete(complete)) = events.last() {
+        assert_eq!(complete.finish_reason, FinishReason::ToolCall);
+        assert_eq!(complete.input_tokens, Some(10));
+        assert_eq!(complete.output_tokens, Some(5));
+        assert_eq!(complete.cache_creation_tokens, None);
+        assert_eq!(complete.cache_read_tokens, Some(7));
+    }
+}

--- a/serdes-ai-models/tests/native_chat_reliability.rs
+++ b/serdes-ai-models/tests/native_chat_reliability.rs
@@ -1,0 +1,214 @@
+#![cfg(feature = "openai")]
+use futures::StreamExt;
+use serde_json::{Value, json};
+use serdes_ai_core::{FinishReason, ModelRequest, ModelResponseStreamEvent, ModelSettings};
+use serdes_ai_models::error::ModelError;
+use serdes_ai_models::openai::{OpenAIChatModel, stream::OpenAIStreamParser};
+use serdes_ai_models::{Model, ModelRequestParameters};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+fn frame(delta: Value, finish: Value) -> String {
+    format!(
+        "data:{}\r\n\r\n",
+        json!({"id":"test", "object":"chat.completion.chunk", "created":1,
+        "model":"alias", "choices":[{"index":0,"delta":delta,"finish_reason":finish}]})
+    )
+}
+
+async fn native(
+    body: String,
+    model: &str,
+    override_key: Option<bool>,
+    usage: bool,
+) -> (Vec<Result<ModelResponseStreamEvent, ModelError>>, Value) {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+    let mut model = OpenAIChatModel::new(model, "local-test").with_base_url(server.uri());
+    if let Some(enabled) = override_key {
+        model = model.with_max_completion_tokens(enabled);
+    }
+    let params = ModelRequestParameters {
+        stream_usage: usage,
+        ..Default::default()
+    };
+    let events = model
+        .request_stream(
+            &[ModelRequest::new()],
+            &ModelSettings::new().max_tokens(17),
+            &params,
+        )
+        .await
+        .unwrap()
+        .collect()
+        .await;
+    let requests = server.received_requests().await.unwrap();
+    (events, serde_json::from_slice(&requests[0].body).unwrap())
+}
+
+#[tokio::test]
+async fn native_eof_preserves_partial_tools_but_errors() {
+    let body = frame(
+        json!({"content":"partial", "tool_calls":[{"index":0,"id":"call-1",
+        "type":"function","function":{"name":"danger","arguments":"{\"x\":"}}]}),
+        Value::Null,
+    );
+    let (events, _) = native(body, "gpt-4o", None, false).await;
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, Ok(ModelResponseStreamEvent::PartStart(_))))
+            .count(),
+        2
+    );
+    assert!(matches!(
+        events.last(),
+        Some(Err(ModelError::IncompleteStream(_)))
+    ));
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Ok(ModelResponseStreamEvent::StreamComplete(_))))
+    );
+}
+
+#[tokio::test]
+async fn native_length_usage_and_cap_keys() {
+    for (name, override_key, completion, usage) in [
+        ("o3", None, true, true),
+        ("gpt-5-custom", None, true, false),
+        ("alias", Some(true), true, true),
+        ("o3", Some(false), false, false),
+        ("gpt-4o", None, false, true),
+    ] {
+        let body = frame(json!({"content":"valid partial"}), json!("length"))
+            + &format!(
+                "data: {}\n\n",
+                json!({"id":"test","object":"chat.completion.chunk","created":1,
+                "model":name,"choices":[],"usage":{"prompt_tokens":12,"completion_tokens":3,"total_tokens":15}})
+            )
+            + "data: [DONE]\n\ndata: [DONE]\n\n";
+        let (events, request) = native(body, name, override_key, usage).await;
+        assert!(events.iter().all(Result::is_ok));
+        assert_eq!(
+            request[if completion {
+                "max_completion_tokens"
+            } else {
+                "max_tokens"
+            }],
+            17
+        );
+        assert!(
+            request
+                .get(if completion {
+                    "max_tokens"
+                } else {
+                    "max_completion_tokens"
+                })
+                .is_none()
+        );
+        assert_eq!(request["stream_options"]["include_usage"], usage);
+        let terminals: Vec<_> = events
+            .iter()
+            .filter_map(|event| match event {
+                Ok(ModelResponseStreamEvent::StreamComplete(event)) => Some(event),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(terminals.len(), 1);
+        assert_eq!(terminals[0].finish_reason, FinishReason::Length);
+        assert_eq!(terminals[0].input_tokens, Some(12));
+    }
+}
+
+#[tokio::test]
+async fn native_provider_and_malformed_errors_are_terminal() {
+    for data in [
+        "{broken",
+        r#"{"error":{"message":"failed","code":"overloaded"}}"#,
+    ] {
+        let (events, _) = native(
+            frame(json!({"content":"kept"}), Value::Null)
+                + &format!("data: {data}\n\ndata: [DONE]\n\n"),
+            "alias",
+            None,
+            false,
+        )
+        .await;
+        assert!(matches!(
+            events.first(),
+            Some(Ok(ModelResponseStreamEvent::PartStart(_)))
+        ));
+        assert!(events.last().unwrap().is_err());
+        assert_eq!(events.len(), 2);
+    }
+}
+
+#[tokio::test]
+async fn every_byte_boundary_preserves_utf8_and_finish_in_same_frame() {
+    let body = frame(json!({"content":" café"}), json!("stop")) + "data: [DONE]";
+    for split in 0..=body.len() {
+        let bytes = body.as_bytes();
+        let input = futures::stream::iter(vec![
+            Ok(bytes::Bytes::copy_from_slice(&bytes[..split])),
+            Ok(bytes::Bytes::copy_from_slice(&bytes[split..])),
+        ]);
+        let events: Vec<_> = OpenAIStreamParser::new(input).collect().await;
+        assert!(events.iter().all(Result::is_ok), "split {split}");
+        assert_eq!(events.len(), 3);
+    }
+}
+
+#[tokio::test]
+async fn finish_frame_eof_requires_explicit_endpoint_opt_in() {
+    let body = frame(json!({"content":"complete"}), json!("stop"));
+    for enabled in [false, true] {
+        let input = futures::stream::iter(vec![Ok(bytes::Bytes::from(body.clone()))]);
+        let events: Vec<_> = OpenAIStreamParser::new(input)
+            .with_finish_reason_terminal(enabled)
+            .collect()
+            .await;
+        assert_eq!(events.last().unwrap().is_ok(), enabled);
+    }
+}
+
+#[tokio::test]
+async fn dropping_stream_cancels_without_synthesizing_success() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+    struct Pending {
+        dropped: Arc<AtomicBool>,
+    }
+    impl futures::Stream for Pending {
+        type Item = Result<bytes::Bytes, reqwest::Error>;
+        fn poll_next(
+            self: std::pin::Pin<&mut Self>,
+            _: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Option<Self::Item>> {
+            std::task::Poll::Pending
+        }
+    }
+    impl Drop for Pending {
+        fn drop(&mut self) {
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+    let dropped = Arc::new(AtomicBool::new(false));
+    let parser = OpenAIStreamParser::new(Pending {
+        dropped: dropped.clone(),
+    });
+    drop(parser);
+    assert!(dropped.load(Ordering::SeqCst));
+}

--- a/serdes-ai-models/tests/native_responses_reliability.rs
+++ b/serdes-ai-models/tests/native_responses_reliability.rs
@@ -1,0 +1,147 @@
+#![cfg(feature = "openai")]
+use serde_json::json;
+use serdes_ai_core::{ModelRequest, ModelRequestPart, ModelSettings};
+use serdes_ai_models::{Model, ModelError, ModelRequestParameters, openai::OpenAIResponsesModel};
+use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method};
+
+fn response(status: &str) -> serde_json::Value {
+    json!({"id":"resp_1","object":"response","created_at":1,"model":"o3",
+        "status":status,"output":[{"type":"reasoning","id":"rs_1","summary":[],
+        "encrypted_content":"secret-ciphertext"},
+        {"type":"message","id":"msg_1","role":"assistant","content":[{"type":"output_text","text":"ok"}]}]})
+}
+
+#[tokio::test]
+async fn encrypted_reasoning_replays_as_native_ordered_item_without_debug_leak() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(response("completed")))
+        .mount(&server)
+        .await;
+    let model = OpenAIResponsesModel::new("o3", "test").with_base_url(server.uri());
+    let settings = ModelSettings::new();
+    let params = ModelRequestParameters::new();
+    let result = model.request(&[], &settings, &params).await.unwrap();
+    assert_eq!(result.parts.len(), 2);
+    assert!(!format!("{result:?}").contains("secret-ciphertext"));
+    let request = ModelRequest::with_parts(vec![ModelRequestPart::ModelResponse(Box::new(result))]);
+    model.request(&[request], &settings, &params).await.unwrap();
+    let requests = server.received_requests().await.unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&requests[1].body).unwrap();
+    assert_eq!(body["include"], json!(["reasoning.encrypted_content"]));
+    assert_eq!(
+        body["input"][0],
+        json!({"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"secret-ciphertext"})
+    );
+    assert_eq!(body["input"][1]["role"], "assistant");
+}
+
+#[tokio::test]
+async fn buffered_responses_reject_nonterminal_cancelled_and_failed_status() {
+    for status in ["in_progress", "cancelled", "failed"] {
+        let server = MockServer::start().await;
+        let mut body = response(status);
+        if status == "failed" {
+            body["error"] = json!({"message":"failed","code":"server_error"});
+        }
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(&server)
+            .await;
+        let model = OpenAIResponsesModel::new("o3", "test").with_base_url(server.uri());
+        let error = match model
+            .request(&[], &ModelSettings::new(), &ModelRequestParameters::new())
+            .await
+        {
+            Ok(_) => panic!("unexpected success for {status}"),
+            Err(error) => error,
+        };
+        match status {
+            "in_progress" => assert!(matches!(error, ModelError::IncompleteStream(_))),
+            "cancelled" => assert!(matches!(error, ModelError::Cancelled)),
+            _ => assert!(matches!(error, ModelError::Api { .. })),
+        }
+    }
+}
+
+#[tokio::test]
+async fn multicontent_replay_identical_across_transport_and_serde() {
+    use futures::StreamExt;
+    use serdes_ai_core::{ModelResponse, ModelResponseStreamEvent as Event};
+    let native = json!({"id":"r","object":"response","created_at":1,"model":"local","status":"completed","output":[
+        {"type":"reasoning","id":"rs","summary":[{"type":"summary_text","text":"one"},{"type":"summary_text","text":"two"}],"encrypted_content":"cipher"},
+        {"type":"message","id":"msg","role":"assistant","content":[{"type":"output_text","text":"first","annotations":[]},{"type":"output_text","text":"second","annotations":[]},{"type":"refusal","refusal":"no"}]}
+    ]});
+    let mut expected = None;
+    for streaming in [false, true] {
+        let server = MockServer::start().await;
+        let template = if streaming {
+            ResponseTemplate::new(200).set_body_string(format!(
+                "data: {}\n\n",
+                json!({"type":"response.completed","response":native})
+            ))
+        } else {
+            ResponseTemplate::new(200).set_body_json(&native)
+        };
+        Mock::given(method("POST"))
+            .respond_with(template)
+            .up_to_n_times(1)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&native))
+            .mount(&server)
+            .await;
+        let model = OpenAIResponsesModel::new("local", "test").with_base_url(server.uri());
+        let settings = ModelSettings::new();
+        let params = ModelRequestParameters::new();
+        let result = if streaming {
+            let mut events = model.request_stream(&[], &settings, &params).await.unwrap();
+            let mut response = ModelResponse::with_parts(vec![]);
+            while let Some(event) = events.next().await {
+                match event.unwrap() {
+                    Event::PartStart(start) => {
+                        assert_eq!(start.index, response.parts.len());
+                        response.parts.push(start.part);
+                    }
+                    Event::PartDelta(delta) => {
+                        assert!(delta.delta.apply(&mut response.parts[delta.index]));
+                    }
+                    Event::StreamComplete(complete) => {
+                        complete.metadata.unwrap().apply(&mut response);
+                    }
+                    _ => {}
+                }
+            }
+            response
+        } else {
+            model.request(&[], &settings, &params).await.unwrap()
+        };
+        let restored: ModelResponse =
+            serde_json::from_str(&serde_json::to_string(&result).unwrap()).unwrap();
+        for value in [result, restored] {
+            let request =
+                ModelRequest::with_parts(vec![ModelRequestPart::ModelResponse(Box::new(value))]);
+            model.request(&[request], &settings, &params).await.unwrap();
+            let requests = server.received_requests().await.unwrap();
+            let body: serde_json::Value =
+                serde_json::from_slice(&requests.last().unwrap().body).unwrap();
+            assert_eq!(body["input"], native["output"]);
+            if let Some(previous) = &expected {
+                assert_eq!(previous, &body["input"]);
+            } else {
+                expected = Some(body["input"].clone());
+            }
+            assert_eq!(
+                body["input"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .filter(|v| v["id"] == "msg")
+                    .count(),
+                1
+            );
+        }
+    }
+}

--- a/serdes-ai-models/tests/responses_sse.rs
+++ b/serdes-ai-models/tests/responses_sse.rs
@@ -1,0 +1,257 @@
+#![cfg(feature = "openai")]
+use futures::StreamExt;
+use serde_json::{Value, json};
+use serdes_ai_core::{FinishReason, ModelResponseStreamEvent as Event, ModelSettings};
+use serdes_ai_models::{Model, ModelError, ModelRequestParameters, openai::OpenAIResponsesModel};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+fn frame(value: Value) -> String {
+    format!("data: {value}\r\n\r\n")
+}
+fn message(text: &str) -> Value {
+    json!({"type":"message","id":"msg_1","role":"assistant","content":[{"type":"output_text","text":text}]})
+}
+fn terminal(status: &str, reason: Option<&str>, output: Value) -> String {
+    frame(
+        json!({"type":format!("response.{status}"),"response":{"id":"resp_1","status":status,"output":output,
+        "incomplete_details":reason.map(|r| json!({"reason":r})),"usage":{"input_tokens":7,"output_tokens":2}}}),
+    )
+}
+async fn native(body: String) -> Vec<Result<Event, ModelError>> {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = vec![0; 65536];
+        socket.read(&mut request).await.unwrap();
+        socket.write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n").await.unwrap();
+        // Force every UTF-8 and JSON byte boundary over real chunked HTTP.
+        for byte in body.as_bytes() {
+            if socket
+                .write_all(&[b'1', b'\r', b'\n', *byte, b'\r', b'\n'])
+                .await
+                .is_err()
+            {
+                return;
+            }
+        }
+        let _ = socket.write_all(b"0\r\n\r\n").await;
+    });
+    OpenAIResponsesModel::new("local", "test")
+        .with_base_url(url)
+        .request_stream(&[], &ModelSettings::new(), &ModelRequestParameters::new())
+        .await
+        .unwrap()
+        .collect()
+        .await
+}
+fn prefix() -> String {
+    frame(json!({"type":"response.created","response":{"id":"resp_1"}}))
+        + &frame(
+            json!({"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","content":[]}}),
+        )
+        + &frame(
+            json!({"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"café"}),
+        )
+}
+#[tokio::test]
+async fn native_chunked_completed_and_incomplete() {
+    for (status, reason, finish) in [
+        ("completed", None, FinishReason::Stop),
+        (
+            "incomplete",
+            Some("max_output_tokens"),
+            FinishReason::Length,
+        ),
+        (
+            "incomplete",
+            Some("content_filter"),
+            FinishReason::ContentFilter,
+        ),
+    ] {
+        let events = native(prefix() + &terminal(status, reason, json!([message("café")]))).await;
+        assert!(events.iter().all(Result::is_ok), "{events:?}");
+        let Some(Ok(Event::StreamComplete(last))) = events.last() else {
+            panic!("missing terminal")
+        };
+        assert_eq!(last.finish_reason, finish);
+        assert_eq!(last.input_tokens, Some(7));
+        assert!(
+            serde_json::to_string(
+                &events
+                    .iter()
+                    .filter_map(|r| r.as_ref().ok())
+                    .collect::<Vec<_>>()
+            )
+            .unwrap()
+            .contains("café")
+        );
+    }
+}
+#[tokio::test]
+async fn native_errors_keep_partials_and_never_complete() {
+    for suffix in [
+        String::new(),
+        "data: {broken\n\n".into(),
+        frame(
+            json!({"type":"response.failed","response":{"id":"resp_1","error":{"code":"server_error"}}}),
+        ),
+        frame(json!({"type":"response.cancelled","response":{"id":"resp_1"}})),
+    ] {
+        let events = native(prefix() + &suffix).await;
+        assert!(events.last().unwrap().is_err());
+        assert!(events.iter().any(|e| matches!(e, Ok(Event::PartDelta(_)))));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, Ok(Event::StreamComplete(_))))
+        );
+    }
+}
+#[tokio::test]
+async fn native_reasoning_and_function_items() {
+    let reasoning =
+        json!({"type":"reasoning","id":"rs_1","summary":[],"encrypted_content":"cipher"});
+    let function = json!({"type":"function_call","id":"fc_1","call_id":"call_1","name":"next","arguments":"{}"});
+    let body = frame(json!({"type":"response.created","response":{"id":"resp_1"}}))
+        + &frame(json!({"type":"response.output_item.added","output_index":0,"item":reasoning}))
+        + &frame(json!({"type":"response.output_item.done","output_index":0,"item":reasoning}))
+        + &frame(
+            json!({"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"next","arguments":""}}),
+        )
+        + &frame(
+            json!({"type":"response.function_call_arguments.delta","output_index":1,"delta":"{"}),
+        )
+        + &frame(
+            json!({"type":"response.function_call_arguments.delta","output_index":1,"delta":"}"}),
+        )
+        + &terminal("completed", None, json!([reasoning, function]));
+    let events = native(body).await;
+    assert!(events.iter().all(Result::is_ok), "{events:?}");
+    assert!(
+        matches!(events.last(), Some(Ok(Event::StreamComplete(e))) if e.finish_reason == FinishReason::ToolCall)
+    );
+    let mut signature = String::new();
+    for event in events.into_iter().map(Result::unwrap) {
+        if let Event::PartDelta(delta) = event {
+            if let serdes_ai_core::ModelResponsePartDelta::Thinking(delta) = delta.delta {
+                signature.push_str(delta.signature_delta.as_deref().unwrap_or_default());
+            }
+        }
+    }
+    assert_eq!(signature, "cipher");
+}
+
+#[tokio::test]
+async fn terminal_metadata_empty_and_opaque_records() {
+    for output in [
+        json!([]),
+        json!([{"type":"web_search_call","id":"ws_1","status":"completed","action":{"type":"search","query":"private query"}}]),
+        json!([{"type":"message","id":"msg_1","content":[{"type":"refusal","refusal":"private refusal"}]}]),
+    ] {
+        let response = json!({"id":"resp_metadata","model":"actual-model","status":"completed","output":output,
+            "usage":{"input_tokens":12,"output_tokens":4,"total_tokens":16,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"reasoning_tokens":2}}});
+        let events = native(frame(
+            json!({"type":"response.completed","response":response}),
+        ))
+        .await;
+        let Some(Ok(Event::StreamComplete(complete))) = events.last() else {
+            panic!("{events:?}")
+        };
+        let metadata = complete.metadata.as_ref().unwrap();
+        assert_eq!(metadata.response_id.as_deref(), Some("resp_metadata"));
+        assert_eq!(
+            metadata.details.as_ref().unwrap()["output_records"]
+                .as_array()
+                .unwrap()
+                .len(),
+            output.as_array().unwrap().len()
+        );
+        assert_eq!(
+            complete.request_usage().unwrap().details.unwrap()["output_tokens_details"]["reasoning_tokens"],
+            2
+        );
+        assert!(!format!("{complete:?}").contains("private"));
+        let mut manager = serdes_ai_streaming::ModelResponsePartsManager::new();
+        manager.handle_stream_complete(complete.clone());
+        assert_eq!(
+            manager.get_response().vendor_id.as_deref(),
+            Some("resp_metadata")
+        );
+    }
+}
+#[tokio::test]
+async fn interleaved_slots_fail_explicitly_not_concatenated() {
+    let events = native(prefix() + &frame(json!({"type":"response.output_text.delta","output_index":0,"content_index":1,"delta":"second"}))).await;
+    assert!(events.last().unwrap().is_err());
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Ok(Event::StreamComplete(_))))
+    );
+}
+
+#[tokio::test]
+async fn interleaved_message_slots_keep_native_order() {
+    let body = frame(
+        json!({"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_1","content":[]}}),
+    ) + &frame(
+        json!({"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}),
+    ) + &frame(
+        json!({"type":"response.content_part.added","output_index":0,"content_index":1,"part":{"type":"output_text","text":"","annotations":[]}}),
+    ) + &frame(
+        json!({"type":"response.output_text.delta","output_index":0,"content_index":1,"delta":"second"}),
+    ) + &frame(
+        json!({"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"first"}),
+    ) + &terminal(
+        "completed",
+        None,
+        json!([{"type":"message","id":"msg_1","content":[{"type":"output_text","text":"first","annotations":[]},{"type":"output_text","text":"second","annotations":[]}]}]),
+    );
+    let events = native(body).await;
+    let mut parts = Vec::new();
+    for event in events {
+        match event.unwrap() {
+            Event::PartStart(start) => {
+                assert_eq!(start.index, parts.len());
+                parts.push(start.part);
+            }
+            Event::PartDelta(delta) => {
+                assert!(delta.delta.apply(&mut parts[delta.index]));
+            }
+            _ => {}
+        }
+    }
+    assert!(
+        matches!(&parts[0], serdes_ai_core::ModelResponsePart::Text(t) if t.content == "first")
+    );
+    assert!(
+        matches!(&parts[1], serdes_ai_core::ModelResponsePart::Text(t) if t.content == "second")
+    );
+}
+
+#[tokio::test]
+async fn cross_item_out_of_order_fails_after_preserving_emitted_partial() {
+    let body = frame(
+        json!({"type":"response.output_item.added","output_index":1,"item":{"type":"message","id":"later","content":[]}}),
+    ) + &frame(
+        json!({"type":"response.output_text.delta","output_index":1,"content_index":0,"delta":"preserved"}),
+    ) + &frame(
+        json!({"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"f","call_id":"c","name":"never","arguments":"{}"}}),
+    );
+    let events = native(body).await;
+    assert!(events.iter().any(|e| matches!(e, Ok(Event::PartDelta(_)))));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, Err(serdes_ai_models::ModelError::InvalidResponse(_))))
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Ok(Event::StreamComplete(_))))
+    );
+    assert!(!events.iter().any(|e| matches!(e, Ok(Event::PartStart(p)) if matches!(p.part, serdes_ai_core::ModelResponsePart::ToolCall(_)))));
+}

--- a/serdes-ai-streaming/src/partial_response.rs
+++ b/serdes-ai-streaming/src/partial_response.rs
@@ -65,6 +65,7 @@ impl PartialPart {
 /// Accumulates streaming deltas into a complete response.
 #[derive(Debug, Clone)]
 pub struct PartialResponse {
+    terminal_metadata: Option<serdes_ai_core::messages::TerminalMetadata>,
     parts: Vec<PartialPart>,
     model_name: Option<String>,
     usage: Option<RequestUsage>,
@@ -84,6 +85,7 @@ impl PartialResponse {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            terminal_metadata: None,
             parts: Vec::new(),
             model_name: None,
             usage: None,
@@ -256,8 +258,24 @@ impl PartialResponse {
             finish_reason: self.finish_reason,
             usage: self.usage,
             vendor_id: self.vendor_id,
-            vendor_details: None,
+            vendor_details: self.terminal_metadata.and_then(|m| m.details),
             kind: "response".to_string(),
+        }
+    }
+
+    /// Preserve terminal metadata when consuming native model events.
+    pub fn handle_stream_complete(
+        &mut self,
+        event: &serdes_ai_core::messages::StreamCompleteEvent,
+    ) {
+        self.finish_reason = Some(event.finish_reason);
+        self.usage = event.request_usage();
+        self.terminal_metadata = event.metadata.clone();
+        if let Some(metadata) = &event.metadata {
+            self.vendor_id = metadata.response_id.clone();
+            if metadata.model.is_some() {
+                self.model_name = metadata.model.clone();
+            }
         }
     }
 

--- a/serdes-ai-streaming/src/parts_manager.rs
+++ b/serdes-ai-streaming/src/parts_manager.rs
@@ -272,6 +272,7 @@ struct ThinkingTagState {
 /// ```
 #[derive(Debug, Default)]
 pub struct ModelResponsePartsManager {
+    terminal: Option<serdes_ai_core::messages::StreamCompleteEvent>,
     /// The managed parts.
     parts: Vec<ManagedPart>,
     /// Map from vendor ID to part index.
@@ -285,6 +286,24 @@ impl ModelResponsePartsManager {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Retain the provider's final usage and metadata alongside accumulated parts.
+    pub fn handle_stream_complete(&mut self, event: serdes_ai_core::messages::StreamCompleteEvent) {
+        self.terminal = Some(event);
+    }
+
+    /// Build a response without discarding terminal metadata (including empty output).
+    pub fn get_response(&self) -> serdes_ai_core::ModelResponse {
+        let mut response = serdes_ai_core::ModelResponse::with_parts(self.get_parts());
+        if let Some(event) = &self.terminal {
+            response.finish_reason = Some(event.finish_reason);
+            response.usage = event.request_usage();
+            if let Some(metadata) = &event.metadata {
+                metadata.apply(&mut response);
+            }
+        }
+        response
     }
 
     /// Get the number of parts.
@@ -908,6 +927,7 @@ impl ModelResponsePartsManager {
 
     /// Clear all parts and reset state.
     pub fn clear(&mut self) {
+        self.terminal = None;
         self.parts.clear();
         self.vendor_id_to_index.clear();
         self.thinking_state = ThinkingTagState::default();

--- a/serdes-ai/src/lib.rs
+++ b/serdes-ai/src/lib.rs
@@ -303,8 +303,9 @@ pub use serdes_ai_core::{
 
 // Agent
 pub use serdes_ai_agent::{
-    Agent, AgentBuilder, AgentRun, AgentRunResult, AgentStream, AgentStreamEvent, EndStrategy,
-    ModelConfig, RunContext, RunOptions, StepResult,
+    Agent, AgentBuilder, AgentCheckpoint, AgentRun, AgentRunResult, AgentStream, AgentStreamEvent,
+    CheckpointBoundary, CheckpointSink, ContextFailurePolicy, ContextPolicy, ContextPolicyInput,
+    EndStrategy, ModelConfig, RunContext, RunOptions, StepResult, TypedAgentStream,
 };
 
 // Models
@@ -426,7 +427,7 @@ pub mod prelude {
     // Agent
     pub use crate::agent::{
         Agent, AgentBuilder, AgentRun, AgentRunResult, AgentStream, AgentStreamEvent, EndStrategy,
-        ModelConfig, RunContext, RunOptions,
+        ModelConfig, RunContext, RunOptions, TypedAgentStream,
     };
 
     // Models


### PR DESCRIPTION
…and typed output

- Introduce application-owned checkpoint lifecycle (CheckpointSink, AgentCheckpoint, CheckpointBoundary) with awaited persistence at request/response/tool-batch/terminal boundaries, including partial streaming snapshots and cancellation/provider-failure records
- Add fallible async ContextPolicy with explicit failure behavior and history processor integration that preserves native tool-call pairs without silent truncation
- Replace buffered Responses streaming fallback with true incremental SSE (responses_stream.rs), adding native terminal metadata, ordered native replay, and strict terminal-status handling
- Add TypedAgentStream and run_stream_typed recovering validator-transformed Output after terminal checkpoint success
- Unify both streaming constructors under a worker supervisor that observes cancellation and receiver closure across the full run lifetime; committed terminal checkpoints win over later detach/cancel
- Harden OpenAI Chat SSE: byte-buffered UTF-8 parsing, single terminal event, deterministic part closing, tool-call validation before dispatch, and premature-EOF errors
- Run configured schema parsing, async output validators, and dynamic prompts in streaming; validation exhaustion fails closed instead of signaling valid output
- Honor streaming parallel-tool settings with bounded, ordered results and retries; correct explicit output-tool mixed-call Early/Exhaustive decisions in both execution paths
- Redact sensitive Debug output for thinking deltas, model responses, and native terminal metadata